### PR TITLE
Add Networks CRUD interface + datatable cleanup

### DIFF
--- a/assets/controllers/datatable_controller.js
+++ b/assets/controllers/datatable_controller.js
@@ -5,8 +5,6 @@ export default class extends Controller {
     static values = {
         pageLength: { type: Number, default: 25 },
         order: { type: Array, default: [[0, 'asc']] },
-        filterColumn: { type: Number, default: -1 },
-        filterLabel: { type: String, default: 'Alle' },
     };
 
     connect() {
@@ -34,48 +32,7 @@ export default class extends Controller {
             columnDefs: [
                 { orderable: false, targets: 'no-sort' },
             ],
-            initComplete: () => {
-                if (this.filterColumnValue >= 0) {
-                    this._addColumnFilter();
-                }
-            },
         });
-    }
-
-    _addColumnFilter() {
-        const column = this._dt.column(this.filterColumnValue);
-        const wrapper = this._dt.table().container();
-        const searchRow = wrapper.querySelector('.dt-search') || wrapper.querySelector('.dataTables_filter');
-
-        const select = document.createElement('select');
-        select.className = 'form-select form-select-sm d-inline-block w-auto me-3';
-
-        const allOption = document.createElement('option');
-        allOption.value = '';
-        allOption.textContent = this.filterLabelValue;
-        select.appendChild(allOption);
-
-        const values = new Set();
-        column.data().each(val => {
-            const text = val.replace(/<[^>]*>/g, '').trim();
-            if (text) values.add(text);
-        });
-
-        [...values].sort().forEach(val => {
-            const option = document.createElement('option');
-            option.value = val;
-            option.textContent = val;
-            select.appendChild(option);
-        });
-
-        select.addEventListener('change', () => {
-            const search = select.value ? select.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : '';
-            column.search(search, true, false).draw();
-        });
-
-        if (searchRow) {
-            searchRow.prepend(select);
-        }
     }
 
     disconnect() {

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -22,6 +22,11 @@ pre.raw-data {
     border-radius: 0.375rem;
 }
 
+/* btn-group with inline forms */
+.btn-group > form {
+    display: contents;
+}
+
 /* Toggle Switch */
 .toggle-switch {
     display: inline-flex;

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Network;
+use App\Form\NetworkType;
+use App\Repository\NetworkRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/networks')]
+class NetworkController extends AbstractController
+{
+    #[Route('', name: 'app_network_index')]
+    public function index(NetworkRepository $networkRepository): Response
+    {
+        return $this->render('network/index.html.twig', [
+            'networks' => $networkRepository->findBy([], ['name' => 'ASC']),
+        ]);
+    }
+
+    #[Route('/new', name: 'app_network_new')]
+    public function new(Request $request, EntityManagerInterface $em): Response
+    {
+        $network = new Network();
+
+        $form = $this->createForm(NetworkType::class, $network);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($network);
+            $em->flush();
+
+            $this->addFlash('success', 'Netzwerk wurde erstellt.');
+
+            return $this->redirectToRoute('app_network_show', ['id' => $network->getId()]);
+        }
+
+        return $this->render('network/new.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_network_show', requirements: ['id' => '\d+'])]
+    public function show(Network $network): Response
+    {
+        return $this->render('network/show.html.twig', [
+            'network' => $network,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_network_edit', requirements: ['id' => '\d+'])]
+    public function edit(Request $request, Network $network, EntityManagerInterface $em): Response
+    {
+        $form = $this->createForm(NetworkType::class, $network);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+
+            $this->addFlash('success', 'Netzwerk wurde aktualisiert.');
+
+            return $this->redirectToRoute('app_network_show', ['id' => $network->getId()]);
+        }
+
+        return $this->render('network/edit.html.twig', [
+            'network' => $network,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'app_network_delete', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function delete(Request $request, Network $network, EntityManagerInterface $em): Response
+    {
+        if ($this->isCsrfTokenValid('delete-network-' . $network->getId(), $request->request->getString('_token'))) {
+            $em->remove($network);
+            $em->flush();
+
+            $this->addFlash('success', 'Netzwerk wurde gelöscht.');
+        }
+
+        return $this->redirectToRoute('app_network_index');
+    }
+}

--- a/src/Form/NetworkType.php
+++ b/src/Form/NetworkType.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\Network;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NetworkType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('identifier', TextType::class, [
+                'label' => 'Identifier',
+                'help' => 'Eindeutiger technischer Bezeichner (z.B. mastodon, bluesky)',
+            ])
+            ->add('name', TextType::class, [
+                'label' => 'Name',
+                'help' => 'Anzeigename des Netzwerks',
+            ])
+            ->add('icon', TextType::class, [
+                'label' => 'Icon',
+                'help' => 'FontAwesome-Klasse (z.B. fab fa-mastodon)',
+            ])
+            ->add('backgroundColor', TextType::class, [
+                'label' => 'Hintergrundfarbe',
+                'help' => 'CSS-Farbwert (z.B. #6364FF)',
+            ])
+            ->add('textColor', TextType::class, [
+                'label' => 'Textfarbe',
+                'help' => 'CSS-Farbwert (z.B. #FFFFFF)',
+            ])
+            ->add('profileUrlPattern', TextType::class, [
+                'label' => 'Profil-URL-Pattern',
+                'help' => 'Regulärer Ausdruck zur Validierung von Profil-URLs',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Network::class,
+        ]);
+    }
+}

--- a/templates/_partials/_navbar.html.twig
+++ b/templates/_partials/_navbar.html.twig
@@ -14,6 +14,11 @@
                     </a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link {% if app.request.attributes.get('_route') starts with 'app_network' %}active{% endif %}" href="{{ path('app_network_index') }}">
+                        <i class="fas fa-network-wired me-1"></i>Networks
+                    </a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link {% if app.request.attributes.get('_route') starts with 'app_profile' %}active{% endif %}" href="{{ path('app_profile_index') }}">
                         <i class="fas fa-users me-1"></i>Profiles
                     </a>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -17,6 +17,11 @@
                         <i class="fas fa-globe fa-2x opacity-50"></i>
                     </div>
                 </div>
+                <div class="card-footer bg-transparent border-0">
+                    <a href="{{ path('app_network_index') }}" class="text-white text-decoration-none">
+                        Alle anzeigen <i class="fas fa-arrow-right"></i>
+                    </a>
+                </div>
             </div>
         </div>
         <div class="col-md-4">

--- a/templates/network/_form.html.twig
+++ b/templates/network/_form.html.twig
@@ -1,24 +1,53 @@
 {{ form_start(form) }}
-    <div class="card">
-        <div class="card-body">
-            {{ form_row(form.identifier) }}
-            {{ form_row(form.name) }}
-            {{ form_row(form.icon) }}
-            <div class="row">
-                <div class="col-md-6">
-                    {{ form_row(form.backgroundColor) }}
+    <div class="row g-4">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <i class="fas fa-network-wired me-1"></i>Netzwerk-Einstellungen
                 </div>
-                <div class="col-md-6">
-                    {{ form_row(form.textColor) }}
+                <div class="card-body">
+                    {{ form_row(form.identifier) }}
+                    {{ form_row(form.name) }}
+                    {{ form_row(form.icon) }}
+                    <div class="row">
+                        <div class="col-md-6">
+                            {{ form_row(form.backgroundColor) }}
+                        </div>
+                        <div class="col-md-6">
+                            {{ form_row(form.textColor) }}
+                        </div>
+                    </div>
+                    {{ form_row(form.profileUrlPattern) }}
                 </div>
             </div>
-            {{ form_row(form.profileUrlPattern) }}
         </div>
-        <div class="card-footer">
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-1"></i>Speichern
-            </button>
-            <a href="{{ cancel_url }}" class="btn btn-secondary">Abbrechen</a>
+
+        <div class="col-lg-4">
+            <div class="card">
+                <div class="card-header">
+                    <i class="fas fa-clock me-1"></i>Fetch-Zeitplan
+                </div>
+                <div class="card-body">
+                    {{ form_row(form.cronExpression) }}
+                    <div class="text-muted small mt-2">
+                        <strong>Beispiele:</strong>
+                        <ul class="mb-0 mt-1">
+                            <li><code>* * * * *</code> — Jede Minute</li>
+                            <li><code>*/5 * * * *</code> — Alle 5 Minuten</li>
+                            <li><code>*/15 * * * *</code> — Alle 15 Minuten</li>
+                            <li><code>0 * * * *</code> — Stündlich</li>
+                            <li><code>0 */6 * * *</code> — Alle 6 Stunden</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
+    </div>
+
+    <div class="mt-4">
+        <button type="submit" class="btn btn-primary">
+            <i class="fas fa-save me-1"></i>Speichern
+        </button>
+        <a href="{{ cancel_url }}" class="btn btn-secondary">Abbrechen</a>
     </div>
 {{ form_end(form) }}

--- a/templates/network/_form.html.twig
+++ b/templates/network/_form.html.twig
@@ -1,0 +1,24 @@
+{{ form_start(form) }}
+    <div class="card">
+        <div class="card-body">
+            {{ form_row(form.identifier) }}
+            {{ form_row(form.name) }}
+            {{ form_row(form.icon) }}
+            <div class="row">
+                <div class="col-md-6">
+                    {{ form_row(form.backgroundColor) }}
+                </div>
+                <div class="col-md-6">
+                    {{ form_row(form.textColor) }}
+                </div>
+            </div>
+            {{ form_row(form.profileUrlPattern) }}
+        </div>
+        <div class="card-footer">
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-save me-1"></i>Speichern
+            </button>
+            <a href="{{ cancel_url }}" class="btn btn-secondary">Abbrechen</a>
+        </div>
+    </div>
+{{ form_end(form) }}

--- a/templates/network/edit.html.twig
+++ b/templates/network/edit.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Netzwerk bearbeiten - Social Network Fetcher{% endblock %}
+
+{% block body %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ path('app_network_index') }}">Networks</a></li>
+            <li class="breadcrumb-item"><a href="{{ path('app_network_show', {id: network.id}) }}">{{ network.name }}</a></li>
+            <li class="breadcrumb-item active">Bearbeiten</li>
+        </ol>
+    </nav>
+
+    <h1 class="mb-4">Netzwerk bearbeiten</h1>
+
+    {% include 'network/_form.html.twig' with {cancel_url: path('app_network_show', {id: network.id})} %}
+{% endblock %}

--- a/templates/network/index.html.twig
+++ b/templates/network/index.html.twig
@@ -1,0 +1,71 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Networks - Social Network Fetcher{% endblock %}
+
+{% block body %}
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>Networks</h1>
+        <a href="{{ path('app_network_new') }}" class="btn btn-primary">
+            <i class="fas fa-plus me-1"></i>Neues Netzwerk
+        </a>
+    </div>
+
+    {% if networks is empty %}
+        <div class="alert alert-info">
+            Keine Netzwerke gefunden.
+            <a href="{{ path('app_network_new') }}">Erstes Netzwerk anlegen?</a>
+        </div>
+    {% else %}
+        <table class="table table-hover table-striped"
+               data-controller="datatable"
+               data-datatable-page-length-value="50"
+               data-datatable-order-value='[[1, "asc"]]'>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Identifier</th>
+                    <th>Icon</th>
+                    <th class="no-sort">Aktionen</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for network in networks %}
+                    <tr>
+                        <td>{{ network.id }}</td>
+                        <td>
+                            <span class="badge badge-network" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
+                                <i class="{{ network.icon }} me-1"></i>{{ network.name }}
+                            </span>
+                        </td>
+                        <td>
+                            <a href="{{ path('app_network_show', {id: network.id}) }}">
+                                {{ network.identifier }}
+                            </a>
+                        </td>
+                        <td><code>{{ network.icon }}</code></td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <a href="{{ path('app_network_show', {id: network.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                                <a href="{{ path('app_network_edit', {id: network.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
+                                    <i class="fas fa-edit"></i>
+                                </a>
+                                <form method="post" action="{{ path('app_network_delete', {id: network.id}) }}"
+                                      class="d-inline"
+                                      data-controller="confirm"
+                                      data-confirm-message-value="Netzwerk &quot;{{ network.name }}&quot; wirklich löschen?">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('delete-network-' ~ network.id) }}">
+                                    <button type="submit" class="btn btn-outline-danger" title="Löschen">
+                                        <i class="fas fa-trash"></i>
+                                    </button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock %}

--- a/templates/network/new.html.twig
+++ b/templates/network/new.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Neues Netzwerk - Social Network Fetcher{% endblock %}
+
+{% block body %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ path('app_network_index') }}">Networks</a></li>
+            <li class="breadcrumb-item active">Neu</li>
+        </ol>
+    </nav>
+
+    <h1 class="mb-4">Neues Netzwerk anlegen</h1>
+
+    {% include 'network/_form.html.twig' with {cancel_url: path('app_network_index')} %}
+{% endblock %}

--- a/templates/network/show.html.twig
+++ b/templates/network/show.html.twig
@@ -1,0 +1,100 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Netzwerk {{ network.name }} - Social Network Fetcher{% endblock %}
+
+{% block body %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ path('app_network_index') }}">Networks</a></li>
+            <li class="breadcrumb-item active">{{ network.name }}</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>
+            <span class="badge badge-network me-2" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
+                <i class="{{ network.icon }}"></i>
+            </span>
+            {{ network.name }}
+        </h1>
+        <a href="{{ path('app_network_edit', {id: network.id}) }}" class="btn btn-outline-primary">
+            <i class="fas fa-edit me-1"></i>Bearbeiten
+        </a>
+    </div>
+
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card mb-4">
+                <div class="card-header">Details</div>
+                <div class="card-body">
+                    <table class="table table-borderless mb-0">
+                        <tr>
+                            <th style="width: 200px;">ID</th>
+                            <td>{{ network.id }}</td>
+                        </tr>
+                        <tr>
+                            <th>Identifier</th>
+                            <td><code>{{ network.identifier }}</code></td>
+                        </tr>
+                        <tr>
+                            <th>Name</th>
+                            <td>{{ network.name }}</td>
+                        </tr>
+                        <tr>
+                            <th>Icon</th>
+                            <td>
+                                <i class="{{ network.icon }} me-2"></i>
+                                <code>{{ network.icon }}</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Hintergrundfarbe</th>
+                            <td>
+                                <span class="d-inline-block rounded me-2" style="width: 20px; height: 20px; background-color: {{ network.backgroundColor }}; vertical-align: middle;"></span>
+                                <code>{{ network.backgroundColor }}</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Textfarbe</th>
+                            <td>
+                                <span class="d-inline-block rounded border me-2" style="width: 20px; height: 20px; background-color: {{ network.textColor }}; vertical-align: middle;"></span>
+                                <code>{{ network.textColor }}</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Badge-Preview</th>
+                            <td>
+                                <span class="badge badge-network" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
+                                    <i class="{{ network.icon }} me-1"></i>{{ network.name }}
+                                </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Profil-URL-Pattern</th>
+                            <td><code>{{ network.profileUrlPattern }}</code></td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-header">Aktionen</div>
+                <div class="card-body d-grid gap-2">
+                    <a href="{{ path('app_network_edit', {id: network.id}) }}" class="btn btn-outline-primary">
+                        <i class="fas fa-edit me-1"></i>Bearbeiten
+                    </a>
+                    <form method="post" action="{{ path('app_network_delete', {id: network.id}) }}"
+                          data-controller="confirm"
+                          data-confirm-message-value="Netzwerk &quot;{{ network.name }}&quot; wirklich löschen?">
+                        <input type="hidden" name="_token" value="{{ csrf_token('delete-network-' ~ network.id) }}">
+                        <button type="submit" class="btn btn-outline-danger w-100">
+                            <i class="fas fa-trash me-1"></i>Löschen
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -19,9 +19,7 @@
         <table class="table table-hover table-striped"
                data-controller="datatable"
                data-datatable-page-length-value="50"
-               data-datatable-order-value='[[0, "asc"]]'
-               data-datatable-filter-column-value="1"
-               data-datatable-filter-label-value="Alle Netzwerke">
+               data-datatable-order-value='[[0, "asc"]]'>
             <thead>
                 <tr>
                     <th>ID</th>


### PR DESCRIPTION
## Summary

- New `NetworkController`, form, and templates for full CRUD on the `Network` entity (used to register new social networks via the web UI)
- Two-column form layout for the network edit/new pages
- Removes the broken DataTables column filter that was causing a timing-init crash, plus a small btn-group form CSS fix

**PR 5 of 17** (the original B5 was absorbed into earlier PRs — see plan note). Stacked on #24.

## Commits

- `61a37e8` Remove broken datatable column filter and add btn-group form fix
- `a105569` Add Networks CRUD with controller, form, templates, and navigation
- `d981d1e` Redesign network form with two-column layout

## Test plan

- [x] `bin/phpunit` — 40 tests, 85 assertions, all green

## Stack

- Previous: #24 (`feat/web-ui-toggles-and-fetch-modal`)
- Next: B7 (Dashboard latest items + server-side profile pagination)