### PR TITLE
Add dashboard latest items + server-side profile pagination

### DIFF
--- a/assets/controllers/profile_list_controller.js
+++ b/assets/controllers/profile_list_controller.js
@@ -1,0 +1,116 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static values = {
+        url: String,
+        page: Number,
+        pages: Number,
+    };
+
+    static targets = ['searchInput', 'networkCheckbox', 'networkCount', 'statusRadio', 'tableBody', 'pagination', 'totalBadge'];
+
+    _searchTimeout = null;
+
+    connect() {
+        this.paginationTarget.addEventListener('click', this._onPaginationClick.bind(this));
+    }
+
+    disconnect() {
+        this.paginationTarget.removeEventListener('click', this._onPaginationClick.bind(this));
+        clearTimeout(this._searchTimeout);
+    }
+
+    onSearchInput() {
+        clearTimeout(this._searchTimeout);
+        this._searchTimeout = setTimeout(() => {
+            this.pageValue = 1;
+            this._load();
+        }, 300);
+    }
+
+    onNetworkChange() {
+        this._updateNetworkCount();
+        this.pageValue = 1;
+        this._load();
+    }
+
+    clearNetworkFilter() {
+        this.networkCheckboxTargets.forEach(cb => cb.checked = false);
+        this._updateNetworkCount();
+        this.pageValue = 1;
+        this._load();
+    }
+
+    onStatusChange() {
+        this.pageValue = 1;
+        this._load();
+    }
+
+    clearStatusFilter() {
+        this.statusRadioTargets.forEach(r => r.checked = false);
+        this.pageValue = 1;
+        this._load();
+    }
+
+    _onPaginationClick(event) {
+        const link = event.target.closest('a.page-link');
+        if (!link) return;
+
+        event.preventDefault();
+
+        const url = new URL(link.href, window.location.origin);
+        const page = parseInt(url.searchParams.get('page'), 10);
+        if (page && page !== this.pageValue) {
+            this.pageValue = page;
+            this._load();
+        }
+    }
+
+    async _load() {
+        const params = new URLSearchParams();
+        params.set('page', this.pageValue);
+
+        const search = this.searchInputTarget.value.trim();
+        if (search) {
+            params.set('search', search);
+        }
+
+        this.networkCheckboxTargets.forEach(cb => {
+            if (cb.checked) {
+                params.append('networks[]', cb.value);
+            }
+        });
+
+        const selectedStatus = this.statusRadioTargets.find(r => r.checked);
+        if (selectedStatus) {
+            params.set('status', selectedStatus.value);
+        }
+
+        try {
+            const response = await fetch(`${this.urlValue}?${params}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+
+            if (!response.ok) return;
+
+            const data = await response.json();
+
+            this.tableBodyTarget.innerHTML = data.html;
+            this.paginationTarget.innerHTML = data.paginationHtml;
+            this.pageValue = data.page;
+            this.pagesValue = data.pages;
+            this.totalBadgeTarget.textContent = data.total;
+
+            const url = new URL(window.location);
+            url.search = params.toString();
+            history.replaceState(null, '', url);
+        } catch (error) {
+            // silently fail on network errors
+        }
+    }
+
+    _updateNetworkCount() {
+        const checked = this.networkCheckboxTargets.filter(cb => cb.checked).length;
+        this.networkCountTarget.textContent = checked > 0 ? checked : '';
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -33,11 +33,14 @@ class DashboardController extends AbstractController
             ];
         }
 
+        $latestItems = $itemRepository->findBy([], ['createdAt' => 'DESC'], 10);
+
         return $this->render('dashboard/index.html.twig', [
             'networkCount' => count($networks),
             'profileCount' => $profileRepository->count([]),
             'itemCount' => $itemRepository->count([]),
             'networkStats' => $networkStats,
+            'latestItems' => $latestItems,
         ]);
     }
 }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -10,6 +10,7 @@ use App\FeedFetcher\FetchResult;
 use App\FeedItemPersister\FeedItemPersisterInterface;
 use App\Model\Profile as ModelProfile;
 use App\Repository\ItemRepository;
+use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -22,11 +23,46 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route('/profiles')]
 class ProfileController extends AbstractController
 {
+    private const PROFILES_PER_PAGE = 50;
+
     #[Route('', name: 'app_profile_index')]
-    public function index(ProfileRepository $profileRepository): Response
+    public function index(Request $request, ProfileRepository $profileRepository, NetworkRepository $networkRepository): Response
     {
+        $page = max(1, $request->query->getInt('page', 1));
+        $search = trim($request->query->getString('search', ''));
+        $networkIds = array_map('intval', (array) $request->query->all('networks'));
+        $status = $request->query->getString('status', '');
+
+        $total = $profileRepository->countFiltered($networkIds, $search, $status);
+        $pages = max(1, (int) ceil($total / self::PROFILES_PER_PAGE));
+        $page = min($page, $pages);
+        $profiles = $profileRepository->findPaginated($page, self::PROFILES_PER_PAGE, $networkIds, $search, $status);
+
+        if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
+            return new JsonResponse([
+                'html' => $this->renderView('profile/_partials/_profile_table_body.html.twig', [
+                    'profiles' => $profiles,
+                ]),
+                'paginationHtml' => $this->renderView('_partials/_pagination.html.twig', [
+                    'page' => $page,
+                    'pages' => $pages,
+                ]),
+                'page' => $page,
+                'pages' => $pages,
+                'total' => $total,
+                'status' => $status,
+            ]);
+        }
+
         return $this->render('profile/index.html.twig', [
-            'profiles' => $profileRepository->findBy([], ['identifier' => 'ASC']),
+            'profiles' => $profiles,
+            'networks' => $networkRepository->findBy([], ['name' => 'ASC']),
+            'page' => $page,
+            'pages' => $pages,
+            'total' => $total,
+            'search' => $search,
+            'selectedNetworks' => $networkIds,
+            'selectedStatus' => $status,
         ]);
     }
 

--- a/src/DataFixtures/NetworkFixtures.php
+++ b/src/DataFixtures/NetworkFixtures.php
@@ -51,7 +51,7 @@ class NetworkFixtures extends Fixture
             self::NETWORK_HOMEPAGE => [
                 'identifier' => 'homepage',
                 'name' => 'Homepage',
-                'icon' => 'far fa-home',
+                'icon' => 'fas fa-house',
                 'backgroundColor' => 'white',
                 'textColor' => 'black',
                 // Altcode: filter_var(URL) – wir approximieren das als "muss URL sein"

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -19,4 +19,61 @@ class ProfileRepository extends ServiceEntityRepository
     {
         return $this->findOneBy(['network' => $network, 'identifier' => $identifier]);
     }
+
+    /**
+     * @param list<int> $networkIds
+     * @return list<Profile>
+     */
+    public function findPaginated(int $page, int $limit, array $networkIds = [], string $search = '', string $status = ''): array
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->leftJoin('p.network', 'n')
+            ->addSelect('n')
+            ->orderBy('p.identifier', 'ASC');
+
+        $this->applyFilters($qb, $networkIds, $search, $status);
+
+        return $qb
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @param list<int> $networkIds
+     */
+    public function countFiltered(array $networkIds = [], string $search = '', string $status = ''): int
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->select('COUNT(p.id)')
+            ->leftJoin('p.network', 'n');
+
+        $this->applyFilters($qb, $networkIds, $search, $status);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param list<int> $networkIds
+     */
+    private function applyFilters(\Doctrine\ORM\QueryBuilder $qb, array $networkIds, string $search, string $status): void
+    {
+        if ($networkIds !== []) {
+            $qb->andWhere('n.id IN (:networkIds)')
+                ->setParameter('networkIds', $networkIds);
+        }
+
+        if ($search !== '') {
+            $qb->andWhere('p.identifier LIKE :search')
+                ->setParameter('search', '%' . $search . '%');
+        }
+
+        match ($status) {
+            'success' => $qb->andWhere('p.lastFetchSuccessDateTime IS NOT NULL'),
+            'failed' => $qb->andWhere('p.lastFetchFailureDateTime IS NOT NULL'),
+            'never' => $qb->andWhere('p.lastFetchSuccessDateTime IS NULL AND p.lastFetchFailureDateTime IS NULL'),
+            default => null,
+        };
+    }
 }

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -85,4 +85,55 @@
             </div>
         {% endfor %}
     </div>
+
+    <h2 class="mb-3">Neueste Items</h2>
+    {% if latestItems is empty %}
+        <div class="alert alert-info">Keine Items vorhanden.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-hover table-striped">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Netzwerk</th>
+                        <th>Profil</th>
+                        <th>Text</th>
+                        <th>Datum</th>
+                        <th>Erstellt</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in latestItems %}
+                        <tr>
+                            <td>{{ item.id }}</td>
+                            <td>
+                                {% if item.profile and item.profile.network %}
+                                    <span class="badge badge-network" style="background-color: {{ item.profile.network.backgroundColor }}; color: {{ item.profile.network.textColor }};">
+                                        <i class="{{ item.profile.network.icon }} me-1"></i>{{ item.profile.network.name }}
+                                    </span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if item.profile %}
+                                    <a href="{{ path('app_profile_show', {id: item.profile.id}) }}">
+                                        {{ item.profile.identifier|length > 30 ? item.profile.identifier[:30] ~ '…' : item.profile.identifier }}
+                                    </a>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <a href="{{ path('app_item_show', {id: item.id}) }}">
+                                    {{ item.text|length > 80 ? item.text[:80] ~ '…' : item.text }}
+                                </a>
+                            </td>
+                            <td>{{ item.dateTime|date('d.m.Y H:i') }}</td>
+                            <td>{{ item.createdAt|date('d.m.Y H:i') }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <a href="{{ path('app_item_index') }}" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-list me-1"></i>Alle Items anzeigen
+        </a>
+    {% endif %}
 {% endblock %}

--- a/templates/profile/_partials/_profile_table_body.html.twig
+++ b/templates/profile/_partials/_profile_table_body.html.twig
@@ -1,0 +1,68 @@
+{% for profile in profiles %}
+    <tr>
+        <td>{{ profile.id }}</td>
+        <td>
+            {% if profile.network %}
+                <span class="badge badge-network" style="background-color: {{ profile.network.backgroundColor }}; color: {{ profile.network.textColor }};">
+                    <i class="{{ profile.network.icon }} me-1"></i>{{ profile.network.name }}
+                </span>
+            {% endif %}
+        </td>
+        <td>
+            <a href="{{ path('app_profile_show', {id: profile.id}) }}">
+                {{ profile.identifier }}
+            </a>
+        </td>
+        <td>
+            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
+        </td>
+        <td>
+            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
+        </td>
+        <td data-fetch-status>
+            {% if profile.lastFetchSuccessDateTime %}
+                <span class="text-success" title="{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i:s') }}">
+                    <i class="fas fa-check me-1"></i>{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i') }}
+                </span>
+            {% elseif profile.lastFetchFailureDateTime %}
+                <span class="text-danger" title="{{ profile.lastFetchFailureError }}">
+                    <i class="fas fa-times me-1"></i>{{ profile.lastFetchFailureDateTime|date('d.m.Y H:i') }}
+                </span>
+            {% else %}
+                <span class="text-muted">Noch nicht abgerufen</span>
+            {% endif %}
+        </td>
+        <td>
+            <div class="d-flex gap-1">
+                <a href="{{ path('app_profile_show', {id: profile.id}) }}" class="btn btn-sm btn-outline-primary" title="Anzeigen">
+                    <i class="fas fa-eye"></i>
+                </a>
+                <a href="{{ path('app_profile_edit', {id: profile.id}) }}" class="btn btn-sm btn-outline-secondary" title="Bearbeiten">
+                    <i class="fas fa-edit"></i>
+                </a>
+                <button type="button"
+                        class="btn btn-sm btn-outline-warning"
+                        title="Items importieren"
+                        data-controller="profile-fetch"
+                        data-profile-fetch-url-value="{{ path('app_profile_fetch', {id: profile.id}) }}"
+                        data-profile-fetch-token-value="{{ csrf_token('fetch-profile-' ~ profile.id) }}"
+                        data-profile-fetch-identifier-value="{{ profile.identifier }}"
+                        data-action="profile-fetch#fetch">
+                    <i class="fas fa-download"></i>
+                </button>
+                <form method="post" action="{{ path('app_profile_delete', {id: profile.id}) }}"
+                      data-controller="confirm"
+                      data-confirm-message-value="Profil &quot;{{ profile.identifier }}&quot; wirklich löschen?">
+                    <input type="hidden" name="_token" value="{{ csrf_token('delete-profile-' ~ profile.id) }}">
+                    <button type="submit" class="btn btn-sm btn-outline-danger" title="Löschen">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </form>
+            </div>
+        </td>
+    </tr>
+{% else %}
+    <tr>
+        <td colspan="7" class="text-center text-muted py-4">Keine Profile gefunden.</td>
+    </tr>
+{% endfor %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -4,22 +4,108 @@
 
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h1>Profiles</h1>
+        <h1>Profiles <span class="badge text-bg-secondary fs-6" data-profile-list-target="totalBadge">{{ total }}</span></h1>
         <a href="{{ path('app_profile_new') }}" class="btn btn-primary">
             <i class="fas fa-plus me-1"></i>Neues Profil
         </a>
     </div>
 
-    {% if profiles is empty %}
-        <div class="alert alert-info">
-            Keine Profile gefunden.
-            <a href="{{ path('app_profile_new') }}">Erstes Profil anlegen?</a>
+    <div data-controller="profile-list"
+         data-profile-list-url-value="{{ path('app_profile_index') }}"
+         data-profile-list-page-value="{{ page }}"
+         data-profile-list-pages-value="{{ pages }}">
+
+        <div class="row mb-3 g-2">
+            <div class="col-md-6">
+                <input type="search"
+                       class="form-control"
+                       placeholder="Suche nach Identifier…"
+                       value="{{ search }}"
+                       data-profile-list-target="searchInput"
+                       data-action="input->profile-list#onSearchInput">
+            </div>
+            <div class="col-md-6 d-flex gap-2">
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                        <i class="fas fa-filter me-1"></i>Netzwerk
+                        <span class="badge text-bg-primary ms-1" data-profile-list-target="networkCount">{{ selectedNetworks|length > 0 ? selectedNetworks|length : '' }}</span>
+                    </button>
+                    <ul class="dropdown-menu p-2" style="min-width: 220px;">
+                        {% for network in networks %}
+                            <li>
+                                <label class="dropdown-item d-flex align-items-center gap-2">
+                                    <input type="checkbox"
+                                           value="{{ network.id }}"
+                                           {{ network.id in selectedNetworks ? 'checked' : '' }}
+                                           data-profile-list-target="networkCheckbox"
+                                           data-action="change->profile-list#onNetworkChange">
+                                    <span class="badge badge-network" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
+                                        <i class="{{ network.icon }} me-1"></i>{{ network.name }}
+                                    </span>
+                                </label>
+                            </li>
+                        {% endfor %}
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button type="button" class="dropdown-item text-muted" data-action="profile-list#clearNetworkFilter">
+                                <i class="fas fa-times me-1"></i>Filter zurücksetzen
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                        <i class="fas fa-sync-alt me-1"></i>Fetch-Status
+                        {% if selectedStatus is defined and selectedStatus %}
+                            <span class="badge text-bg-primary ms-1">1</span>
+                        {% endif %}
+                    </button>
+                    <ul class="dropdown-menu p-2" style="min-width: 220px;">
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio"
+                                       name="statusFilter"
+                                       value="success"
+                                       {{ selectedStatus is defined and selectedStatus == 'success' ? 'checked' : '' }}
+                                       data-profile-list-target="statusRadio"
+                                       data-action="change->profile-list#onStatusChange">
+                                <i class="fas fa-check-circle text-success me-1"></i>Erfolgreich
+                            </label>
+                        </li>
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio"
+                                       name="statusFilter"
+                                       value="failed"
+                                       {{ selectedStatus is defined and selectedStatus == 'failed' ? 'checked' : '' }}
+                                       data-profile-list-target="statusRadio"
+                                       data-action="change->profile-list#onStatusChange">
+                                <i class="fas fa-times-circle text-danger me-1"></i>Fehlgeschlagen
+                            </label>
+                        </li>
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio"
+                                       name="statusFilter"
+                                       value="never"
+                                       {{ selectedStatus is defined and selectedStatus == 'never' ? 'checked' : '' }}
+                                       data-profile-list-target="statusRadio"
+                                       data-action="change->profile-list#onStatusChange">
+                                <i class="fas fa-minus-circle text-secondary me-1"></i>Nie abgerufen
+                            </label>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button type="button" class="dropdown-item text-muted" data-action="profile-list#clearStatusFilter">
+                                <i class="fas fa-times me-1"></i>Filter zurücksetzen
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
-    {% else %}
-        <table class="table table-hover table-striped"
-               data-controller="datatable"
-               data-datatable-page-length-value="50"
-               data-datatable-order-value='[[0, "asc"]]'>
+
+        <table class="table table-hover table-striped">
             <thead>
                 <tr>
                     <th>ID</th>
@@ -28,78 +114,18 @@
                     <th>Auto-Fetch</th>
                     <th>Quelltext</th>
                     <th>Letzter Fetch</th>
-                    <th class="no-sort">Aktionen</th>
+                    <th>Aktionen</th>
                 </tr>
             </thead>
-            <tbody>
-                {% for profile in profiles %}
-                    <tr>
-                        <td>{{ profile.id }}</td>
-                        <td>
-                            {% if profile.network %}
-                                <span class="badge badge-network" style="background-color: {{ profile.network.backgroundColor }}; color: {{ profile.network.textColor }};">
-                                    <i class="{{ profile.network.icon }} me-1"></i>{{ profile.network.name }}
-                                </span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <a href="{{ path('app_profile_show', {id: profile.id}) }}">
-                                {{ profile.identifier }}
-                            </a>
-                        </td>
-                        <td>
-                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
-                        </td>
-                        <td>
-                            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
-                        </td>
-                        <td data-fetch-status>
-                            {% if profile.lastFetchSuccessDateTime %}
-                                <span class="text-success" title="{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i:s') }}">
-                                    <i class="fas fa-check me-1"></i>{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i') }}
-                                </span>
-                            {% elseif profile.lastFetchFailureDateTime %}
-                                <span class="text-danger" title="{{ profile.lastFetchFailureError }}">
-                                    <i class="fas fa-times me-1"></i>{{ profile.lastFetchFailureDateTime|date('d.m.Y H:i') }}
-                                </span>
-                            {% else %}
-                                <span class="text-muted">Noch nicht abgerufen</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div class="btn-group btn-group-sm">
-                                <a href="{{ path('app_profile_show', {id: profile.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
-                                    <i class="fas fa-eye"></i>
-                                </a>
-                                <a href="{{ path('app_profile_edit', {id: profile.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
-                                    <i class="fas fa-edit"></i>
-                                </a>
-                                <button type="button"
-                                        class="btn btn-outline-warning"
-                                        title="Items importieren"
-                                        data-controller="profile-fetch"
-                                        data-profile-fetch-url-value="{{ path('app_profile_fetch', {id: profile.id}) }}"
-                                        data-profile-fetch-token-value="{{ csrf_token('fetch-profile-' ~ profile.id) }}"
-                                        data-profile-fetch-identifier-value="{{ profile.identifier }}"
-                                        data-action="profile-fetch#fetch">
-                                    <i class="fas fa-download"></i>
-                                </button>
-                                <form method="post" action="{{ path('app_profile_delete', {id: profile.id}) }}"
-                                      class="d-inline"
-                                      data-controller="confirm"
-                                      data-confirm-message-value="Profil &quot;{{ profile.identifier }}&quot; wirklich löschen?">
-                                    <input type="hidden" name="_token" value="{{ csrf_token('delete-profile-' ~ profile.id) }}">
-                                    <button type="submit" class="btn btn-outline-danger" title="Löschen">
-                                        <i class="fas fa-trash"></i>
-                                    </button>
-                                </form>
-                            </div>
-                        </td>
-                    </tr>
-                {% endfor %}
+            <tbody data-profile-list-target="tableBody">
+                {% include 'profile/_partials/_profile_table_body.html.twig' with { profiles: profiles } %}
             </tbody>
         </table>
-    {% endif %}
+
+        <div data-profile-list-target="pagination">
+            {% include '_partials/_pagination.html.twig' with { page: page, pages: pages } %}
+        </div>
+    </div>
 
     {% include '_partials/_delete_modal.html.twig' %}
 


### PR DESCRIPTION
## Summary

- Adds a "Latest items" table to the dashboard
- Replaces client-side filtering on the profile list with proper server-side pagination, search, and filters (Stimulus + JSON endpoint)

**PR 6 of 17**. Stacked on #25.

## Commits

- `7ae7836` Add latest items table to dashboard
- `36d8664` Add server-side pagination, search, and filters to profile list

## Test plan

- [x] `bin/phpunit` — 40 tests, 85 assertions, all green

## Stack

- Previous: #25 (`feat/networks-crud`)
- Next: B8 (Profile import dedup fixes)