### PR TITLE
Profile import dedup fixes

### DIFF
--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -59,7 +59,7 @@ class ImportProfilesCommand extends Command
         $created = 0;
         $updated = 0;
         $skipped = 0;
-        $seen = [];
+        $seen = [];       // networkId::identifier → Profile entity (tracks persisted-but-unflushed)
 
         foreach ($apiProfiles as $data) {
             $networkIdentifier = $data['network'] ?? null;
@@ -77,10 +77,10 @@ class ImportProfilesCommand extends Command
                 $skipped++;
                 continue;
             }
-            $seen[$uniqueKey] = true;
 
-            $existing = $this->profileRepository->find($data['id'])
-                ?? $this->profileRepository->findOneByNetworkAndIdentifier($network, $data['identifier']);
+            // Priority: match by unique constraint (network+identifier), then by API id
+            $existing = $this->profileRepository->findOneByNetworkAndIdentifier($network, $data['identifier'])
+                ?? $this->profileRepository->find($data['id']);
 
             if ($existing) {
                 $profile = $existing;
@@ -90,6 +90,8 @@ class ImportProfilesCommand extends Command
                 $profile->setId($data['id']);
                 $isNew = true;
             }
+
+            $seen[$uniqueKey] = $profile;
 
             $profile->setNetwork($network);
             $profile->setIdentifier($data['identifier']);
@@ -132,7 +134,12 @@ class ImportProfilesCommand extends Command
         }
 
         if (!$dryRun) {
-            $this->entityManager->flush();
+            try {
+                $this->entityManager->flush();
+            } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
+                $io->error(sprintf('Unique-Constraint-Verletzung: %s', $e->getMessage()));
+                return Command::FAILURE;
+            }
         }
 
         $io->success(sprintf(

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -20,6 +20,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 )]
 class ImportProfilesCommand extends Command
 {
+    private const BATCH_SIZE = 50;
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly EntityManagerInterface $entityManager,
@@ -56,8 +58,9 @@ class ImportProfilesCommand extends Command
             $networkMap[$network->getIdentifier()] = $network;
         }
 
-        // Deduplicate API data upfront: keep first occurrence per network+identifier
+        // Deduplicate API data: by network+identifier (DB constraint) AND by API id (Doctrine identity map)
         $uniqueProfiles = [];
+        $seenIds = [];
         $duplicatesRemoved = 0;
 
         foreach ($apiProfiles as $data) {
@@ -68,23 +71,28 @@ class ImportProfilesCommand extends Command
                 continue;
             }
 
-            $uniqueKey = $networkIdentifier . '::' . $data['identifier'];
+            $network = $networkMap[$networkIdentifier];
+            $constraintKey = $network->getId() . '::' . $data['identifier'];
+            $apiId = $data['id'];
 
-            if (isset($uniqueProfiles[$uniqueKey])) {
+            if (isset($uniqueProfiles[$constraintKey]) || isset($seenIds[$apiId])) {
                 $duplicatesRemoved++;
                 continue;
             }
 
-            $uniqueProfiles[$uniqueKey] = $data;
+            $uniqueProfiles[$constraintKey] = $data;
+            $seenIds[$apiId] = true;
         }
 
         if ($duplicatesRemoved > 0) {
             $io->note(sprintf('%d Duplikate in API-Daten entfernt.', $duplicatesRemoved));
         }
 
+        $io->info(sprintf('%d eindeutige Profile zum Import.', count($uniqueProfiles)));
+
         $created = 0;
         $updated = 0;
-        $skipped = 0;
+        $batchCount = 0;
 
         foreach ($uniqueProfiles as $data) {
             $network = $networkMap[$data['network']];
@@ -138,6 +146,13 @@ class ImportProfilesCommand extends Command
             } else {
                 $updated++;
             }
+
+            $batchCount++;
+            if (!$dryRun && $batchCount >= self::BATCH_SIZE) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+                $batchCount = 0;
+            }
         }
 
         if (!$dryRun) {
@@ -145,11 +160,10 @@ class ImportProfilesCommand extends Command
         }
 
         $io->success(sprintf(
-            '%s%d erstellt, %d aktualisiert, %d übersprungen.',
+            '%s%d erstellt, %d aktualisiert.',
             $dryRun ? '[Dry-Run] ' : '',
             $created,
             $updated,
-            $skipped,
         ));
 
         return Command::SUCCESS;

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -89,8 +89,7 @@ class ImportProfilesCommand extends Command
         foreach ($uniqueProfiles as $data) {
             $network = $networkMap[$data['network']];
 
-            $existing = $this->profileRepository->findOneByNetworkAndIdentifier($network, $data['identifier'])
-                ?? $this->profileRepository->find($data['id']);
+            $existing = $this->profileRepository->findOneByNetworkAndIdentifier($network, $data['identifier']);
 
             if ($existing) {
                 $profile = $existing;

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -72,7 +72,7 @@ class ImportProfilesCommand extends Command
             }
 
             $network = $networkMap[$networkIdentifier];
-            $constraintKey = $network->getId() . '::' . $data['identifier'];
+            $constraintKey = $network->getId() . '::' . mb_strtolower($data['identifier']);
             $apiId = $data['id'];
 
             if (isset($uniqueProfiles[$constraintKey]) || isset($seenIds[$apiId])) {

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -150,7 +150,6 @@ class ImportProfilesCommand extends Command
             $batchCount++;
             if (!$dryRun && $batchCount >= self::BATCH_SIZE) {
                 $this->entityManager->flush();
-                $this->entityManager->clear();
                 $batchCount = 0;
             }
         }

--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -56,29 +56,39 @@ class ImportProfilesCommand extends Command
             $networkMap[$network->getIdentifier()] = $network;
         }
 
-        $created = 0;
-        $updated = 0;
-        $skipped = 0;
-        $seen = [];       // networkId::identifier → Profile entity (tracks persisted-but-unflushed)
+        // Deduplicate API data upfront: keep first occurrence per network+identifier
+        $uniqueProfiles = [];
+        $duplicatesRemoved = 0;
 
         foreach ($apiProfiles as $data) {
             $networkIdentifier = $data['network'] ?? null;
 
             if (!$networkIdentifier || !isset($networkMap[$networkIdentifier])) {
                 $io->warning(sprintf('Netzwerk "%s" nicht gefunden, überspringe Profil #%d (%s)', $networkIdentifier, $data['id'], $data['identifier'] ?? ''));
-                $skipped++;
                 continue;
             }
 
-            $network = $networkMap[$networkIdentifier];
-            $uniqueKey = $network->getId() . '::' . $data['identifier'];
+            $uniqueKey = $networkIdentifier . '::' . $data['identifier'];
 
-            if (isset($seen[$uniqueKey])) {
-                $skipped++;
+            if (isset($uniqueProfiles[$uniqueKey])) {
+                $duplicatesRemoved++;
                 continue;
             }
 
-            // Priority: match by unique constraint (network+identifier), then by API id
+            $uniqueProfiles[$uniqueKey] = $data;
+        }
+
+        if ($duplicatesRemoved > 0) {
+            $io->note(sprintf('%d Duplikate in API-Daten entfernt.', $duplicatesRemoved));
+        }
+
+        $created = 0;
+        $updated = 0;
+        $skipped = 0;
+
+        foreach ($uniqueProfiles as $data) {
+            $network = $networkMap[$data['network']];
+
             $existing = $this->profileRepository->findOneByNetworkAndIdentifier($network, $data['identifier'])
                 ?? $this->profileRepository->find($data['id']);
 
@@ -90,8 +100,6 @@ class ImportProfilesCommand extends Command
                 $profile->setId($data['id']);
                 $isNew = true;
             }
-
-            $seen[$uniqueKey] = $profile;
 
             $profile->setNetwork($network);
             $profile->setIdentifier($data['identifier']);
@@ -134,12 +142,7 @@ class ImportProfilesCommand extends Command
         }
 
         if (!$dryRun) {
-            try {
-                $this->entityManager->flush();
-            } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
-                $io->error(sprintf('Unique-Constraint-Verletzung: %s', $e->getMessage()));
-                return Command::FAILURE;
-            }
+            $this->entityManager->flush();
         }
 
         $io->success(sprintf(


### PR DESCRIPTION
## Summary

Six iterative fixes for the profile import command, all targeting the same root cause: duplicate profiles in the criticalmass.in API response and the resulting unique-constraint violations during import.

**PR 7 of 17**. Stacked on #26.

## Commits

- `c35ae09` Fix duplicate profile import by prioritizing unique constraint lookup
- `543552c` Deduplicate API profiles upfront before import
- `fb06d11` Remove find-by-id fallback in profile import
- `1619b4e` Fix profile import with proper dedup and batch flushing
- `d3d94ea` Fix entity manager clear detaching network entities during import
- `83c6700` Use case-insensitive dedup for profile import

## Test plan

- [x] `bin/phpunit` — 40 tests, 85 assertions, all green
- [ ] Reviewer to confirm the dedup logic handles both name and identifier collisions

## Stack

- Previous: #26 (`feat/dashboard-and-pagination`)
- Next: B9 (Scheduled fetch command)