### PR TITLE
Add AJAX item search with Handlebars client-side rendering

### DIFF
--- a/assets/controllers/item_list_controller.js
+++ b/assets/controllers/item_list_controller.js
@@ -1,0 +1,186 @@
+import { Controller } from '@hotwired/stimulus';
+import Handlebars from 'handlebars';
+
+export default class extends Controller {
+    static values = {
+        url: String,
+        page: Number,
+        pages: Number,
+        profile: Number,
+    };
+
+    static targets = [
+        'searchInput', 'profileSelect', 'networkCheckbox', 'networkCount',
+        'statusRadio', 'tableBody', 'pagination', 'totalBadge',
+        'itemRowTemplate', 'emptyTemplate', 'paginationTemplate',
+    ];
+
+    _searchTimeout = null;
+    _itemRowTpl = null;
+    _emptyTpl = null;
+    _paginationTpl = null;
+
+    connect() {
+        this._itemRowTpl = Handlebars.compile(this.itemRowTemplateTarget.innerHTML);
+        this._emptyTpl = Handlebars.compile(this.emptyTemplateTarget.innerHTML);
+        this._paginationTpl = Handlebars.compile(this.paginationTemplateTarget.innerHTML);
+
+        Handlebars.registerHelper('truncate', (str, len) => {
+            if (!str) return '';
+            return str.length > len ? str.substring(0, len) + '...' : str;
+        });
+
+        Handlebars.registerHelper('eq', (a, b) => a === b);
+        Handlebars.registerHelper('gt', (a, b) => a > b);
+
+        if (this.profileValue) {
+            this._load();
+        }
+    }
+
+    disconnect() {
+        clearTimeout(this._searchTimeout);
+    }
+
+    onSearchInput() {
+        clearTimeout(this._searchTimeout);
+        this._searchTimeout = setTimeout(() => {
+            this.pageValue = 1;
+            this._load();
+        }, 300);
+    }
+
+    onProfileChange() {
+        this.pageValue = 1;
+        this._load();
+    }
+
+    onNetworkChange() {
+        this._updateNetworkCount();
+        this.pageValue = 1;
+        this._load();
+    }
+
+    clearNetworkFilter() {
+        this.networkCheckboxTargets.forEach(cb => cb.checked = false);
+        this._updateNetworkCount();
+        this.pageValue = 1;
+        this._load();
+    }
+
+    onStatusChange() {
+        this.pageValue = 1;
+        this._load();
+    }
+
+    clearStatusFilter() {
+        this.statusRadioTargets.forEach(r => r.checked = false);
+        this.pageValue = 1;
+        this._load();
+    }
+
+    onPageClick(event) {
+        event.preventDefault();
+        const page = parseInt(event.currentTarget.dataset.page, 10);
+        if (page && page !== this.pageValue) {
+            this.pageValue = page;
+            this._load();
+        }
+    }
+
+    async _load() {
+        const params = new URLSearchParams();
+        params.set('page', this.pageValue);
+
+        if (this.hasSearchInputTarget) {
+            const search = this.searchInputTarget.value.trim();
+            if (search) params.set('search', search);
+        }
+
+        if (this.hasProfileSelectTarget) {
+            const profileId = this.profileSelectTarget.value;
+            if (profileId) params.set('profile', profileId);
+        } else if (this.profileValue) {
+            params.set('profile', this.profileValue);
+        }
+
+        if (this.hasNetworkCheckboxTarget) {
+            this.networkCheckboxTargets.forEach(cb => {
+                if (cb.checked) params.append('networks[]', cb.value);
+            });
+        }
+
+        if (this.hasStatusRadioTarget) {
+            const selected = this.statusRadioTargets.find(r => r.checked);
+            if (selected) params.set('status', selected.value);
+        }
+
+        try {
+            const response = await fetch(`${this.urlValue}?${params}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+
+            if (!response.ok) return;
+
+            const data = await response.json();
+
+            if (data.items.length === 0) {
+                this.tableBodyTarget.innerHTML = this._emptyTpl();
+            } else {
+                this.tableBodyTarget.innerHTML = data.items
+                    .map(item => this._itemRowTpl({ ...item, csrfToken: data.csrfToken }))
+                    .join('');
+            }
+
+            this._renderPagination(data.page, data.pages);
+            this.pageValue = data.page;
+            this.pagesValue = data.pages;
+
+            if (this.hasTotalBadgeTarget) {
+                this.totalBadgeTarget.textContent = data.total;
+            }
+
+            if (!this.profileValue) {
+                const url = new URL(window.location);
+                url.search = params.toString();
+                history.replaceState(null, '', url);
+            }
+        } catch (error) {
+            // silently fail on network errors
+        }
+    }
+
+    _renderPagination(page, pages) {
+        if (!this.hasPaginationTarget) return;
+
+        if (pages <= 1) {
+            this.paginationTarget.innerHTML = '';
+            return;
+        }
+
+        const pageNumbers = [];
+        for (let p = 1; p <= pages; p++) {
+            if (p <= 3 || p > pages - 2 || (p >= page - 1 && p <= page + 1)) {
+                pageNumbers.push({ num: p, active: p === page, ellipsis: false });
+            } else if (p === 4 || p === pages - 2) {
+                pageNumbers.push({ num: p, active: false, ellipsis: true });
+            }
+        }
+
+        this.paginationTarget.innerHTML = this._paginationTpl({
+            page,
+            pages,
+            prevDisabled: page <= 1,
+            nextDisabled: page >= pages,
+            prevPage: page - 1,
+            nextPage: page + 1,
+            pageNumbers,
+        });
+    }
+
+    _updateNetworkCount() {
+        if (!this.hasNetworkCountTarget) return;
+        const checked = this.networkCheckboxTargets.filter(cb => cb.checked).length;
+        this.networkCountTarget.textContent = checked > 0 ? checked : '';
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -32,4 +32,7 @@ return [
     '@symfony/stimulus-bundle' => [
         'path' => './vendor/symfony/stimulus-bundle/assets/dist/loader.js',
     ],
+    'handlebars' => [
+        'version' => '4.7.8',
+    ],
 ];

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\Item;
 use App\Form\ItemType;
 use App\Repository\ItemRepository;
+use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 #[Route('/items')]
 class ItemController extends AbstractController
@@ -23,31 +25,77 @@ class ItemController extends AbstractController
         Request $request,
         ItemRepository $itemRepository,
         ProfileRepository $profileRepository,
+        NetworkRepository $networkRepository,
+        CsrfTokenManagerInterface $csrfTokenManager,
     ): Response {
-        $profileId = $request->query->getInt('profile');
-        $profile = $profileId ? $profileRepository->find($profileId) : null;
+        $profileId = $request->query->getInt('profile') ?: null;
         $page = max(1, $request->query->getInt('page', 1));
+        $search = trim($request->query->getString('search', ''));
+        $networkIds = array_map('intval', (array) $request->query->all('networks'));
+        $status = $request->query->getString('status', '');
 
-        $criteria = $profile ? ['profile' => $profile] : [];
-        $total = $itemRepository->count($criteria);
+        $total = $itemRepository->countFiltered($profileId, $networkIds, $search, $status);
         $pages = max(1, (int) ceil($total / self::ITEMS_PER_PAGE));
         $page = min($page, $pages);
 
-        $items = $itemRepository->findBy(
-            $criteria,
-            ['dateTime' => 'DESC'],
-            self::ITEMS_PER_PAGE,
-            ($page - 1) * self::ITEMS_PER_PAGE,
-        );
+        $items = $itemRepository->findPaginated($page, self::ITEMS_PER_PAGE, $profileId, $networkIds, $search, $status);
+
+        if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
+            return new JsonResponse([
+                'items' => $this->serializeItems($items),
+                'csrfToken' => $csrfTokenManager->getToken('toggle-item')->getValue(),
+                'page' => $page,
+                'pages' => $pages,
+                'total' => $total,
+            ]);
+        }
 
         return $this->render('item/index.html.twig', [
             'items' => $items,
-            'profile' => $profile,
             'profiles' => $profileRepository->findBy([], ['identifier' => 'ASC']),
+            'networks' => $networkRepository->findBy([], ['name' => 'ASC']),
             'page' => $page,
             'pages' => $pages,
             'total' => $total,
+            'search' => $search,
+            'selectedProfile' => $profileId,
+            'selectedNetworks' => $networkIds,
+            'selectedStatus' => $status,
         ]);
+    }
+
+    /**
+     * @param list<Item> $items
+     * @return list<array<string, mixed>>
+     */
+    private function serializeItems(array $items): array
+    {
+        return array_map(function (Item $item): array {
+            $profile = $item->getProfile();
+            $network = $profile?->getNetwork();
+
+            return [
+                'id' => $item->getId(),
+                'text' => $item->getText(),
+                'title' => $item->getTitle(),
+                'dateTime' => $item->getDateTime()?->format('d.m.Y H:i'),
+                'hidden' => $item->isHidden(),
+                'deleted' => $item->isDeleted(),
+                'showUrl' => $this->generateUrl('app_item_show', ['id' => $item->getId()]),
+                'editUrl' => $this->generateUrl('app_item_edit', ['id' => $item->getId()]),
+                'profile' => $profile ? [
+                    'id' => $profile->getId(),
+                    'identifier' => $profile->getIdentifier(),
+                    'showUrl' => $this->generateUrl('app_profile_show', ['id' => $profile->getId()]),
+                    'network' => $network ? [
+                        'name' => $network->getName(),
+                        'icon' => $network->getIcon(),
+                        'backgroundColor' => $network->getBackgroundColor(),
+                        'textColor' => $network->getTextColor(),
+                    ] : null,
+                ] : null,
+            ];
+        }, $items);
     }
 
     #[Route('/{id}', name: 'app_item_show', requirements: ['id' => '\d+'])]

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Item;
 use App\Entity\Profile;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /** @extends ServiceEntityRepository<Item> */
@@ -21,5 +22,70 @@ class ItemRepository extends ServiceEntityRepository
             'profile' => $profile,
             'uniqueIdentifier' => $uniqueIdentifier,
         ]);
+    }
+
+    /**
+     * @param list<int> $networkIds
+     * @return list<Item>
+     */
+    public function findPaginated(int $page, int $limit, ?int $profileId = null, array $networkIds = [], string $search = '', string $status = ''): array
+    {
+        $qb = $this->createQueryBuilder('i')
+            ->leftJoin('i.profile', 'p')
+            ->addSelect('p')
+            ->leftJoin('p.network', 'n')
+            ->addSelect('n')
+            ->orderBy('i.dateTime', 'DESC');
+
+        $this->applyFilters($qb, $profileId, $networkIds, $search, $status);
+
+        return $qb
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @param list<int> $networkIds
+     */
+    public function countFiltered(?int $profileId = null, array $networkIds = [], string $search = '', string $status = ''): int
+    {
+        $qb = $this->createQueryBuilder('i')
+            ->select('COUNT(i.id)')
+            ->leftJoin('i.profile', 'p')
+            ->leftJoin('p.network', 'n');
+
+        $this->applyFilters($qb, $profileId, $networkIds, $search, $status);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param list<int> $networkIds
+     */
+    private function applyFilters(QueryBuilder $qb, ?int $profileId, array $networkIds, string $search, string $status): void
+    {
+        if ($profileId !== null) {
+            $qb->andWhere('p.id = :profileId')
+                ->setParameter('profileId', $profileId);
+        }
+
+        if ($networkIds !== []) {
+            $qb->andWhere('n.id IN (:networkIds)')
+                ->setParameter('networkIds', $networkIds);
+        }
+
+        if ($search !== '') {
+            $qb->andWhere('i.text LIKE :search OR i.uniqueIdentifier LIKE :search OR i.title LIKE :search')
+                ->setParameter('search', '%' . $search . '%');
+        }
+
+        match ($status) {
+            'active' => $qb->andWhere('i.hidden = false AND i.deleted = false'),
+            'hidden' => $qb->andWhere('i.hidden = true'),
+            'deleted' => $qb->andWhere('i.deleted = true'),
+            default => null,
+        };
     }
 }

--- a/templates/item/index.html.twig
+++ b/templates/item/index.html.twig
@@ -1,43 +1,113 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Items{% if profile %} - {{ profile.identifier }}{% endif %} - Social Network Fetcher{% endblock %}
+{% block title %}Items - Social Network Fetcher{% endblock %}
 
 {% block body %}
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h1>
-            Items
-            {% if profile %}
-                <small class="text-muted">
-                    {% if profile.network %}
-                        <span class="badge badge-network" style="background-color: {{ profile.network.backgroundColor }}; color: {{ profile.network.textColor }};">
-                            <i class="{{ profile.network.icon }}"></i>
-                        </span>
-                    {% endif %}
-                    {{ profile.identifier }}
-                </small>
-            {% endif %}
-        </h1>
-        <span class="badge text-bg-secondary fs-6">{{ total }} Items</span>
+        <h1>Items <span class="badge text-bg-secondary fs-6" data-item-list-target="totalBadge">{{ total }}</span></h1>
     </div>
 
-    <div class="mb-3">
-        <form class="row g-2 align-items-center" method="get">
-            <div class="col-auto">
-                <select name="profile" class="form-select form-select-sm" onchange="this.form.submit()">
+    <div data-controller="item-list"
+         data-item-list-url-value="{{ path('app_item_index') }}"
+         data-item-list-page-value="{{ page }}"
+         data-item-list-pages-value="{{ pages }}">
+
+        <div class="row mb-3 g-2">
+            <div class="col-md-4">
+                <input type="search"
+                       class="form-control"
+                       placeholder="Suche in Text, Titel, ID…"
+                       value="{{ search }}"
+                       data-item-list-target="searchInput"
+                       data-action="input->item-list#onSearchInput">
+            </div>
+            <div class="col-md-3">
+                <select class="form-select"
+                        data-item-list-target="profileSelect"
+                        data-action="change->item-list#onProfileChange">
                     <option value="">Alle Profile</option>
                     {% for p in profiles %}
-                        <option value="{{ p.id }}" {% if profile and profile.id == p.id %}selected{% endif %}>
+                        <option value="{{ p.id }}" {% if selectedProfile == p.id %}selected{% endif %}>
                             {{ p.network ? p.network.name ~ ': ' : '' }}{{ p.identifier }}
                         </option>
                     {% endfor %}
                 </select>
             </div>
-        </form>
-    </div>
+            <div class="col-md-5 d-flex gap-2">
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                        <i class="fas fa-filter me-1"></i>Netzwerk
+                        <span class="badge text-bg-primary ms-1" data-item-list-target="networkCount">{{ selectedNetworks|length > 0 ? selectedNetworks|length : '' }}</span>
+                    </button>
+                    <ul class="dropdown-menu p-2" style="min-width: 220px;">
+                        {% for network in networks %}
+                            <li>
+                                <label class="dropdown-item d-flex align-items-center gap-2">
+                                    <input type="checkbox"
+                                           value="{{ network.id }}"
+                                           {{ network.id in selectedNetworks ? 'checked' : '' }}
+                                           data-item-list-target="networkCheckbox"
+                                           data-action="change->item-list#onNetworkChange">
+                                    <span class="badge badge-network" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
+                                        <i class="{{ network.icon }} me-1"></i>{{ network.name }}
+                                    </span>
+                                </label>
+                            </li>
+                        {% endfor %}
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button type="button" class="dropdown-item text-muted" data-action="item-list#clearNetworkFilter">
+                                <i class="fas fa-times me-1"></i>Filter zurücksetzen
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+                <div class="dropdown">
+                    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside">
+                        <i class="fas fa-eye me-1"></i>Status
+                        {% if selectedStatus is defined and selectedStatus %}
+                            <span class="badge text-bg-primary ms-1">1</span>
+                        {% endif %}
+                    </button>
+                    <ul class="dropdown-menu p-2" style="min-width: 220px;">
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio" name="statusFilter" value="active"
+                                       {{ selectedStatus is defined and selectedStatus == 'active' ? 'checked' : '' }}
+                                       data-item-list-target="statusRadio"
+                                       data-action="change->item-list#onStatusChange">
+                                <i class="fas fa-check-circle text-success me-1"></i>Aktiv
+                            </label>
+                        </li>
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio" name="statusFilter" value="hidden"
+                                       {{ selectedStatus is defined and selectedStatus == 'hidden' ? 'checked' : '' }}
+                                       data-item-list-target="statusRadio"
+                                       data-action="change->item-list#onStatusChange">
+                                <i class="fas fa-eye-slash text-warning me-1"></i>Versteckt
+                            </label>
+                        </li>
+                        <li>
+                            <label class="dropdown-item d-flex align-items-center gap-2">
+                                <input type="radio" name="statusFilter" value="deleted"
+                                       {{ selectedStatus is defined and selectedStatus == 'deleted' ? 'checked' : '' }}
+                                       data-item-list-target="statusRadio"
+                                       data-action="change->item-list#onStatusChange">
+                                <i class="fas fa-trash text-danger me-1"></i>Gelöscht
+                            </label>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button type="button" class="dropdown-item text-muted" data-action="item-list#clearStatusFilter">
+                                <i class="fas fa-times me-1"></i>Filter zurücksetzen
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
 
-    {% if items is empty %}
-        <div class="alert alert-info">Keine Items gefunden.</div>
-    {% else %}
         <div class="table-responsive">
             <table class="table table-hover table-striped">
                 <thead>
@@ -51,65 +121,159 @@
                         <th>Aktionen</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody data-item-list-target="tableBody">
                     {% set toggleToken = csrf_token('toggle-item') %}
-                    {% for item in items %}
-                        <tr id="item-row-{{ item.id }}"
-                            class="{% if item.deleted %}table-row-deleted{% elseif item.hidden %}table-row-hidden{% endif %}"
-                            data-controller="toggle"
-                            data-toggle-id-value="{{ item.id }}"
-                            data-toggle-token-value="{{ toggleToken }}">
-                            <td>{{ item.id }}</td>
-                            <td>
-                                {% if item.profile and item.profile.network %}
-                                    <span class="badge badge-network" style="background-color: {{ item.profile.network.backgroundColor }}; color: {{ item.profile.network.textColor }};">
-                                        <i class="{{ item.profile.network.icon }} me-1"></i>{{ item.profile.network.name }}
-                                    </span>
-                                {% endif %}
-                            </td>
-                            <td>
-                                {% if item.profile %}
-                                    <a href="{{ path('app_profile_show', {id: item.profile.id}) }}">
-                                        {{ item.profile.identifier|length > 30 ? item.profile.identifier|slice(0, 30) ~ '...' : item.profile.identifier }}
+                    {% if items is empty %}
+                        <tr><td colspan="7" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
+                    {% else %}
+                        {% for item in items %}
+                            <tr id="item-row-{{ item.id }}"
+                                class="{% if item.deleted %}table-row-deleted{% elseif item.hidden %}table-row-hidden{% endif %}"
+                                data-controller="toggle"
+                                data-toggle-id-value="{{ item.id }}"
+                                data-toggle-token-value="{{ toggleToken }}">
+                                <td>{{ item.id }}</td>
+                                <td>
+                                    {% if item.profile and item.profile.network %}
+                                        <span class="badge badge-network" style="background-color: {{ item.profile.network.backgroundColor }}; color: {{ item.profile.network.textColor }};">
+                                            <i class="{{ item.profile.network.icon }} me-1"></i>{{ item.profile.network.name }}
+                                        </span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if item.profile %}
+                                        <a href="{{ path('app_profile_show', {id: item.profile.id}) }}">
+                                            {{ item.profile.identifier|length > 30 ? item.profile.identifier|slice(0, 30) ~ '...' : item.profile.identifier }}
+                                        </a>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <a href="{{ path('app_item_show', {id: item.id}) }}">
+                                        {{ item.text|length > 80 ? item.text|slice(0, 80) ~ '...' : item.text }}
                                     </a>
-                                {% endif %}
-                            </td>
-                            <td>
-                                <a href="{{ path('app_item_show', {id: item.id}) }}">
-                                    {{ item.text|length > 80 ? item.text|slice(0, 80) ~ '...' : item.text }}
-                                </a>
-                            </td>
-                            <td>{{ item.dateTime|date('d.m.Y H:i') }}</td>
-                            <td>
-                                <button class="btn btn-sm {{ item.hidden ? 'btn-warning' : 'btn-outline-warning' }}"
-                                        data-action="toggle#toggleHidden"
-                                        data-toggle-target="hiddenBtn"
-                                        title="Versteckt">
-                                    <i class="fas fa-eye-slash"></i>
-                                </button>
-                                <button class="btn btn-sm {{ item.deleted ? 'btn-danger' : 'btn-outline-danger' }}"
-                                        data-action="toggle#toggleDeleted"
-                                        data-toggle-target="deletedBtn"
-                                        title="Gelöscht">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                            </td>
-                            <td>
-                                <div class="btn-group btn-group-sm">
-                                    <a href="{{ path('app_item_show', {id: item.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
-                                        <i class="fas fa-eye"></i>
-                                    </a>
-                                    <a href="{{ path('app_item_edit', {id: item.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
-                                        <i class="fas fa-edit"></i>
-                                    </a>
-                                </div>
-                            </td>
-                        </tr>
-                    {% endfor %}
+                                </td>
+                                <td>{{ item.dateTime|date('d.m.Y H:i') }}</td>
+                                <td>
+                                    <button class="btn btn-sm {{ item.hidden ? 'btn-warning' : 'btn-outline-warning' }}"
+                                            data-action="toggle#toggleHidden"
+                                            data-toggle-target="hiddenBtn"
+                                            title="Versteckt">
+                                        <i class="fas fa-eye-slash"></i>
+                                    </button>
+                                    <button class="btn btn-sm {{ item.deleted ? 'btn-danger' : 'btn-outline-danger' }}"
+                                            data-action="toggle#toggleDeleted"
+                                            data-toggle-target="deletedBtn"
+                                            title="Gelöscht">
+                                        <i class="fas fa-trash"></i>
+                                    </button>
+                                </td>
+                                <td>
+                                    <div class="btn-group btn-group-sm">
+                                        <a href="{{ path('app_item_show', {id: item.id}) }}" class="btn btn-outline-primary" title="Anzeigen">
+                                            <i class="fas fa-eye"></i>
+                                        </a>
+                                        <a href="{{ path('app_item_edit', {id: item.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
+                                            <i class="fas fa-edit"></i>
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endif %}
                 </tbody>
             </table>
         </div>
 
-        {% include '_partials/_pagination.html.twig' %}
-    {% endif %}
+        <div data-item-list-target="pagination">
+            {% include '_partials/_pagination.html.twig' with { page: page, pages: pages } %}
+        </div>
+
+        {% verbatim %}
+        <template data-item-list-target="itemRowTemplate">
+            <tr id="item-row-{{id}}"
+                class="{{#if deleted}}table-row-deleted{{else}}{{#if hidden}}table-row-hidden{{/if}}{{/if}}"
+                data-controller="toggle"
+                data-toggle-id-value="{{id}}"
+                data-toggle-token-value="{{csrfToken}}">
+                <td>{{id}}</td>
+                <td>
+                    {{#if profile.network}}
+                        <span class="badge badge-network" style="background-color: {{profile.network.backgroundColor}}; color: {{profile.network.textColor}};">
+                            <i class="{{profile.network.icon}} me-1"></i>{{profile.network.name}}
+                        </span>
+                    {{/if}}
+                </td>
+                <td>
+                    {{#if profile}}
+                        <a href="{{profile.showUrl}}">{{truncate profile.identifier 30}}</a>
+                    {{/if}}
+                </td>
+                <td>
+                    <a href="{{showUrl}}">{{truncate text 80}}</a>
+                </td>
+                <td>{{dateTime}}</td>
+                <td>
+                    <button class="btn btn-sm {{#if hidden}}btn-warning{{else}}btn-outline-warning{{/if}}"
+                            data-action="toggle#toggleHidden"
+                            data-toggle-target="hiddenBtn"
+                            title="Versteckt">
+                        <i class="fas fa-eye-slash"></i>
+                    </button>
+                    <button class="btn btn-sm {{#if deleted}}btn-danger{{else}}btn-outline-danger{{/if}}"
+                            data-action="toggle#toggleDeleted"
+                            data-toggle-target="deletedBtn"
+                            title="Gelöscht">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </td>
+                <td>
+                    <div class="btn-group btn-group-sm">
+                        <a href="{{showUrl}}" class="btn btn-outline-primary" title="Anzeigen">
+                            <i class="fas fa-eye"></i>
+                        </a>
+                        <a href="{{editUrl}}" class="btn btn-outline-secondary" title="Bearbeiten">
+                            <i class="fas fa-edit"></i>
+                        </a>
+                    </div>
+                </td>
+            </tr>
+        </template>
+
+        <template data-item-list-target="emptyTemplate">
+            <tr><td colspan="7" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
+        </template>
+
+        <template data-item-list-target="paginationTemplate">
+            {{#if (gt pages 1)}}
+            <nav aria-label="Seitennavigation">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item {{#if prevDisabled}}disabled{{/if}}">
+                        <a class="page-link" href="#" data-page="{{prevPage}}" data-action="item-list#onPageClick">
+                            <i class="fas fa-chevron-left"></i>
+                        </a>
+                    </li>
+                    {{#each pageNumbers}}
+                        {{#if this.ellipsis}}
+                            <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                        {{else}}
+                            <li class="page-item {{#if this.active}}active{{/if}}">
+                                {{#if this.active}}
+                                    <span class="page-link">{{this.num}}</span>
+                                {{else}}
+                                    <a class="page-link" href="#" data-page="{{this.num}}" data-action="item-list#onPageClick">{{this.num}}</a>
+                                {{/if}}
+                            </li>
+                        {{/if}}
+                    {{/each}}
+                    <li class="page-item {{#if nextDisabled}}disabled{{/if}}">
+                        <a class="page-link" href="#" data-page="{{nextPage}}" data-action="item-list#onPageClick">
+                            <i class="fas fa-chevron-right"></i>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+            {{/if}}
+        </template>
+        {% endverbatim %}
+    </div>
 {% endblock %}

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -108,6 +108,120 @@
                 </div>
             </div>
 
+            <div class="card mb-4"
+                 data-controller="item-list"
+                 data-item-list-url-value="{{ path('app_item_index') }}"
+                 data-item-list-page-value="1"
+                 data-item-list-pages-value="1"
+                 data-item-list-profile-value="{{ profile.id }}">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    Items <span class="badge text-bg-secondary" data-item-list-target="totalBadge">{{ itemCount }}</span>
+                </div>
+                <div class="card-body">
+                    <div class="row mb-3 g-2">
+                        <div class="col">
+                            <input type="search" class="form-control form-control-sm"
+                                   placeholder="Suche in Items…"
+                                   data-item-list-target="searchInput"
+                                   data-action="input->item-list#onSearchInput">
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover table-striped table-sm">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Text</th>
+                                    <th>Datum</th>
+                                    <th>Status</th>
+                                    <th>Aktionen</th>
+                                </tr>
+                            </thead>
+                            <tbody data-item-list-target="tableBody">
+                                <tr><td colspan="5" class="text-center text-muted py-3"><i class="fas fa-spinner fa-spin me-1"></i>Lade…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div data-item-list-target="pagination"></div>
+                </div>
+
+                {% verbatim %}
+                <template data-item-list-target="itemRowTemplate">
+                    <tr id="item-row-{{id}}"
+                        class="{{#if deleted}}table-row-deleted{{else}}{{#if hidden}}table-row-hidden{{/if}}{{/if}}"
+                        data-controller="toggle"
+                        data-toggle-id-value="{{id}}"
+                        data-toggle-token-value="{{csrfToken}}">
+                        <td>{{id}}</td>
+                        <td>
+                            <a href="{{showUrl}}">{{truncate text 80}}</a>
+                        </td>
+                        <td>{{dateTime}}</td>
+                        <td>
+                            <button class="btn btn-sm {{#if hidden}}btn-warning{{else}}btn-outline-warning{{/if}}"
+                                    data-action="toggle#toggleHidden"
+                                    data-toggle-target="hiddenBtn"
+                                    title="Versteckt">
+                                <i class="fas fa-eye-slash"></i>
+                            </button>
+                            <button class="btn btn-sm {{#if deleted}}btn-danger{{else}}btn-outline-danger{{/if}}"
+                                    data-action="toggle#toggleDeleted"
+                                    data-toggle-target="deletedBtn"
+                                    title="Gelöscht">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <a href="{{showUrl}}" class="btn btn-outline-primary" title="Anzeigen">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                                <a href="{{editUrl}}" class="btn btn-outline-secondary" title="Bearbeiten">
+                                    <i class="fas fa-edit"></i>
+                                </a>
+                            </div>
+                        </td>
+                    </tr>
+                </template>
+
+                <template data-item-list-target="emptyTemplate">
+                    <tr><td colspan="5" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
+                </template>
+
+                <template data-item-list-target="paginationTemplate">
+                    {{#if (gt pages 1)}}
+                    <nav aria-label="Seitennavigation">
+                        <ul class="pagination pagination-sm justify-content-center">
+                            <li class="page-item {{#if prevDisabled}}disabled{{/if}}">
+                                <a class="page-link" href="#" data-page="{{prevPage}}" data-action="item-list#onPageClick">
+                                    <i class="fas fa-chevron-left"></i>
+                                </a>
+                            </li>
+                            {{#each pageNumbers}}
+                                {{#if this.ellipsis}}
+                                    <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                                {{else}}
+                                    <li class="page-item {{#if this.active}}active{{/if}}">
+                                        {{#if this.active}}
+                                            <span class="page-link">{{this.num}}</span>
+                                        {{else}}
+                                            <a class="page-link" href="#" data-page="{{this.num}}" data-action="item-list#onPageClick">{{this.num}}</a>
+                                        {{/if}}
+                                    </li>
+                                {{/if}}
+                            {{/each}}
+                            <li class="page-item {{#if nextDisabled}}disabled{{/if}}">
+                                <a class="page-link" href="#" data-page="{{nextPage}}" data-action="item-list#onPageClick">
+                                    <i class="fas fa-chevron-right"></i>
+                                </a>
+                            </li>
+                        </ul>
+                    </nav>
+                    {{/if}}
+                </template>
+                {% endverbatim %}
+            </div>
+
             {% if profile.additionalData %}
                 <div class="card mb-4">
                     <div class="card-header">Zusätzliche Daten</div>


### PR DESCRIPTION
## Summary

Adds full-text item search to the item index and profile detail pages, using a Stimulus controller plus Handlebars templates for client-side rendering. The backend gets `ItemRepository` filtered query methods that the AJAX endpoint exposes.

**PR 13 of 17**. Stacked on #32.

## Commits

- `70a2abd` Add filtered query methods to ItemRepository
- `0b99777` Add AJAX item search with Handlebars client-side rendering
- `6573139` Add search UI to item index and profile detail pages

## Test plan

- [x] `bin/phpunit` — 118 tests, 277 assertions, no errors/failures

## Stack

- Previous: #32 (`feat/web-auth`)
- Next: B15 (Dark sidebar redesign)