### PR TITLE
Add optional Profile title field, apache-pack, README/CLAUDE.md updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Symfony 8 application that fetches social media feeds from various networks (Mastodon, Bluesky, Instagram, Facebook, Threads, Homepage/RSS). Supports multi-tenancy: API clients authenticate via Bearer token and see only their linked profiles. Console commands for feed fetching, Web-UI for administration, REST API (API Platform) for client access.
 
+Can run in two modes:
+- **Upstream mode**: Fetches profiles from and pushes items to the criticalmass.in API
+- **Standalone mode**: Imports data from criticalmass.in into a local PostgreSQL database, served via Web-UI and REST API
+
 ## Commands
 
 ```bash
@@ -16,21 +20,23 @@ bin/phpunit tests/NetworkFeedFetcher/Bluesky/         # run test directory
 php bin/console feeds:fetch mastodon -c 50            # fetch feeds
 php bin/console feed:list instagram_profile           # list profiles
 php bin/console network:list                          # list registered fetchers
+php bin/console app:fetch-scheduled                   # run scheduled fetches (cron-based)
+php bin/console app:import-profiles                   # import profiles from criticalmass.in API
 php bin/console app:import-items -v                   # import items from criticalmass.in API
 php bin/console app:import-items --network=twitter    # import only one network
-php bin/console app:import-items --dry-run             # preview without writing
+php bin/console app:import-items --dry-run            # preview without writing
 
-php bin/console app:client:create <name>               # create API client, outputs token
-php bin/console app:client:list                         # list all clients
-php bin/console app:client:regenerate-token <name>      # regenerate token
-php bin/console app:client:disable <name>               # disable client
-php bin/console app:client:enable <name>                # enable client
+php bin/console app:client:create <name>              # create API client, outputs token
+php bin/console app:client:list                       # list all clients
+php bin/console app:client:regenerate-token <name>    # regenerate token
+php bin/console app:client:disable <name>             # disable client
+php bin/console app:client:enable <name>              # enable client
 
-php bin/console app:rssapp:sync-feed-ids                  # sync RSS.app feed IDs to DB
-php bin/console app:rssapp:sync-feed-ids --dry-run        # preview without writing
+php bin/console app:rssapp:sync-feed-ids              # sync RSS.app feed IDs to DB
+php bin/console app:rssapp:sync-feed-ids --dry-run    # preview without writing
 php bin/console app:rssapp:sync-feed-ids --network=instagram_profile  # only one network
-php bin/console app:rssapp:sync-feed-ids --force          # re-check profiles with existing feed IDs
-php bin/console app:rssapp:sync-feed-ids -v               # show all profiles including skipped
+php bin/console app:rssapp:sync-feed-ids --force      # re-check profiles with existing feed IDs
+php bin/console app:rssapp:sync-feed-ids -v           # show all profiles including skipped
 ```
 
 ## Architecture
@@ -59,6 +65,13 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 - `IdentifierParser.php` — extracts handle/username from URL-based identifiers stored in the DB
 - `EntryConverter.php` — converts API response to `SocialNetworkFeedItem`
 
+### Entities
+
+- **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
+- **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`. Supports soft-delete and hide toggles.
+- **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
+- **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
+
 ### Serializer
 
 Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `NullableDateTimeNormalizer` to handle null values and Unix timestamps from the API. CamelCase-to-snake_case name conversion. `SKIP_NULL_VALUES` on serialization.
@@ -74,6 +87,23 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - CLI commands and feed fetching run system-wide, no client context
 - Security: `ApiTokenAuthenticator` + `ClientTokenUserProvider`, stateless firewall for `/api/*`
 
+### Web UI
+
+- **Authentication**: Form login at `/login`, in-memory admin user via `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD_HASH` env vars, implemented in `WebUserProvider`
+- **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `LoginController`
+- **Frontend stack**: Bootstrap 5.3, Stimulus controllers, Handlebars templates, Symfony Asset Mapper (no build step)
+- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`
+- **CSS**: Custom design system in `assets/styles/app.css` (dark sidebar, stat cards, network cards, data tables)
+- **AJAX patterns**: Profile and item lists use Stimulus + Handlebars for client-side rendering with AJAX pagination, search, and filtering. Controllers return JSON when `X-Requested-With: XMLHttpRequest` header is present.
+
+### REST API (API Platform)
+
+- All endpoints under `/api/` require Bearer token (except `/api/docs`)
+- Profiles, items: client-scoped via custom State Providers/Processors
+- Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
+- Networks: public read access
+- OpenAPI docs at `/api/docs`
+
 ## Adding a New Network Fetcher
 
 1. Create directory `src/NetworkFeedFetcher/YourNetwork/`
@@ -82,6 +112,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 4. Create `IdentifierParser` (profiles in DB use URLs as identifiers)
 5. Create `EntryConverter` to map API data to `SocialNetworkFeedItem`
 6. Add tests in `tests/NetworkFeedFetcher/YourNetwork/`
+7. Register the network in the database (via Web UI at `/networks/new` or migration)
 
 No service registration needed — autoconfiguration handles it.
 
@@ -108,4 +139,12 @@ The app can run as a standalone instance that imports data from the criticalmass
 
 ## Environment Variables
 
-Key vars in `.env`: `CRITICALMASS_HOSTNAME` (API base URL), `RSS_APP_API_KEY`, `RSS_APP_API_SECRET`. The `$criticalmassHostname` binding in `services.yaml` injects into `ProfileFetcher`, `ImportProfilesCommand`, `ImportItemsCommand`, and `ProfilePersister`.
+Key vars in `.env`: `CRITICALMASS_HOSTNAME` (API base URL), `RSS_APP_API_KEY`, `RSS_APP_API_SECRET`, `WEB_ADMIN_USERNAME`, `WEB_ADMIN_PASSWORD_HASH`, `DATABASE_URL`. The `$criticalmassHostname` binding in `services.yaml` injects into `ProfileFetcher`, `ImportProfilesCommand`, `ImportItemsCommand`, and `ProfilePersister`.
+
+## Local Development
+
+```bash
+docker compose up -d                                 # start PostgreSQL
+symfony serve -d                                     # start web server
+php bin/console doctrine:migrations:migrate          # run migrations
+```

--- a/README.md
+++ b/README.md
@@ -1,30 +1,87 @@
 # SocialNetwork Fetcher
 
-Symfony 8 CLI application that fetches social media feeds from various networks and pushes them to the [criticalmass.in](https://criticalmass.in) API.
+Symfony 8 application that fetches social media feeds from various networks and aggregates them. Originally designed to push data to the [criticalmass.in](https://criticalmass.in) API, it also supports standalone mode with a local PostgreSQL database, a web-based admin UI, and a multi-tenant REST API for external clients.
 
 ## Requirements
 
 - PHP 8.5+
 - Composer
+- Docker & Docker Compose (for PostgreSQL)
 
 ## Installation
 
 ```bash
+git clone git@github.com:criticalmass-one/socialnetwork-fetcher.git
+cd socialnetwork-fetcher
 composer install
+```
+
+### Database setup
+
+Start PostgreSQL via Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+This starts a PostgreSQL 16 container with a persistent volume. The default credentials are configured in `compose.yaml` (`app` / `!ChangeMe!`).
+
+Create and migrate the database:
+
+```bash
+php bin/console doctrine:database:create
+php bin/console doctrine:migrations:migrate
+```
+
+### Configuration
+
+Copy the environment file and adjust it:
+
+```bash
 cp .env .env.local
 ```
 
-Edit `.env.local` with your credentials:
+Key environment variables:
 
-```env
-CRITICALMASS_HOSTNAME=https://criticalmass.in
-RSS_APP_API_KEY=your_key
-RSS_APP_API_SECRET=your_secret
+| Variable | Purpose | Default |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | see `compose.yaml` |
+| `CRITICALMASS_HOSTNAME` | criticalmass.in API hostname | `criticalmass.in` |
+| `RSS_APP_API_KEY` | RSS.app API key (for Instagram, Facebook, Threads) | — |
+| `RSS_APP_API_SECRET` | RSS.app API secret | — |
+| `WEB_ADMIN_USERNAME` | Web UI admin username | `admin` |
+| `WEB_ADMIN_PASSWORD_HASH` | Bcrypt hash for web login | `$2y$13$changeme` |
+
+Generate a password hash for the web admin:
+
+```bash
+php bin/console security:hash-password 'your-password'
 ```
 
-## Usage
+Then set `WEB_ADMIN_PASSWORD_HASH` in `.env.local` to the generated hash.
 
-### Fetch feeds
+### Start the dev server
+
+```bash
+symfony serve -d
+```
+
+The application is accessible at `https://127.0.0.1:8000`.
+
+## Supported Networks
+
+| Network | Identifier | API | Auth required |
+|---|---|---|---|
+| Mastodon | `mastodon` | Mastodon API v1 | No |
+| Bluesky | `bluesky` | AT Protocol (public) | No |
+| Homepage/RSS | `homepage` | Direct RSS/Atom feed | No |
+| Instagram | `instagram_profile` | via RSS.app | Yes (RSS.app) |
+| Facebook | `facebook_page` | via RSS.app | Yes (RSS.app) |
+| Threads | `threads_profile` | via RSS.app | Yes (RSS.app) |
+
+## Console Commands
+
+### Feed fetching
 
 ```bash
 # Fetch all networks
@@ -35,9 +92,12 @@ php bin/console feeds:fetch mastodon bluesky
 
 # Fetch with options
 php bin/console feeds:fetch instagram_profile --count=50 --citySlug=hamburg
+
+# Run scheduled fetches (based on cron expressions per network)
+php bin/console app:fetch-scheduled
 ```
 
-Options:
+Options for `feeds:fetch`:
 
 | Option | Short | Description |
 |---|---|---|
@@ -45,49 +105,103 @@ Options:
 | `--fromDateTime` | `-f` | Start date filter |
 | `--untilDateTime` | `-u` | End date filter |
 | `--includeOldItems` | `-i` | Include already fetched items |
-| `--citySlug` | | Filter by city |
+| `--citySlug` | | Filter by city slug |
 
-### List registered networks
-
-```bash
-php bin/console network:list
-```
-
-```
- ------------------- -------------------------------------------------------
-  Network             Fetcher
- ------------------- -------------------------------------------------------
-  bluesky             App\NetworkFeedFetcher\Bluesky\BlueskyFeedFetcher
-  facebook_page       App\NetworkFeedFetcher\Facebook\FacebookFeedFetcher
-  homepage            App\NetworkFeedFetcher\Homepage\HomepageFeedFetcher
-  instagram_profile   App\NetworkFeedFetcher\Instagram\InstagramFeedFetcher
-  mastodon            App\NetworkFeedFetcher\Mastodon\MastodonFeedFetcher
-  threads_profile     App\NetworkFeedFetcher\Threads\ThreadFeedFetcher
- ------------------- -------------------------------------------------------
-```
-
-### List feeds/profiles
+### Profile & network management
 
 ```bash
-# List all
-php bin/console feed:list
-
-# Filter by network
-php bin/console feed:list mastodon bluesky
+php bin/console network:list                          # list registered network fetchers
+php bin/console feed:list                             # list all profiles
+php bin/console feed:list mastodon bluesky            # list profiles by network
 ```
 
-## Supported Networks
+### Standalone mode (data import)
 
-| Network | Identifier | API | Auth required |
-|---|---|---|---|
-| Mastodon | `mastodon` | Mastodon API v1 | No |
-| Bluesky | `bluesky` | AT Protocol (public) | No |
-| Instagram | `instagram_profile` | via RSS.app | Yes (RSS.app) |
-| Facebook | `facebook_page` | via RSS.app | Yes (RSS.app) |
-| Threads | `threads_profile` | via RSS.app | Yes (RSS.app) |
-| Homepage/RSS | `homepage` | Direct RSS/Atom | No |
+Import data from the criticalmass.in API into the local database:
+
+```bash
+php bin/console app:import-profiles                   # import profile metadata
+php bin/console app:import-items -v                   # import feed items per profile
+php bin/console app:import-items --network=twitter    # import only one network
+php bin/console app:import-items --dry-run            # preview without writing
+```
+
+Import limits: max 5000 items per profile, batch size 200 for database writes.
+
+### API client management
+
+```bash
+php bin/console app:client:create <name>              # create client, outputs Bearer token
+php bin/console app:client:list                       # list all clients
+php bin/console app:client:regenerate-token <name>    # regenerate token
+php bin/console app:client:enable <name>              # enable client
+php bin/console app:client:disable <name>             # disable client
+```
+
+### RSS.app integration
+
+```bash
+php bin/console app:rssapp:sync-feed-ids              # sync RSS.app feed IDs to DB
+php bin/console app:rssapp:sync-feed-ids --dry-run    # preview
+php bin/console app:rssapp:sync-feed-ids --network=instagram_profile
+php bin/console app:rssapp:sync-feed-ids --force      # re-check existing feed IDs
+```
+
+## Web UI
+
+The admin interface is accessible after login at `/login`. It provides:
+
+- **Dashboard** — Overview with network statistics, profile/item counts, and a table of recent items
+- **Networks** — CRUD for social networks (name, icon, color, cron schedule)
+- **Profiles** — Searchable/filterable list with auto-fetch toggle, fetch status, manual fetch trigger, RSS.app registration
+- **Items** — Searchable/filterable list with hide/delete toggles, network and profile filters
+- **Clients** — API client management with token display, enable/disable
+
+The frontend uses Bootstrap 5, Stimulus controllers for interactive features (toggles, AJAX pagination, search), and Handlebars for client-side template rendering. Assets are managed via Symfony Asset Mapper (no build step needed).
+
+## REST API
+
+All API endpoints under `/api/` require Bearer token authentication:
+
+```
+Authorization: Bearer <token>
+```
+
+Tokens are generated via `app:client:create`.
+
+### Endpoints
+
+**Profiles** (client-scoped):
+- `GET /api/profiles` — List profiles linked to the authenticated client
+- `GET /api/profiles/{id}` — Get single profile
+- `POST /api/profiles` — Create or link an existing profile (idempotent)
+- `PUT /api/profiles/{id}` — Update profile
+- `DELETE /api/profiles/{id}` — Unlink from client; soft-deletes if no other clients remain
+
+**Items** (client-scoped):
+- `GET /api/items` — List feed items (paginated, 50 per page)
+- `GET /api/items/{id}` — Get single item
+- `POST /api/items` — Create item
+- `PUT /api/items/{id}` — Update item
+
+**Timeline**:
+- `GET /api/timeline` — Chronological feed (default: last 24h, max 100 items)
+  - Query params: `limit`, `since`, `until`, `network`
+
+**Networks** (public):
+- `GET /api/networks` — List all networks
+- `GET /api/networks/{id}` — Get single network
+
+**Documentation**:
+- `GET /api/docs` — Interactive OpenAPI documentation
+
+### Multi-tenancy
+
+Profiles are shared across clients via a join table. Each client sees only its linked profiles and their items. Creating a profile that already exists links it to the client (idempotent). Deleting a profile unlinks it; it is soft-deleted only when no clients reference it. Profiles and items are never physically deleted.
 
 ## Architecture
+
+### Feed fetching flow
 
 ```
 feeds:fetch command
@@ -105,32 +219,78 @@ FeedFetcher (orchestrator)
     +-- ProfilePersister ---------> criticalmass.in API (update metadata)
 ```
 
-Network fetchers are auto-discovered via Symfony's autoconfiguration. Any class implementing `NetworkFeedFetcherInterface` is automatically registered — no manual service configuration needed.
+### Service wiring
 
-### Adding a new network
+Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcherInterface` gets tagged via `Kernel::build()` and injected into `FeedFetcher` through the `SocialNetworkFetcherPass` compiler pass. No manual service registration needed.
 
-1. Create `src/NetworkFeedFetcher/YourNetwork/YourNetworkFeedFetcher.php` extending `AbstractNetworkFeedFetcher`
-2. Create `IdentifierParser.php` to extract handles from URL-based identifiers
-3. Create `EntryConverter.php` to map API responses to `SocialNetworkFeedItem`
-4. Add tests in `tests/NetworkFeedFetcher/YourNetwork/`
+### Network fetcher types
+
+- **Direct API fetchers**: `MastodonFeedFetcher`, `BlueskyFeedFetcher`, `HomepageFeedFetcher` — call the network's API directly
+- **RSS.app-based fetchers**: `FacebookFeedFetcher`, `InstagramFeedFetcher`, `ThreadFeedFetcher` — proxy through RSS.app's API
+
+### Each network fetcher directory contains
+
+```
+src/NetworkFeedFetcher/YourNetwork/
+    *FeedFetcher.php       — implements NetworkFeedFetcherInterface
+    IdentifierParser.php   — extracts handle/username from URL identifiers
+    EntryConverter.php     — converts API response to SocialNetworkFeedItem
+```
+
+### Entities
+
+| Entity | Purpose |
+|---|---|
+| `Profile` | Social network profile (URL identifier, optional title, network reference, fetch metadata) |
+| `Item` | Feed item (text, title, permalink, timestamps, hidden/deleted flags) |
+| `Network` | Social network definition (name, icon, colors, cron expression) |
+| `Client` | API client (name, Bearer token, enabled flag, linked profiles) |
+
+### Security
+
+- **Web UI** (`/`): Form-based login, `ROLE_ADMIN`, in-memory user via env vars
+- **API** (`/api/*`): Stateless Bearer token authentication, `ROLE_API_CLIENT`
+- **API docs** (`/api/docs`): Public access
+
+## Adding a New Network Fetcher
+
+1. Create directory `src/NetworkFeedFetcher/YourNetwork/`
+2. Create `YourNetworkFeedFetcher` extending `AbstractNetworkFeedFetcher`
+3. Override `getNetworkIdentifier()` if the class name doesn't follow the `{Network}FeedFetcher` pattern
+4. Create `IdentifierParser` to extract handles from URL-based identifiers
+5. Create `EntryConverter` to map API data to `SocialNetworkFeedItem`
+6. Add tests in `tests/NetworkFeedFetcher/YourNetwork/`
+7. Register the network in the database (via Web UI or migration)
+
+No service registration needed — autoconfiguration handles it.
 
 ## Testing
 
 ```bash
-# Run all tests
-bin/phpunit
-
-# Run a specific test file
-bin/phpunit tests/NetworkFeedFetcher/Bluesky/EntryConverterTest.php
-
-# Filter by test name
-bin/phpunit --filter testConvertValidEntry
+bin/phpunit                                          # run all tests
+bin/phpunit tests/NetworkFeedFetcher/Bluesky/        # run test directory
+bin/phpunit --filter testParseHandleFormat            # run single test
 ```
+
+## Tech Stack
+
+- **Framework**: Symfony 8.0
+- **PHP**: 8.5+
+- **Database**: PostgreSQL 16
+- **API**: API Platform 4.2
+- **Frontend**: Bootstrap 5.3, Stimulus 3.2, Handlebars 4.7
+- **Assets**: Symfony Asset Mapper (no build step)
+- **Testing**: PHPUnit 13
+- **API Docs**: NelmioApiDocBundle (OpenAPI/Swagger)
 
 ## Git Workflow
 
-- Every feature, fix, or refactoring gets its own branch — never commit directly to `main`.
-- Never squash commits. Keep individual commits as logical, reviewable work packages.
-- PRs must have appropriate labels and be assigned to the maintainer.
+- Never commit directly to `main`. Every feature, fix, or refactoring gets its own branch.
+- Never squash commits. Keep individual commits as logical, reviewable work packages so each step remains traceable.
+- PRs must have appropriate labels (e.g. `bug`, `enhancement`, `AI-generated`) and be assigned to `maltehuebner`.
 - PRs may only be merged after all tests have passed.
 - Delete remote branches after merging.
+
+## License
+
+Private repository. All rights reserved.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "halaxa/json-machine": "^1.2",
         "laminas/laminas-feed": "^2.12",
         "laminas/laminas-http": "^2.11",
-        "nelmio/api-doc-bundle": "^5.9",
         "symfony/apache-pack": "*",
         "symfony/asset": "^8.0",
         "symfony/asset-mapper": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79c1c2e6d31406b2499797b136559608",
+    "content-hash": "f882778bdc259b4adbdd3339c5126086",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2710,6 +2710,32 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/apache-pack",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/apache-pack.git",
+                "reference": "3aa5818d73ad2551281fc58a75afd9ca82622e6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/apache-pack/zipball/3aa5818d73ad2551281fc58a75afd9ca82622e6c",
+                "reference": "3aa5818d73ad2551281fc58a75afd9ca82622e6c",
+                "shasum": ""
+            },
+            "type": "symfony-pack",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A pack for Apache support in Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/apache-pack/issues",
+                "source": "https://github.com/symfony/apache-pack/tree/master"
+            },
+            "time": "2017-12-12T01:46:35+00:00"
         },
         {
             "name": "symfony/asset",

--- a/migrations/Version20260316140505.php
+++ b/migrations/Version20260316140505.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260316140505 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('COMMENT ON COLUMN client.created_at IS \'\'');
+        $this->addSql('ALTER TABLE profile ADD title VARCHAR(255) DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN profile.deleted_at IS \'\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('COMMENT ON COLUMN client.created_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE profile DROP title');
+        $this->addSql('COMMENT ON COLUMN profile.deleted_at IS \'(DC2Type:datetime_immutable)\'');
+    }
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,60 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an pointless hierarchical URL).
+# This avoids that the rewriting rules for the front controller are spread
+# across the whole .htaccess file.
+DirectoryIndex index.php
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symlinks or if you experience problems related to symlinks
+# when compiling assets.
+# Options FollowSymlinks
+
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
+# to the front controller "/index.php" but be rewritten to "/index.php/index".
+<IfModule mod_negotiation.c>
+    Options -MultiViews
+</IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Determine the RewriteBase automatically and set it as environment variable.
+    # If you are using Apache aliases to do mass virtual hosting or installed the
+    # project in a subdirectory, the base path will be prepended to allow proper
+    # resolution of the index.php file and to redirect to the correct URI. It will
+    # work in environments without path prefix as well, providing a safe, one-size
+    # fits-all solution. But as you do not need it in this case, you can comment
+    # the following 2 lines to eliminate the overhead.
+    RewriteCond %{REQUEST_URI}::$0 ^(/.+)/(.*)::\2$
+    RewriteRule .* - [E=BASE:%1]
+
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
+    RewriteCond %{HTTP:Authorization} .+
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%0]
+
+    # Redirect to URI without front controller to prevent duplicate content
+    # (with and without `/index.php`). Only do this redirect on the initial
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+    # pointless redirect to the same URI we are already at.
+    RewriteCond %{ENV:REDIRECT_STATUS} =""
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+
+    # If the requested filename exists, simply serve it.
+    # We only want to let Apache serve files and not directories.
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^ - [L]
+
+    # Rewrite all other queries to the front controller.
+    RewriteRule ^ %{ENV:BASE}/index.php [L]
+</IfModule>
+
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a simple catch-all redirect to
+        # the front controller. This requires the AllowOverride directive to be set to
+        # "FileInfo" in your Apache virtual host configuration.
+        RedirectMatch 307 ^/$ /index.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
+</IfModule>

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -86,6 +86,7 @@ class ItemController extends AbstractController
                 'profile' => $profile ? [
                     'id' => $profile->getId(),
                     'identifier' => $profile->getIdentifier(),
+                    'displayName' => $profile->getDisplayName(),
                     'showUrl' => $this->generateUrl('app_profile_show', ['id' => $profile->getId()]),
                     'network' => $network ? [
                         'name' => $network->getName(),

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -61,6 +61,11 @@ class Profile
     #[ApiProperty(description: 'Network-specific identifier, typically a URL. Example: "https://mastodon.social/@username" for Mastodon or "username.bsky.social" for Bluesky.')]
     private ?string $identifier = null;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Groups(['profile:read', 'profile:write'])]
+    #[ApiProperty(description: 'Human-readable display name for the profile. Falls back to identifier if not set.')]
+    private ?string $title = null;
+
     #[ORM\ManyToOne(targetEntity: Network::class)]
     #[ORM\JoinColumn(name: 'network_id', referencedColumnName: 'id', nullable: false)]
     #[Groups(['profile:read', 'profile:write'])]
@@ -143,6 +148,23 @@ class Profile
         $this->identifier = $identifier;
 
         return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDisplayName(): string
+    {
+        return $this->title ?? $this->identifier ?? '';
     }
 
     public function getNetwork(): ?Network

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -36,6 +36,11 @@ class ProfileType extends AbstractType
                 'label' => 'Identifier',
                 'help' => 'URL oder Benutzername im Netzwerk',
             ])
+            ->add('title', TextType::class, [
+                'label' => 'Titel',
+                'required' => false,
+                'help' => 'Anzeigename für dieses Profil (optional)',
+            ])
             ->add('autoFetch', CheckboxType::class, [
                 'label' => 'Auto-Fetch',
                 'required' => false,

--- a/symfony.lock
+++ b/symfony.lock
@@ -189,6 +189,15 @@
     "ralouphie/getallheaders": {
         "version": "3.0.3"
     },
+    "symfony/apache-pack": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5d454ec6cc4c700ed3d963f3803e1d427d9669fb"
+        }
+    },
     "symfony/asset-mapper": {
         "version": "8.0",
         "recipe": {

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -103,7 +103,7 @@
                                     <td>
                                         {% if item.profile %}
                                             <a href="{{ path('app_profile_show', {id: item.profile.id}) }}" class="link-subtle">
-                                                {{ item.profile.identifier|length > 30 ? item.profile.identifier[:30] ~ '…' : item.profile.identifier }}
+                                                {{ item.profile.displayName|length > 30 ? item.profile.displayName[:30] ~ '…' : item.profile.displayName }}
                                             </a>
                                         {% endif %}
                                     </td>

--- a/templates/item/index.html.twig
+++ b/templates/item/index.html.twig
@@ -26,7 +26,7 @@
                     <option value="">Alle Profile</option>
                     {% for p in profiles %}
                         <option value="{{ p.id }}" {% if selectedProfile == p.id %}selected{% endif %}>
-                            {{ p.network ? p.network.name ~ ': ' : '' }}{{ p.identifier }}
+                            {{ p.network ? p.network.name ~ ': ' : '' }}{{ p.displayName }}
                         </option>
                     {% endfor %}
                 </select>
@@ -143,7 +143,7 @@
                                         <td>
                                             {% if item.profile %}
                                                 <a href="{{ path('app_profile_show', {id: item.profile.id}) }}">
-                                                    {{ item.profile.identifier|length > 30 ? item.profile.identifier|slice(0, 30) ~ '...' : item.profile.identifier }}
+                                                    {{ item.profile.displayName|length > 30 ? item.profile.displayName|slice(0, 30) ~ '...' : item.profile.displayName }}
                                                 </a>
                                             {% endif %}
                                         </td>
@@ -207,7 +207,7 @@
                 </td>
                 <td>
                     {{#if profile}}
-                        <a href="{{profile.showUrl}}">{{truncate profile.identifier 30}}</a>
+                        <a href="{{profile.showUrl}}">{{truncate profile.displayName 30}}</a>
                     {{/if}}
                 </td>
                 <td>

--- a/templates/profile/_form.html.twig
+++ b/templates/profile/_form.html.twig
@@ -6,6 +6,7 @@
                 {{ form_row(form.id) }}
             {% endif %}
             {{ form_row(form.identifier) }}
+            {{ form_row(form.title) }}
             <div class="row">
                 <div class="col-md-6">
                     {{ form_row(form.autoFetch) }}

--- a/templates/profile/_partials/_profile_table_body.html.twig
+++ b/templates/profile/_partials/_profile_table_body.html.twig
@@ -10,7 +10,7 @@
         </td>
         <td>
             <a href="{{ path('app_profile_show', {id: profile.id}) }}">
-                {{ profile.identifier }}
+                {{ profile.displayName }}
             </a>
         </td>
         <td>

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -110,7 +110,7 @@
                     <tr>
                         <th>ID</th>
                         <th>Netzwerk</th>
-                        <th>Identifier</th>
+                        <th>Profil</th>
                         <th>Auto-Fetch</th>
                         <th>Quelltext</th>
                         <th>Letzter Fetch</th>

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -1,8 +1,8 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Profil {{ profile.identifier }} - Social Network Fetcher{% endblock %}
+{% block title %}Profil {{ profile.displayName }} - Social Network Fetcher{% endblock %}
 
-{% block page_title %}{{ profile.identifier }}{% endblock %}
+{% block page_title %}{{ profile.displayName }}{% endblock %}
 
 {% block topbar_actions %}
     <a href="{{ path('app_profile_edit', {id: profile.id}) }}" class="action-btn" title="Bearbeiten">
@@ -17,7 +17,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{{ path('app_profile_index') }}">Profiles</a></li>
-            <li class="breadcrumb-item active">{{ profile.identifier }}</li>
+            <li class="breadcrumb-item active">{{ profile.displayName }}</li>
         </ol>
     </nav>
 
@@ -44,6 +44,10 @@
                         <tr>
                             <th>Identifier</th>
                             <td>{{ profile.identifier }}</td>
+                        </tr>
+                        <tr>
+                            <th>Titel</th>
+                            <td>{{ profile.title ?? '-' }}</td>
                         </tr>
                         <tr>
                             <th>Auto-Fetch</th>


### PR DESCRIPTION
## Summary

Mixed cleanup PR:
- **`Profile.title`**: optional display name on profiles, falling back to identifier when not set. Includes migration and form field.
- **`symfony/apache-pack`**: adds `public/.htaccess` for Apache deployments.
- **README.md / CLAUDE.md updates**: comprehensive doc refresh covering the new commands and features.

**PR 15 of 17**. Stacked on #34.

## Commits

- `b03ff30` Add symfony/apache-pack with .htaccess
- `edefb30` Add optional title field to Profile entity
- `90e64e7` Update README.md and CLAUDE.md with comprehensive documentation

## Test plan

- [x] `bin/phpunit` — 118 tests, 277 assertions, no errors/failures (after `bin/console doctrine:schema:create --env=test` to add the new `title` column)

## Stack

- Previous: #34 (`feat/dark-sidebar`)
- Next: B17 (Media download system)