### PR TITLE
Web UI: interactive toggles, fetch button & modal, remove autoPublish

### DIFF
--- a/assets/controllers/profile_fetch_controller.js
+++ b/assets/controllers/profile_fetch_controller.js
@@ -31,6 +31,7 @@ export default class extends Controller {
 
             if (response.ok && data.success) {
                 body.innerHTML = this._renderSuccess(data);
+                this._updateFetchStatus(data);
             } else {
                 body.innerHTML = this._renderError(data.error || 'Unbekannter Fehler');
             }
@@ -88,6 +89,33 @@ export default class extends Controller {
                 </div>
             </div>
         `;
+    }
+
+    _updateFetchStatus(data) {
+        const row = this.element.closest('tr');
+
+        if (row) {
+            const cell = row.querySelector('[data-fetch-status]');
+            if (cell) {
+                cell.innerHTML = `
+                    <span class="text-success" title="${this._escapeHtml(data.lastFetchDateTimeFull)}">
+                        <i class="fas fa-check me-1"></i>${this._escapeHtml(data.lastFetchDateTime)}
+                    </span>
+                `;
+            }
+        } else {
+            const card = document.querySelector('[data-fetch-status]');
+            if (card) {
+                card.innerHTML = `
+                    <div class="mb-3">
+                        <small class="text-muted d-block">Letzter erfolgreicher Fetch</small>
+                        <span class="text-success">
+                            <i class="fas fa-check me-1"></i>${this._escapeHtml(data.lastFetchDateTimeFull)}
+                        </span>
+                    </div>
+                `;
+            }
+        }
     }
 
     _escapeHtml(text) {

--- a/assets/controllers/profile_fetch_controller.js
+++ b/assets/controllers/profile_fetch_controller.js
@@ -1,0 +1,98 @@
+import { Controller } from '@hotwired/stimulus';
+import { Modal } from 'bootstrap';
+
+export default class extends Controller {
+    static values = {
+        url: String,
+        token: String,
+        identifier: String,
+    };
+
+    async fetch() {
+        const modal = document.getElementById('fetchModal');
+        const bsModal = Modal.getOrCreateInstance(modal);
+
+        const body = modal.querySelector('.modal-body');
+        body.innerHTML = this._renderLoading();
+        modal.querySelector('.modal-footer').classList.add('d-none');
+        bsModal.show();
+
+        const formData = new FormData();
+        formData.append('_token', this.tokenValue);
+
+        try {
+            const response = await window.fetch(this.urlValue, {
+                method: 'POST',
+                body: formData,
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                body.innerHTML = this._renderSuccess(data);
+            } else {
+                body.innerHTML = this._renderError(data.error || 'Unbekannter Fehler');
+            }
+        } catch (error) {
+            body.innerHTML = this._renderError(error.message);
+        }
+
+        modal.querySelector('.modal-footer').classList.remove('d-none');
+    }
+
+    _renderLoading() {
+        return `
+            <div class="text-center py-4">
+                <div class="spinner-border text-primary mb-3" role="status">
+                    <span class="visually-hidden">Laden...</span>
+                </div>
+                <p class="mb-0 text-muted">Lade Einträge für <strong>${this._escapeHtml(this.identifierValue)}</strong>…</p>
+            </div>
+        `;
+    }
+
+    _renderSuccess(data) {
+        return `
+            <div class="py-2">
+                <div class="alert alert-success mb-3">
+                    <i class="fas fa-check-circle me-1"></i>Import abgeschlossen
+                </div>
+                <table class="table table-sm table-borderless mb-0">
+                    <tr>
+                        <th style="width: 160px;">Fetcher</th>
+                        <td><code>${this._escapeHtml(data.fetcher)}</code></td>
+                    </tr>
+                    <tr>
+                        <th>Einträge geladen</th>
+                        <td><span class="badge text-bg-primary">${data.fetched}</span></td>
+                    </tr>
+                    <tr>
+                        <th>Neu gespeichert</th>
+                        <td><span class="badge text-bg-success">${data.new}</span></td>
+                    </tr>
+                    <tr>
+                        <th>Duplikate</th>
+                        <td><span class="badge text-bg-secondary">${data.duplicates}</span></td>
+                    </tr>
+                </table>
+            </div>
+        `;
+    }
+
+    _renderError(message) {
+        return `
+            <div class="py-2">
+                <div class="alert alert-danger mb-0">
+                    <i class="fas fa-exclamation-triangle me-1"></i>${this._escapeHtml(message)}
+                </div>
+            </div>
+        `;
+    }
+
+    _escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}

--- a/assets/controllers/profile_toggle_controller.js
+++ b/assets/controllers/profile_toggle_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        id: Number,
+        field: String,
+        token: String,
+        state: Boolean,
+    };
+
+    async toggle() {
+        const checkbox = this.element.querySelector('input[type="checkbox"]');
+        checkbox.disabled = true;
+        this.element.classList.add('toggle-loading');
+
+        const url = `/profiles/${this.idValue}/toggle-${this.fieldValue}`;
+        const body = new FormData();
+        body.append('_token', this.tokenValue);
+
+        try {
+            const response = await fetch(url, { method: 'POST', body });
+            if (!response.ok) throw new Error('Request failed');
+
+            const data = await response.json();
+            const newState = data[this.fieldValue];
+
+            this.stateValue = newState;
+            checkbox.checked = newState;
+        } catch (error) {
+            checkbox.checked = this.stateValue;
+            console.error('Toggle failed:', error);
+        } finally {
+            checkbox.disabled = false;
+            this.element.classList.remove('toggle-loading');
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -21,3 +21,51 @@ pre.raw-data {
     padding: 1rem;
     border-radius: 0.375rem;
 }
+
+/* Toggle Switch */
+.toggle-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    user-select: none;
+}
+.toggle-switch input[type="checkbox"] {
+    display: none;
+}
+.toggle-switch .toggle-track {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    background: #dee2e6;
+    border-radius: 12px;
+    transition: background 0.25s ease;
+}
+.toggle-switch .toggle-track::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: #fff;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.25s cubic-bezier(0.68, -0.30, 0.27, 1.30);
+}
+.toggle-switch input:checked + .toggle-track {
+    background: #198754;
+}
+.toggle-switch input:checked + .toggle-track::after {
+    transform: translateX(20px);
+}
+.toggle-switch.toggle-loading .toggle-track {
+    opacity: 0.5;
+}
+.toggle-switch.toggle-loading .toggle-track::after {
+    animation: toggle-pulse 0.6s ease-in-out infinite alternate;
+}
+@keyframes toggle-pulse {
+    from { box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2); }
+    to { box-shadow: 0 1px 8px rgba(25, 135, 84, 0.5); }
+}

--- a/migrations/Version20260303120000.php
+++ b/migrations/Version20260303120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260303120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove unused auto_publish column from profile';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE profile DROP auto_publish');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE profile ADD auto_publish BOOLEAN DEFAULT true NOT NULL');
+    }
+}

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -93,7 +93,6 @@ class ImportProfilesCommand extends Command
 
             $profile->setNetwork($network);
             $profile->setIdentifier($data['identifier']);
-            $profile->setAutoPublish($data['auto_publish'] ?? true);
             $profile->setAutoFetch($data['auto_fetch'] ?? true);
 
             $additionalData = $data['additional_data'] ?? null;

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -230,6 +230,8 @@ class ProfileController extends AbstractController
                     'fetched' => count($feedItemList),
                     'new' => $newCount,
                     'duplicates' => $duplicateCount,
+                    'lastFetchDateTime' => $profile->getLastFetchSuccessDateTime()->format('d.m.Y H:i'),
+                    'lastFetchDateTimeFull' => $profile->getLastFetchSuccessDateTime()->format('d.m.Y H:i:s'),
                 ]);
             }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -136,7 +136,7 @@ class ProfileController extends AbstractController
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
     }
 
-    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|autoPublish|fetchSource'], methods: ['POST'])]
+    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource'], methods: ['POST'])]
     public function toggle(Request $request, Profile $profile, string $field, EntityManagerInterface $em): JsonResponse
     {
         if (!$this->isCsrfTokenValid('toggle-profile-' . $profile->getId(), $request->request->getString('_token'))) {
@@ -146,7 +146,6 @@ class ProfileController extends AbstractController
         $setter = 'set' . ucfirst($field);
         $getter = match ($field) {
             'autoFetch' => 'isAutoFetch',
-            'autoPublish' => 'isAutoPublish',
             'fetchSource' => 'isFetchSource',
         };
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -14,6 +14,7 @@ use App\Repository\ProfileRepository;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -133,6 +134,27 @@ class ProfileController extends AbstractController
         }
 
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
+    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|autoPublish|fetchSource'], methods: ['POST'])]
+    public function toggle(Request $request, Profile $profile, string $field, EntityManagerInterface $em): JsonResponse
+    {
+        if (!$this->isCsrfTokenValid('toggle-profile-' . $profile->getId(), $request->request->getString('_token'))) {
+            return new JsonResponse(['error' => 'Invalid CSRF token'], Response::HTTP_FORBIDDEN);
+        }
+
+        $setter = 'set' . ucfirst($field);
+        $getter = match ($field) {
+            'autoFetch' => 'isAutoFetch',
+            'autoPublish' => 'isAutoPublish',
+            'fetchSource' => 'isFetchSource',
+        };
+
+        $newValue = !$profile->$getter();
+        $profile->$setter($newValue);
+        $em->flush();
+
+        return new JsonResponse([$field => $newValue]);
     }
 
     #[Route('/{id}/fetch', name: 'app_profile_fetch', requirements: ['id' => '\d+'], methods: ['POST'])]

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -159,7 +159,13 @@ class ProfileController extends AbstractController
     #[Route('/{id}/fetch', name: 'app_profile_fetch', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function fetch(Request $request, Profile $profile, FeedFetcher $feedFetcher, FeedItemPersisterInterface $feedItemPersister, EntityManagerInterface $em): Response
     {
+        $isAjax = $request->headers->get('X-Requested-With') === 'XMLHttpRequest';
+
         if (!$this->isCsrfTokenValid('fetch-profile-' . $profile->getId(), $request->request->getString('_token'))) {
+            if ($isAjax) {
+                return new JsonResponse(['error' => 'Invalid CSRF token'], Response::HTTP_FORBIDDEN);
+            }
+
             return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
         }
 
@@ -167,6 +173,7 @@ class ProfileController extends AbstractController
         $modelProfile->setId($profile->getId());
         $modelProfile->setIdentifier($profile->getIdentifier());
         $modelProfile->setNetwork($profile->getNetwork()->getIdentifier());
+        $modelProfile->setFetchSource($profile->isFetchSource());
 
         $fetcher = null;
         foreach ($feedFetcher->getNetworkFetcherList() as $networkFetcher) {
@@ -177,25 +184,71 @@ class ProfileController extends AbstractController
         }
 
         if (!$fetcher) {
+            if ($isAjax) {
+                return new JsonResponse([
+                    'error' => sprintf('Kein Fetcher für Netzwerk "%s" verfügbar.', $profile->getNetwork()->getIdentifier()),
+                ], Response::HTTP_BAD_REQUEST);
+            }
+
             $this->addFlash('warning', sprintf('Kein Fetcher für Netzwerk "%s" verfügbar.', $profile->getNetwork()->getIdentifier()));
 
             return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
         }
 
-        $fetchInfo = new FetchInfo();
-        $feedItemList = $fetcher->fetch($modelProfile, $fetchInfo);
+        $fetcherName = (new \ReflectionClass($fetcher))->getShortName();
 
-        $fetchResult = new FetchResult();
-        $fetchResult->setProfile($modelProfile)->setCounterFetched(count($feedItemList));
+        try {
+            $fetchInfo = new FetchInfo();
+            $feedItemList = $fetcher->fetch($modelProfile, $fetchInfo);
 
-        $feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+            $fetchResult = new FetchResult();
+            $fetchResult->setProfile($modelProfile)->setCounterFetched(count($feedItemList));
 
-        $profile->setLastFetchSuccessDateTime(new \DateTimeImmutable());
-        $profile->setLastFetchFailureDateTime(null);
-        $profile->setLastFetchFailureError(null);
-        $em->flush();
+            if ($feedItemPersister instanceof \App\FeedItemPersister\DoctrineFeedItemPersister) {
+                $feedItemPersister->resetCounters();
+            }
 
-        $this->addFlash('success', sprintf('%d Items wurden importiert.', count($feedItemList)));
+            $feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+
+            $profile->setLastFetchSuccessDateTime(new \DateTimeImmutable());
+            $profile->setLastFetchFailureDateTime(null);
+            $profile->setLastFetchFailureError(null);
+            $em->flush();
+
+            if ($isAjax) {
+                $newCount = 0;
+                $duplicateCount = 0;
+
+                if ($feedItemPersister instanceof \App\FeedItemPersister\DoctrineFeedItemPersister) {
+                    $newCount = $feedItemPersister->getNewCount();
+                    $duplicateCount = $feedItemPersister->getDuplicateCount();
+                }
+
+                return new JsonResponse([
+                    'success' => true,
+                    'fetcher' => $fetcherName,
+                    'fetched' => count($feedItemList),
+                    'new' => $newCount,
+                    'duplicates' => $duplicateCount,
+                ]);
+            }
+
+            $this->addFlash('success', sprintf('%d Items wurden importiert.', count($feedItemList)));
+        } catch (\Exception $e) {
+            $profile->setLastFetchFailureDateTime(new \DateTimeImmutable());
+            $profile->setLastFetchFailureError($e->getMessage());
+            $em->flush();
+
+            if ($isAjax) {
+                return new JsonResponse([
+                    'success' => false,
+                    'fetcher' => $fetcherName,
+                    'error' => $e->getMessage(),
+                ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+
+            $this->addFlash('danger', sprintf('Fehler beim Import: %s', $e->getMessage()));
+        }
 
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
     }

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -46,10 +46,6 @@ class Profile
     #[Groups(['profile:read'])]
     private ?\DateTimeImmutable $createdAt = null;
 
-    #[ORM\Column(type: 'boolean', options: ['default' => true])]
-    #[Groups(['profile:read', 'profile:write'])]
-    private bool $autoPublish = true;
-
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['profile:read'])]
     private ?\DateTimeImmutable $lastFetchSuccessDateTime = null;
@@ -118,18 +114,6 @@ class Profile
     public function setCreatedAt(?\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    public function isAutoPublish(): bool
-    {
-        return $this->autoPublish;
-    }
-
-    public function setAutoPublish(bool $autoPublish): self
-    {
-        $this->autoPublish = $autoPublish;
 
         return $this;
     }

--- a/src/FeedItemPersister/DoctrineFeedItemPersister.php
+++ b/src/FeedItemPersister/DoctrineFeedItemPersister.php
@@ -12,6 +12,9 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class DoctrineFeedItemPersister implements FeedItemPersisterInterface
 {
+    private int $newCount = 0;
+    private int $duplicateCount = 0;
+
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly ProfileRepository $profileRepository,
@@ -46,6 +49,9 @@ class DoctrineFeedItemPersister implements FeedItemPersisterInterface
             $entity
                 ->setProfile($profileEntity)
                 ->setUniqueIdentifier($uniqueIdentifier);
+            $this->newCount++;
+        } else {
+            $this->duplicateCount++;
         }
 
         $dateTime = $feedItem->getDateTime();
@@ -68,6 +74,24 @@ class DoctrineFeedItemPersister implements FeedItemPersisterInterface
     public function flush(): FeedItemPersisterInterface
     {
         $this->entityManager->flush();
+
+        return $this;
+    }
+
+    public function getNewCount(): int
+    {
+        return $this->newCount;
+    }
+
+    public function getDuplicateCount(): int
+    {
+        return $this->duplicateCount;
+    }
+
+    public function resetCounters(): self
+    {
+        $this->newCount = 0;
+        $this->duplicateCount = 0;
 
         return $this;
     }

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -36,10 +36,6 @@ class ProfileType extends AbstractType
                 'label' => 'Identifier',
                 'help' => 'URL oder Benutzername im Netzwerk',
             ])
-            ->add('autoPublish', CheckboxType::class, [
-                'label' => 'Auto-Publish',
-                'required' => false,
-            ])
             ->add('autoFetch', CheckboxType::class, [
                 'label' => 'Auto-Fetch',
                 'required' => false,

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -8,7 +8,6 @@ class Profile
     protected ?string $identifier = null;
     protected string $network;
     private ?\DateTime $createdAt = null;
-    protected bool $autoPublish = true;
     protected ?\DateTime $lastFetchSuccessDateTime = null;
     protected ?\DateTime $lastFetchFailureDateTime = null;
     protected ?string $lastFetchFailureError = null;
@@ -67,18 +66,6 @@ class Profile
     public function setCreatedAt(?\DateTimeInterface $createdAt): self
     {
         $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    public function isAutoPublish(): bool
-    {
-        return $this->autoPublish;
-    }
-
-    public function setAutoPublish(bool $autoPublish): Profile
-    {
-        $this->autoPublish = $autoPublish;
 
         return $this;
     }

--- a/src/ProfileFetcher/DoctrineProfileFetcher.php
+++ b/src/ProfileFetcher/DoctrineProfileFetcher.php
@@ -57,7 +57,6 @@ class DoctrineProfileFetcher implements ProfileFetcherInterface
         $model->setId($entity->getId());
         $model->setIdentifier($entity->getIdentifier());
         $model->setNetwork($entity->getNetwork()->getIdentifier());
-        $model->setAutoPublish($entity->isAutoPublish());
         $model->setAutoFetch($entity->isAutoFetch());
 
         if ($entity->getLastFetchSuccessDateTime()) {

--- a/src/ProfilePersister/DoctrineProfilePersister.php
+++ b/src/ProfilePersister/DoctrineProfilePersister.php
@@ -54,7 +54,6 @@ class DoctrineProfilePersister implements ProfilePersisterInterface
         $additionalData = $profile->getAdditionalData();
 
         $entity
-            ->setAutoPublish($profile->isAutoPublish())
             ->setAutoFetch((bool) $profile->getAutoFetch())
             ->setLastFetchSuccessDateTime($profile->getLastFetchSuccessDateTime() ? \DateTimeImmutable::createFromInterface($profile->getLastFetchSuccessDateTime()) : null)
             ->setLastFetchFailureDateTime($profile->getLastFetchFailureDateTime() ? \DateTimeImmutable::createFromInterface($profile->getLastFetchFailureDateTime()) : null)

--- a/templates/_partials/_profile_toggle.html.twig
+++ b/templates/_partials/_profile_toggle.html.twig
@@ -1,0 +1,11 @@
+{# Usage: include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } #}
+<label class="toggle-switch"
+       data-controller="profile-toggle"
+       data-profile-toggle-id-value="{{ profile.id }}"
+       data-profile-toggle-field-value="{{ field }}"
+       data-profile-toggle-token-value="{{ csrf_token('toggle-profile-' ~ profile.id) }}"
+       data-profile-toggle-state-value="{{ state ? 'true' : 'false' }}"
+       data-action="change->profile-toggle#toggle">
+    <input type="checkbox" {{ state ? 'checked' : '' }}>
+    <span class="toggle-track"></span>
+</label>

--- a/templates/profile/_form.html.twig
+++ b/templates/profile/_form.html.twig
@@ -7,13 +7,10 @@
             {% endif %}
             {{ form_row(form.identifier) }}
             <div class="row">
-                <div class="col-md-4">
+                <div class="col-md-6">
                     {{ form_row(form.autoFetch) }}
                 </div>
-                <div class="col-md-4">
-                    {{ form_row(form.autoPublish) }}
-                </div>
-                <div class="col-md-4">
+                <div class="col-md-6">
                     {{ form_row(form.fetchSource) }}
                 </div>
             </div>

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -50,18 +50,10 @@
                             </a>
                         </td>
                         <td>
-                            {% if profile.autoFetch %}
-                                <span class="badge text-bg-success">Ja</span>
-                            {% else %}
-                                <span class="badge text-bg-secondary">Nein</span>
-                            {% endif %}
+                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
                         </td>
                         <td>
-                            {% if profile.autoPublish %}
-                                <span class="badge text-bg-success">Ja</span>
-                            {% else %}
-                                <span class="badge text-bg-secondary">Nein</span>
-                            {% endif %}
+                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoPublish', state: profile.autoPublish } %}
                         </td>
                         <td>
                             {% if profile.lastFetchSuccessDateTime %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -55,7 +55,7 @@
                         <td>
                             {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
                         </td>
-                        <td>
+                        <td data-fetch-status>
                             {% if profile.lastFetchSuccessDateTime %}
                                 <span class="text-success" title="{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i:s') }}">
                                     <i class="fas fa-check me-1"></i>{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i') }}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -28,6 +28,7 @@
                     <th>Netzwerk</th>
                     <th>Identifier</th>
                     <th>Auto-Fetch</th>
+                    <th>Quelltext</th>
                     <th>Letzter Fetch</th>
                     <th class="no-sort">Aktionen</th>
                 </tr>
@@ -50,6 +51,9 @@
                         </td>
                         <td>
                             {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
+                        </td>
+                        <td>
+                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
                         </td>
                         <td>
                             {% if profile.lastFetchSuccessDateTime %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -28,7 +28,6 @@
                     <th>Netzwerk</th>
                     <th>Identifier</th>
                     <th>Auto-Fetch</th>
-                    <th>Auto-Publish</th>
                     <th>Letzter Fetch</th>
                     <th class="no-sort">Aktionen</th>
                 </tr>
@@ -51,9 +50,6 @@
                         </td>
                         <td>
                             {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
-                        </td>
-                        <td>
-                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoPublish', state: profile.autoPublish } %}
                         </td>
                         <td>
                             {% if profile.lastFetchSuccessDateTime %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -76,6 +76,16 @@
                                 <a href="{{ path('app_profile_edit', {id: profile.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
                                     <i class="fas fa-edit"></i>
                                 </a>
+                                <button type="button"
+                                        class="btn btn-outline-warning"
+                                        title="Items importieren"
+                                        data-controller="profile-fetch"
+                                        data-profile-fetch-url-value="{{ path('app_profile_fetch', {id: profile.id}) }}"
+                                        data-profile-fetch-token-value="{{ csrf_token('fetch-profile-' ~ profile.id) }}"
+                                        data-profile-fetch-identifier-value="{{ profile.identifier }}"
+                                        data-action="profile-fetch#fetch">
+                                    <i class="fas fa-download"></i>
+                                </button>
                                 <form method="post" action="{{ path('app_profile_delete', {id: profile.id}) }}"
                                       class="d-inline"
                                       data-controller="confirm"
@@ -94,4 +104,19 @@
     {% endif %}
 
     {% include '_partials/_delete_modal.html.twig' %}
+
+    <div class="modal fade" id="fetchModal" tabindex="-1" aria-labelledby="fetchModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="fetchModalLabel">Items importieren</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer d-none">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -56,21 +56,19 @@
                         <tr>
                             <th>Auto-Fetch</th>
                             <td>
-                                {% if profile.autoFetch %}
-                                    <span class="badge text-bg-success">Aktiv</span>
-                                {% else %}
-                                    <span class="badge text-bg-secondary">Inaktiv</span>
-                                {% endif %}
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
                             </td>
                         </tr>
                         <tr>
                             <th>Auto-Publish</th>
                             <td>
-                                {% if profile.autoPublish %}
-                                    <span class="badge text-bg-success">Aktiv</span>
-                                {% else %}
-                                    <span class="badge text-bg-secondary">Inaktiv</span>
-                                {% endif %}
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoPublish', state: profile.autoPublish } %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Quelltext laden</th>
+                            <td>
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
                             </td>
                         </tr>
                         <tr>

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -86,7 +86,7 @@
         <div class="col-md-4">
             <div class="card mb-4">
                 <div class="card-header">Fetch-Status</div>
-                <div class="card-body">
+                <div class="card-body" data-fetch-status>
                     {% if profile.lastFetchSuccessDateTime %}
                         <div class="mb-3">
                             <small class="text-muted d-block">Letzter erfolgreicher Fetch</small>
@@ -126,12 +126,15 @@
                     <a href="{{ path('app_profile_edit', {id: profile.id}) }}" class="btn btn-outline-primary">
                         <i class="fas fa-edit me-1"></i>Bearbeiten
                     </a>
-                    <form method="post" action="{{ path('app_profile_fetch', {id: profile.id}) }}">
-                        <input type="hidden" name="_token" value="{{ csrf_token('fetch-profile-' ~ profile.id) }}">
-                        <button type="submit" class="btn btn-outline-warning w-100">
-                            <i class="fas fa-download me-1"></i>Items importieren
-                        </button>
-                    </form>
+                    <button type="button"
+                            class="btn btn-outline-warning w-100"
+                            data-controller="profile-fetch"
+                            data-profile-fetch-url-value="{{ path('app_profile_fetch', {id: profile.id}) }}"
+                            data-profile-fetch-token-value="{{ csrf_token('fetch-profile-' ~ profile.id) }}"
+                            data-profile-fetch-identifier-value="{{ profile.identifier }}"
+                            data-action="profile-fetch#fetch">
+                        <i class="fas fa-download me-1"></i>Items importieren
+                    </button>
                     {% set rssAppFeedId = profile.additionalData.rss_feed_id|default(null) %}
                     {% if rssAppFeedId %}
                         <form method="post" action="{{ path('app_profile_rssapp_delete', {id: profile.id}) }}"
@@ -164,4 +167,19 @@
     </div>
 
     {% include '_partials/_delete_modal.html.twig' %}
+
+    <div class="modal fade" id="fetchModal" tabindex="-1" aria-labelledby="fetchModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="fetchModalLabel">Items importieren</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer d-none">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -60,12 +60,6 @@
                             </td>
                         </tr>
                         <tr>
-                            <th>Auto-Publish</th>
-                            <td>
-                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoPublish', state: profile.autoPublish } %}
-                            </td>
-                        </tr>
-                        <tr>
                             <th>Quelltext laden</th>
                             <td>
                                 {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}


### PR DESCRIPTION
## Summary

Polishes the profile management UI:
- Stimulus toggle switches for the profile settings (autoFetch / fetchSource / saveX flags)
- Fetch button with a live status modal on both the profile list and detail pages
- Removes the unused `autoPublish` field from `Profile` (with migration)

**PR 4 of 18** in the standalone-split stack. Stacked on #23.

## Commits

- `47422c9` Add interactive toggle switches for profile settings
- `47974e5` Remove unused autoPublish field from Profile
- `4d7e3a4` Add fetchSource toggle to profile list view
- `2f81073` Add fetch button with status modal to profile list
- `7e3be46` Add fetch modal to profile detail page and update fetch status live

## Test plan

- [x] `bin/phpunit` — 40 tests, 85 assertions, all green

## Stack

- Previous: #23 (`feat/source-fetcher`)
- Next: B5 (Networks CRUD — see plan note: B5 has been reduced because the rename and duplicate-property fix were pulled forward into earlier PRs)