### PR TITLE
Add scheduled fetch command with per-network cron expressions

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ APP_SECRET=e63692e1110a2d39e4103655dc5ce84b
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
 ###< symfony/framework-bundle ###
 
-CRITICALMASS_HOSTNAME="https://criticalmass.in"
+CRITICALMASS_HOSTNAME="criticalmass.in"
 
 RSS_APP_API_KEY=c_ULGigpJGEh9ByT
 RSS_APP_API_SECRET=s_zlrGVS4T3dY4YCOfR1U8w5

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.6",
+        "dragonmantank/cron-expression": "^3.6",
         "laminas/laminas-feed": "^2.12",
         "laminas/laminas-http": "^2.11",
         "symfony/asset": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec20d67a04b5717e230b5e41145be352",
+    "content-hash": "3a2acb2766696dc20df9e3be4d90e96a",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1463,6 +1463,70 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
             },
             "time": "2026-02-08T16:21:46+00:00"
+        },
+        {
+            "name": "dragonmantank/cron-expression",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dragonmantank/cron-expression.git",
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d61a8a9604ec1f8c3d150d09db6ce98b32675013",
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2|^8.3|^8.4|^8.5"
+            },
+            "replace": {
+                "mtdowling/cron-expression": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.32|^2.1.31",
+                "phpunit/phpunit": "^8.5.48|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris@ctankersley.com",
+                    "homepage": "https://github.com/dragonmantank"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "support": {
+                "issues": "https://github.com/dragonmantank/cron-expression/issues",
+                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dragonmantank",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-31T18:51:33+00:00"
         },
         {
             "name": "laminas/laminas-escaper",

--- a/migrations/Version20260313225512.php
+++ b/migrations/Version20260313225512.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260313225512 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE network ADD cron_expression VARCHAR(64) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE network DROP cron_expression');
+    }
+}

--- a/src/Command/ScheduledFetchCommand.php
+++ b/src/Command/ScheduledFetchCommand.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\FeedFetcher\FeedFetcherInterface;
+use App\FeedFetcher\FetchInfo;
+use App\FeedFetcher\FetchResult;
+use App\Repository\NetworkRepository;
+use Cron\CronExpression;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:fetch-scheduled',
+    description: 'Fetch feeds for networks whose cron expression matches the current time',
+)]
+class ScheduledFetchCommand extends Command
+{
+    public function __construct(
+        private readonly NetworkRepository $networkRepository,
+        private readonly FeedFetcherInterface $feedFetcher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Nur anzeigen, welche Netzwerke abgerufen würden')
+            ->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'Anzahl Items pro Profil', '50')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = $input->getOption('dry-run');
+        $count = (int) $input->getOption('count');
+        $now = new \DateTimeImmutable();
+
+        $networks = $this->networkRepository->findAll();
+        $dueNetworks = [];
+
+        foreach ($networks as $network) {
+            $expression = $network->getCronExpression();
+
+            if ($expression === null || $expression === '') {
+                continue;
+            }
+
+            $cron = new CronExpression($expression);
+
+            if ($cron->isDue($now)) {
+                $dueNetworks[] = $network->getIdentifier();
+            }
+        }
+
+        if ($dueNetworks === []) {
+            $io->info(sprintf('[%s] Keine Netzwerke fällig.', $now->format('H:i')));
+            return Command::SUCCESS;
+        }
+
+        $io->info(sprintf('[%s] Fällige Netzwerke: %s', $now->format('H:i'), implode(', ', $dueNetworks)));
+
+        if ($dryRun) {
+            $io->success(sprintf('[Dry-Run] Würde %d Netzwerke fetchen.', count($dueNetworks)));
+            return Command::SUCCESS;
+        }
+
+        $fetchInfo = new FetchInfo();
+        $fetchInfo->setCount($count);
+
+        foreach ($dueNetworks as $networkIdentifier) {
+            $fetchInfo->addNetwork($networkIdentifier);
+        }
+
+        $callback = function (FetchResult $fetchResult) use ($io): void {
+            $io->writeln(sprintf(
+                '  <info>%s</info>: %d Items',
+                $fetchResult->getProfile()->getIdentifier(),
+                $fetchResult->getCounterFetched(),
+            ));
+        };
+
+        $this->feedFetcher
+            ->fetch($fetchInfo, $callback)
+            ->persist();
+
+        $io->success('Fertig.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DataFixtures/NetworkFixtures.php
+++ b/src/DataFixtures/NetworkFixtures.php
@@ -286,6 +286,7 @@ class NetworkFixtures extends Fixture
             $network->setBackgroundColor($data['backgroundColor']);
             $network->setTextColor($data['textColor']);
             $network->setProfileUrlPattern($data['profileUrlPattern']);
+            $network->setCronExpression($data['cronExpression'] ?? null);
 
             $manager->persist($network);
             $this->addReference($reference, $network);

--- a/src/Entity/Network.php
+++ b/src/Entity/Network.php
@@ -55,6 +55,10 @@ class Network
     #[Groups(['network:read', 'network:write'])]
     private ?string $profileUrlPattern = null;
 
+    #[ORM\Column(type: 'string', length: 64, nullable: true)]
+    #[Groups(['network:read', 'network:write'])]
+    private ?string $cronExpression = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -128,6 +132,18 @@ class Network
     public function setProfileUrlPattern(string $profileUrlPattern): self
     {
         $this->profileUrlPattern = $profileUrlPattern;
+
+        return $this;
+    }
+
+    public function getCronExpression(): ?string
+    {
+        return $this->cronExpression;
+    }
+
+    public function setCronExpression(?string $cronExpression): self
+    {
+        $this->cronExpression = $cronExpression;
 
         return $this;
     }

--- a/src/Form/NetworkType.php
+++ b/src/Form/NetworkType.php
@@ -37,6 +37,11 @@ class NetworkType extends AbstractType
                 'label' => 'Profil-URL-Pattern',
                 'help' => 'Regulärer Ausdruck zur Validierung von Profil-URLs',
             ])
+            ->add('cronExpression', TextType::class, [
+                'label' => 'Cron-Expression',
+                'help' => 'Crontab-Notation für den Fetch-Zeitplan (z.B. */15 * * * * = alle 15 Minuten). Leer = kein automatischer Fetch.',
+                'required' => false,
+            ])
         ;
     }
 


### PR DESCRIPTION
## Summary

Adds the `app:fetch-scheduled` command and a `cron_expression` column on the `Network` entity. Each network can carry its own cron schedule; the new command iterates networks whose cron is due and triggers a fetch. Includes the migration.

**PR 8 of 17**. Stacked on #27.

## Commits

- `3491c6c` Add scheduled fetch command with per-network cron expressions

## Test plan

- [x] `bin/phpunit` — 40 tests, 85 assertions, all green

## Stack

- Previous: #27 (`feat/import-dedup-fixes`)
- Next: B10 (Remove DataTables)