### PR TITLE
Add media download system: Flysystem, photo/video downloaders, command, button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@
 /public/assets/
 /assets/vendor/
 ###< symfony/asset-mapper ###
+
+/public/media/
+###> phpunit/phpunit ###
+/phpunit.xml
+/.phpunit.cache/
+###< phpunit/phpunit ###

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ php bin/console app:rssapp:sync-feed-ids --dry-run    # preview without writing
 php bin/console app:rssapp:sync-feed-ids --network=instagram_profile  # only one network
 php bin/console app:rssapp:sync-feed-ids --force      # re-check profiles with existing feed IDs
 php bin/console app:rssapp:sync-feed-ids -v           # show all profiles including skipped
+
+php bin/console app:download-media                    # download media for all enabled profiles
+php bin/console app:download-media --profile=42       # download for specific profile
+php bin/console app:download-media --retry-failed     # retry previously failed downloads
+php bin/console app:download-media --photos-only      # only photos
+php bin/console app:download-media --videos-only      # only videos
 ```
 
 ## Architecture
@@ -48,6 +54,7 @@ Command → FeedFetcher → ProfileFetcher (loads profiles from criticalmass.in 
                       → NetworkFeedFetcher.fetch() (per profile, network-specific)
                       → FeedItemPersister (pushes items to criticalmass.in API)
                       → ProfilePersister (updates profile metadata)
+                      → MediaDownloadService (downloads photos/videos if profile flags set)
 ```
 
 ### Service Wiring
@@ -67,10 +74,23 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 ### Entities
 
-- **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
-- **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`. Supports soft-delete and hide toggles.
+- **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `savePhotos`, `saveVideos`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
+- **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`. Supports soft-delete, hide toggles, and media downloads.
 - **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
 - **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
+
+### Media Download System
+
+Profiles can opt into automatic photo/video downloads via `savePhotos` and `saveVideos` flags. Media is stored via Flysystem (local adapter at `public/media/`).
+
+- **`MediaUrlExtractor`** — extracts photo URLs from `raw` JSON (RSS.app `thumbnail`, Bluesky `embed.images[]`, Mastodon `media_attachments[]`). Supports multiple photos per item. Video URL is the item's `permalink`.
+- **`PhotoDownloader`** — downloads images via HttpClient, stores as `{profileId}/{itemId}/photo_{index}.{ext}` in Flysystem
+- **`VideoDownloader`** — downloads videos via `yt-dlp` process, stores as `{profileId}/{itemId}/video.{ext}` on disk. Requires `yt-dlp` to be installed; gracefully skips if unavailable.
+- **`MediaDownloadService`** — orchestrates downloads, manages `mediaStatus` lifecycle (`downloading` → `completed`/`failed`)
+- **`DownloadMediaCommand`** — CLI for bulk downloads with `--profile`, `--retry-failed`, `--photos-only`, `--videos-only` options
+- Auto-download triggers after feed fetch when profile has `savePhotos`/`saveVideos` enabled
+- Manual download via button on item detail page (Stimulus `media_download_controller`)
+- Item entity stores `photoPaths` (JSON array of relative paths), `videoPath` (string), `mediaStatus`, `mediaError`
 
 ### Serializer
 
@@ -92,7 +112,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - **Authentication**: Form login at `/login`, in-memory admin user via `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD_HASH` env vars, implemented in `WebUserProvider`
 - **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `LoginController`
 - **Frontend stack**: Bootstrap 5.3, Stimulus controllers, Handlebars templates, Symfony Asset Mapper (no build step)
-- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`
+- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`, `media_download_controller`
 - **CSS**: Custom design system in `assets/styles/app.css` (dark sidebar, stat cards, network cards, data tables)
 - **AJAX patterns**: Profile and item lists use Stimulus + Handlebars for client-side rendering with AJAX pagination, search, and filtering. Controllers return JSON when `X-Requested-With: XMLHttpRequest` header is present.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Symfony 8 application that fetches social media feeds from various networks and 
 - PHP 8.5+
 - Composer
 - Docker & Docker Compose (for PostgreSQL)
+- yt-dlp (optional, for video downloads)
 
 ## Installation
 
@@ -147,14 +148,28 @@ php bin/console app:rssapp:sync-feed-ids --network=instagram_profile
 php bin/console app:rssapp:sync-feed-ids --force      # re-check existing feed IDs
 ```
 
+### Media download
+
+Download photos and videos for feed items. Photos are extracted from the raw API response (supports multiple photos per post for Bluesky and Mastodon). Videos are downloaded via `yt-dlp` from the item's permalink URL.
+
+```bash
+php bin/console app:download-media                    # all profiles with savePhotos/saveVideos enabled
+php bin/console app:download-media --profile=42       # specific profile
+php bin/console app:download-media --retry-failed     # retry previously failed downloads
+php bin/console app:download-media --photos-only      # only photos
+php bin/console app:download-media --videos-only      # only videos (requires yt-dlp)
+```
+
+Media files are stored in `public/media/{profileId}/{itemId}/`. Profiles must have `savePhotos` and/or `saveVideos` enabled (toggle in Web UI or API). When enabled, media is also downloaded automatically after each feed fetch.
+
 ## Web UI
 
 The admin interface is accessible after login at `/login`. It provides:
 
 - **Dashboard** — Overview with network statistics, profile/item counts, and a table of recent items
 - **Networks** — CRUD for social networks (name, icon, color, cron schedule)
-- **Profiles** — Searchable/filterable list with auto-fetch toggle, fetch status, manual fetch trigger, RSS.app registration
-- **Items** — Searchable/filterable list with hide/delete toggles, network and profile filters
+- **Profiles** — Searchable/filterable list with auto-fetch toggle, save photos/videos toggles, fetch status, manual fetch trigger, RSS.app registration
+- **Items** — Searchable/filterable list with hide/delete toggles, media status indicators, network and profile filters, manual media download
 - **Clients** — API client management with token display, enable/disable
 
 The frontend uses Bootstrap 5, Stimulus controllers for interactive features (toggles, AJAX pagination, search), and Handlebars for client-side template rendering. Assets are managed via Symfony Asset Mapper (no build step needed).
@@ -241,8 +256,8 @@ src/NetworkFeedFetcher/YourNetwork/
 
 | Entity | Purpose |
 |---|---|
-| `Profile` | Social network profile (URL identifier, optional title, network reference, fetch metadata) |
-| `Item` | Feed item (text, title, permalink, timestamps, hidden/deleted flags) |
+| `Profile` | Social network profile (URL identifier, optional title, network reference, fetch metadata, savePhotos/saveVideos flags) |
+| `Item` | Feed item (text, title, permalink, timestamps, hidden/deleted flags, photoPaths, videoPath, mediaStatus) |
 | `Network` | Social network definition (name, icon, colors, cron expression) |
 | `Client` | API client (name, Bearer token, enabled flag, linked profiles) |
 

--- a/assets/controllers/media_download_controller.js
+++ b/assets/controllers/media_download_controller.js
@@ -1,0 +1,128 @@
+import { Controller } from '@hotwired/stimulus';
+import { Modal } from 'bootstrap';
+
+export default class extends Controller {
+    static values = {
+        url: String,
+        token: String,
+    };
+
+    async download() {
+        const modal = document.getElementById('mediaDownloadModal');
+        const bsModal = Modal.getOrCreateInstance(modal);
+
+        const body = modal.querySelector('.modal-body');
+        body.innerHTML = this._renderLoading();
+        modal.querySelector('.modal-footer').classList.add('d-none');
+        bsModal.show();
+
+        const formData = new FormData();
+        formData.append('_token', this.tokenValue);
+
+        try {
+            const response = await window.fetch(this.urlValue, {
+                method: 'POST',
+                body: formData,
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                body.innerHTML = this._renderSuccess(data);
+                this._updateMediaDisplay(data);
+            } else {
+                body.innerHTML = this._renderError(data.error || 'Unbekannter Fehler');
+            }
+        } catch (error) {
+            body.innerHTML = this._renderError(error.message);
+        }
+
+        modal.querySelector('.modal-footer').classList.remove('d-none');
+    }
+
+    _renderLoading() {
+        return `
+            <div class="text-center py-4">
+                <div class="spinner-border text-primary mb-3" role="status">
+                    <span class="visually-hidden">Laden...</span>
+                </div>
+                <p class="mb-0 text-muted">Medien werden heruntergeladen…</p>
+            </div>
+        `;
+    }
+
+    _renderSuccess(data) {
+        let details = '';
+        const photoPaths = data.photoPaths || [];
+
+        if (photoPaths.length > 0) {
+            details += `<tr><th>Fotos</th><td><i class="fas fa-check text-success me-1"></i>${photoPaths.length} Foto(s) heruntergeladen</td></tr>`;
+        }
+
+        if (data.videoPath) {
+            details += `<tr><th>Video</th><td><i class="fas fa-check text-success me-1"></i>${this._escapeHtml(data.videoPath)}</td></tr>`;
+        }
+
+        if (photoPaths.length === 0 && !data.videoPath) {
+            details += `<tr><td colspan="2" class="text-muted">Keine Medien zum Herunterladen gefunden.</td></tr>`;
+        }
+
+        return `
+            <div class="py-2">
+                <div class="alert alert-success mb-3">
+                    <i class="fas fa-check-circle me-1"></i>Download abgeschlossen
+                </div>
+                <table class="table table-sm table-borderless mb-0">
+                    ${details}
+                </table>
+            </div>
+        `;
+    }
+
+    _renderError(message) {
+        return `
+            <div class="py-2">
+                <div class="alert alert-danger mb-0">
+                    <i class="fas fa-exclamation-triangle me-1"></i>${this._escapeHtml(message)}
+                </div>
+            </div>
+        `;
+    }
+
+    _updateMediaDisplay(data) {
+        const mediaCard = document.getElementById('media-card');
+        const photoPaths = data.photoPaths || [];
+
+        if (mediaCard && (photoPaths.length > 0 || data.videoPath)) {
+            let html = '';
+
+            if (photoPaths.length > 0) {
+                const colClass = photoPaths.length === 1 ? 'col-12' : 'col-6';
+                html += '<div class="row g-2 mb-3">';
+
+                photoPaths.forEach((path, i) => {
+                    html += `<div class="${colClass}"><img src="/media/${this._escapeHtml(path)}" class="img-fluid rounded" alt="Foto ${i + 1}"></div>`;
+                });
+
+                html += '</div>';
+            }
+
+            if (data.videoPath) {
+                html += `<div class="mb-3"><video src="/media/${this._escapeHtml(data.videoPath)}" controls class="w-100 rounded"></video></div>`;
+            }
+
+            const content = mediaCard.querySelector('.media-content');
+
+            if (content) {
+                content.innerHTML = html;
+            }
+        }
+    }
+
+    _escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
         "halaxa/json-machine": "^1.2",
         "laminas/laminas-feed": "^2.12",
         "laminas/laminas-http": "^2.11",
+        "league/flysystem-bundle": "^3.6",
+        "nelmio/api-doc-bundle": "^5.9",
         "symfony/apache-pack": "*",
         "symfony/asset": "^8.0",
         "symfony/asset-mapper": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f882778bdc259b4adbdd3339c5126086",
+    "content-hash": "1b98ff5325b94a6dddd6a68852a0deee",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2186,6 +2186,387 @@
                 }
             ],
             "time": "2026-02-16T08:59:56+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "3.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/254b1595b16b22dbddaaef9ed6ca9fdac4956725",
+                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem-local": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.295.10",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-mongodb": "^1.3|^2",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "guzzlehttp/psr7": "^2.6",
+                "microsoft/azure-storage-blob": "^1.1",
+                "mongodb/mongodb": "^1.2|^2",
+                "phpseclib/phpseclib": "^3.0.36",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "File storage abstraction for PHP",
+            "keywords": [
+                "WebDAV",
+                "aws",
+                "cloud",
+                "file",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/3.32.0"
+            },
+            "time": "2026-02-25T17:01:41+00:00"
+        },
+        {
+            "name": "league/flysystem-bundle",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-bundle.git",
+                "reference": "123ab96910177751faf3b6cc85eecc360ec12a1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-bundle/zipball/123ab96910177751faf3b6cc85eecc360ec12a1f",
+                "reference": "123ab96910177751faf3b6cc85eecc360ec12a1f",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^3.0",
+                "php": ">=8.2",
+                "symfony/config": "^6.0 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.0 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/http-kernel": "^6.0 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/mongodb-odm": "^2.0",
+                "league/flysystem-async-aws-s3": "^3.1",
+                "league/flysystem-aws-s3-v3": "^3.1",
+                "league/flysystem-azure-blob-storage": "^3.1",
+                "league/flysystem-ftp": "^3.1",
+                "league/flysystem-google-cloud-storage": "^3.1",
+                "league/flysystem-gridfs": "^3.28",
+                "league/flysystem-memory": "^3.1",
+                "league/flysystem-read-only": "^3.15",
+                "league/flysystem-sftp-v3": "^3.1",
+                "league/flysystem-webdav": "^3.29",
+                "platformcommunity/flysystem-bunnycdn": "^3.3",
+                "symfony/dotenv": "^6.0 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^6.0 || ^7.0 || ^8.0",
+                "symfony/phpunit-bridge": "^6.0 || ^7.0 || ^8.0",
+                "symfony/var-dumper": "^6.0 || ^7.0 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "League\\FlysystemBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                }
+            ],
+            "description": "Symfony bundle integrating Flysystem into Symfony applications",
+            "keywords": [
+                "Flysystem",
+                "bundle",
+                "filesystem",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem-bundle/issues",
+                "source": "https://github.com/thephpleague/flysystem-bundle/tree/3.6.2"
+            },
+            "time": "2026-02-05T15:26:57+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
+            },
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "nelmio/api-doc-bundle",
+            "version": "v5.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioApiDocBundle.git",
+                "reference": "7f69a498db473c71dcf7782d97601b601b54a640"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioApiDocBundle/zipball/7f69a498db473c71dcf7782d97601b601b54a640",
+                "reference": "7f69a498db473c71dcf7782d97601b601b54a640",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.0 || ^6.0",
+                "phpdocumentor/type-resolver": "^1.8.2 || ^2.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/config": "^6.4 || ^7.2 || ^8.0",
+                "symfony/console": "^6.4 || ^7.2 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.2 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/framework-bundle": "^6.4 || ^7.2 || ^8.0",
+                "symfony/http-foundation": "^6.4 || ^7.2 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.2 || ^8.0",
+                "symfony/options-resolver": "^6.4 || ^7.2 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.2 || ^8.0",
+                "symfony/routing": "^6.4 || ^7.2 || ^8.0",
+                "symfony/type-info": "^7.2 || ^8.0",
+                "zircote/swagger-php": "^4.11.1 || ^5.0"
+            },
+            "conflict": {
+                "symfony/property-info": "6.4.32 || 7.3.10 || 7.4.4 || 8.0.4",
+                "zircote/swagger-php": "4.8.7 || 5.5.0"
+            },
+            "require-dev": {
+                "api-platform/core": "^3.2 || ^4.0",
+                "doctrine/inflector": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.52",
+                "friendsofsymfony/rest-bundle": "^3.2.0",
+                "jms/serializer": "^3.32",
+                "jms/serializer-bundle": "^5.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "symfony/asset": "^6.4 || ^7.2 || ^8.0",
+                "symfony/browser-kit": "^6.4 || ^7.2 || ^8.0",
+                "symfony/cache": "^6.4 || ^7.2 || ^8.0",
+                "symfony/dom-crawler": "^6.4 || ^7.2 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.2 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.2 || ^8.0",
+                "symfony/form": "^6.4 || ^7.2 || ^8.0",
+                "symfony/phpunit-bridge": "^6.4 || ^7.2 || ^8.0",
+                "symfony/security-csrf": "^6.4 || ^7.2 || ^8.0",
+                "symfony/security-http": "^6.4 || ^7.2 || ^8.0",
+                "symfony/serializer": "^6.4 || ^7.2 || ^8.0",
+                "symfony/translation": "^6.4 || ^7.2 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.2 || ^8.0",
+                "symfony/uid": "^6.4 || ^7.2 || ^8.0",
+                "symfony/validator": "^6.4 || ^7.2 || ^8.0",
+                "willdurand/hateoas-bundle": "^2.7 || ^3.0",
+                "willdurand/negotiation": "^3.0"
+            },
+            "suggest": {
+                "api-platform/core": "For using an API oriented framework.",
+                "friendsofsymfony/rest-bundle": "For using the parameters annotations.",
+                "jms/serializer-bundle": "For describing your models.",
+                "symfony/asset": "For using the Swagger UI.",
+                "symfony/cache": "For using a PSR-6 compatible cache implementation with the API doc generator.",
+                "symfony/form": "For describing your form type models.",
+                "symfony/monolog-bundle": "For using a PSR-3 compatible logger implementation with the API PHP describer.",
+                "symfony/security-csrf": "For using csrf protection tokens in forms.",
+                "symfony/serializer": "For describing your models.",
+                "symfony/twig-bundle": "For using the Swagger UI.",
+                "symfony/validator": "For describing the validation constraints in your models.",
+                "willdurand/hateoas-bundle": "For extracting HATEOAS metadata."
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\ApiDocBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioApiDocBundle/contributors"
+                }
+            ],
+            "description": "Generates documentation for your REST API from attributes",
+            "keywords": [
+                "api",
+                "doc",
+                "documentation",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/nelmio/NelmioApiDocBundle/issues",
+                "source": "https://github.com/nelmio/NelmioApiDocBundle/tree/v5.9.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DjordyKoert",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-04T15:36:43+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -12,4 +12,5 @@ return [
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
     DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
+    League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
 ];

--- a/config/packages/flysystem.yaml
+++ b/config/packages/flysystem.yaml
@@ -1,0 +1,6 @@
+flysystem:
+    storages:
+        default.storage:
+            adapter: 'local'
+            options:
+                directory: '%kernel.project_dir%/public/media'

--- a/config/reference.php
+++ b/config/reference.php
@@ -1555,6 +1555,22 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     enable_static_query_cache?: bool|Param, // Default: true
  *     connection_keys?: list<mixed>,
  * }
+ * @psalm-type FlysystemConfig = array{
+ *     storages?: array<string, array{ // Default: []
+ *         adapter: scalar|Param|null,
+ *         options?: list<mixed>,
+ *         visibility?: scalar|Param|null, // Default: null
+ *         directory_visibility?: scalar|Param|null, // Default: null
+ *         retain_visibility?: bool|Param|null, // Default: null
+ *         case_sensitive?: bool|Param, // Default: true
+ *         disable_asserts?: bool|Param, // Default: false
+ *         public_url?: list<scalar|Param|null>,
+ *         path_normalizer?: scalar|Param|null, // Default: null
+ *         public_url_generator?: scalar|Param|null, // Default: null
+ *         temporary_url_generator?: scalar|Param|null, // Default: null
+ *         read_only?: bool|Param, // Default: false
+ *     }>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1567,6 +1583,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     stimulus?: StimulusConfig,
  *     security?: SecurityConfig,
  *     nelmio_api_doc?: NelmioApiDocConfig,
+ *     flysystem?: FlysystemConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1580,6 +1597,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         web_profiler?: WebProfilerConfig,
  *         security?: SecurityConfig,
  *         nelmio_api_doc?: NelmioApiDocConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1593,6 +1611,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         stimulus?: StimulusConfig,
  *         security?: SecurityConfig,
  *         nelmio_api_doc?: NelmioApiDocConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1608,6 +1627,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         security?: SecurityConfig,
  *         nelmio_api_doc?: NelmioApiDocConfig,
  *         dama_doctrine_test?: DamaDoctrineTestConfig,
+ *         flysystem?: FlysystemConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,7 @@ services:
             $rssAppApiSecret: '%env(RSS_APP_API_SECRET)%'
             $webAdminUsername: '%env(WEB_ADMIN_USERNAME)%'
             $webAdminPasswordHash: '%env(WEB_ADMIN_PASSWORD_HASH)%'
+            $mediaDirectory: '%kernel.project_dir%/public/media'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/migrations/Version20260316152552.php
+++ b/migrations/Version20260316152552.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260316152552 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE item ADD photo_paths JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE item ADD video_path VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE item ADD media_status VARCHAR(20) DEFAULT NULL');
+        $this->addSql('ALTER TABLE item ADD media_error TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE profile ADD save_photos BOOLEAN DEFAULT false NOT NULL');
+        $this->addSql('ALTER TABLE profile ADD save_videos BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE item DROP photo_paths');
+        $this->addSql('ALTER TABLE item DROP video_path');
+        $this->addSql('ALTER TABLE item DROP media_status');
+        $this->addSql('ALTER TABLE item DROP media_error');
+        $this->addSql('ALTER TABLE profile DROP save_photos');
+        $this->addSql('ALTER TABLE profile DROP save_videos');
+    }
+}

--- a/src/Command/DownloadMediaCommand.php
+++ b/src/Command/DownloadMediaCommand.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\Item;
+use App\MediaDownloader\MediaDownloadService;
+use App\Repository\ItemRepository;
+use App\Repository\ProfileRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DownloadMediaCommand extends Command
+{
+    public function __construct(
+        private readonly MediaDownloadService $mediaDownloadService,
+        private readonly ProfileRepository $profileRepository,
+        private readonly ItemRepository $itemRepository,
+    ) {
+        parent::__construct(null);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:download-media')
+            ->setDescription('Download media (photos/videos) for feed items')
+            ->addOption('profile', null, InputOption::VALUE_REQUIRED, 'Download media for a specific profile ID')
+            ->addOption('retry-failed', null, InputOption::VALUE_NONE, 'Retry previously failed downloads')
+            ->addOption('photos-only', null, InputOption::VALUE_NONE, 'Download only photos')
+            ->addOption('videos-only', null, InputOption::VALUE_NONE, 'Download only videos')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $profileId = $input->getOption('profile');
+        $retryFailed = $input->getOption('retry-failed');
+        $photosOnly = $input->getOption('photos-only');
+        $videosOnly = $input->getOption('videos-only');
+
+        $downloadPhotos = !$videosOnly;
+        $downloadVideos = !$photosOnly;
+
+        if ($profileId) {
+            $profile = $this->profileRepository->find((int) $profileId);
+
+            if (!$profile) {
+                $io->error(sprintf('Profile with ID %d not found.', $profileId));
+
+                return Command::FAILURE;
+            }
+
+            $profiles = [$profile];
+        } else {
+            $profiles = $this->profileRepository->findBy(['deleted' => false]);
+
+            // Filter to profiles that have savePhotos or saveVideos enabled
+            $profiles = array_filter($profiles, fn ($p) => $p->isSavePhotos() || $p->isSaveVideos());
+        }
+
+        if (empty($profiles)) {
+            $io->info('No profiles with media download enabled found.');
+
+            return Command::SUCCESS;
+        }
+
+        $totalItems = 0;
+
+        foreach ($profiles as $profile) {
+            $io->section(sprintf('Profile #%d: %s', $profile->getId(), $profile->getDisplayName()));
+
+            $criteria = ['profile' => $profile];
+
+            if ($retryFailed) {
+                $criteria['mediaStatus'] = 'failed';
+            } else {
+                $criteria['mediaStatus'] = null;
+            }
+
+            $items = $this->itemRepository->findBy($criteria);
+
+            if (empty($items)) {
+                $io->text('No items to process.');
+
+                continue;
+            }
+
+            $io->text(sprintf('Processing %d items...', count($items)));
+            $io->progressStart(count($items));
+
+            $photo = $profileId ? $downloadPhotos : ($profile->isSavePhotos() && $downloadPhotos);
+            $video = $profileId ? $downloadVideos : ($profile->isSaveVideos() && $downloadVideos);
+
+            foreach ($items as $item) {
+                $this->mediaDownloadService->downloadMedia($item, $photo, $video);
+                $io->progressAdvance();
+                $totalItems++;
+            }
+
+            $io->progressFinish();
+        }
+
+        $io->success(sprintf('Processed %d items across %d profiles.', $totalItems, count($profiles)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -43,7 +43,7 @@ class ItemController extends AbstractController
 
         if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
             return new JsonResponse([
-                'items' => $this->serializeItems($items),
+                'items' => $this->serializeItems($items, $csrfTokenManager),
                 'csrfToken' => $csrfTokenManager->getToken('toggle-item')->getValue(),
                 'page' => $page,
                 'pages' => $pages,
@@ -69,9 +69,9 @@ class ItemController extends AbstractController
      * @param list<Item> $items
      * @return list<array<string, mixed>>
      */
-    private function serializeItems(array $items): array
+    private function serializeItems(array $items, CsrfTokenManagerInterface $csrfTokenManager): array
     {
-        return array_map(function (Item $item): array {
+        return array_map(function (Item $item) use ($csrfTokenManager): array {
             $profile = $item->getProfile();
             $network = $profile?->getNetwork();
 
@@ -88,6 +88,8 @@ class ItemController extends AbstractController
                 'mediaStatus' => $item->getMediaStatus(),
                 'showUrl' => $this->generateUrl('app_item_show', ['id' => $item->getId()]),
                 'editUrl' => $this->generateUrl('app_item_edit', ['id' => $item->getId()]),
+                'downloadMediaUrl' => $this->generateUrl('app_item_download_media', ['id' => $item->getId()]),
+                'downloadMediaToken' => $csrfTokenManager->getToken('download-media-' . $item->getId())->getValue(),
                 'profile' => $profile ? [
                     'id' => $profile->getId(),
                     'identifier' => $profile->getIdentifier(),

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Item;
 use App\Form\ItemType;
+use App\MediaDownloader\MediaDownloadService;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
@@ -81,6 +82,10 @@ class ItemController extends AbstractController
                 'dateTime' => $item->getDateTime()?->format('d.m.Y H:i'),
                 'hidden' => $item->isHidden(),
                 'deleted' => $item->isDeleted(),
+                'hasPhoto' => $item->hasPhoto(),
+                'hasVideo' => $item->hasVideo(),
+                'photoCount' => $item->getPhotoCount(),
+                'mediaStatus' => $item->getMediaStatus(),
                 'showUrl' => $this->generateUrl('app_item_show', ['id' => $item->getId()]),
                 'editUrl' => $this->generateUrl('app_item_edit', ['id' => $item->getId()]),
                 'profile' => $profile ? [
@@ -155,5 +160,30 @@ class ItemController extends AbstractController
         return new JsonResponse([
             'deleted' => $item->isDeleted(),
         ]);
+    }
+
+    #[Route('/{id}/download-media', name: 'app_item_download_media', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function downloadMedia(Request $request, Item $item, MediaDownloadService $mediaDownloadService): JsonResponse
+    {
+        if (!$this->isCsrfTokenValid('download-media-' . $item->getId(), $request->request->getString('_token'))) {
+            return new JsonResponse(['error' => 'Invalid CSRF token'], Response::HTTP_FORBIDDEN);
+        }
+
+        try {
+            $mediaDownloadService->downloadMedia($item);
+
+            return new JsonResponse([
+                'success' => true,
+                'photoPaths' => $item->getPhotoPaths(),
+                'videoPath' => $item->getVideoPath(),
+                'mediaStatus' => $item->getMediaStatus(),
+            ]);
+        } catch (\Exception $e) {
+            return new JsonResponse([
+                'success' => false,
+                'error' => $e->getMessage(),
+                'mediaStatus' => $item->getMediaStatus(),
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -172,7 +172,7 @@ class ProfileController extends AbstractController
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
     }
 
-    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource'], methods: ['POST'])]
+    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource|savePhotos|saveVideos'], methods: ['POST'])]
     public function toggle(Request $request, Profile $profile, string $field, EntityManagerInterface $em): JsonResponse
     {
         if (!$this->isCsrfTokenValid('toggle-profile-' . $profile->getId(), $request->request->getString('_token'))) {
@@ -183,6 +183,8 @@ class ProfileController extends AbstractController
         $getter = match ($field) {
             'autoFetch' => 'isAutoFetch',
             'fetchSource' => 'isFetchSource',
+            'savePhotos' => 'isSavePhotos',
+            'saveVideos' => 'isSaveVideos',
         };
 
         $newValue = !$profile->$getter();

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -132,6 +132,26 @@ class Item
     #[ApiProperty(description: 'Parsed/processed version of the source content.')]
     private ?string $parsedSource = null;
 
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Relative paths to downloaded photo files.', readable: true, writable: false)]
+    private ?array $photoPaths = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Relative path to the downloaded video file.', readable: true, writable: false)]
+    private ?string $videoPath = null;
+
+    #[ORM\Column(type: 'string', length: 20, nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Media download status: null, pending, downloading, completed, failed.', readable: true, writable: false)]
+    private ?string $mediaStatus = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Error message from a failed media download attempt.', readable: true, writable: false)]
+    private ?string $mediaError = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -284,5 +304,82 @@ class Item
         $this->source = $source;
 
         return $this;
+    }
+
+    public function getPhotoPaths(): array
+    {
+        return $this->photoPaths ?? [];
+    }
+
+    public function setPhotoPaths(?array $photoPaths): self
+    {
+        $this->photoPaths = $photoPaths;
+
+        return $this;
+    }
+
+    public function addPhotoPath(string $path): self
+    {
+        $paths = $this->getPhotoPaths();
+        $paths[] = $path;
+        $this->photoPaths = $paths;
+
+        return $this;
+    }
+
+    public function getVideoPath(): ?string
+    {
+        return $this->videoPath;
+    }
+
+    public function setVideoPath(?string $videoPath): self
+    {
+        $this->videoPath = $videoPath;
+
+        return $this;
+    }
+
+    public function getMediaStatus(): ?string
+    {
+        return $this->mediaStatus;
+    }
+
+    public function setMediaStatus(?string $mediaStatus): self
+    {
+        $this->mediaStatus = $mediaStatus;
+
+        return $this;
+    }
+
+    public function getMediaError(): ?string
+    {
+        return $this->mediaError;
+    }
+
+    public function setMediaError(?string $mediaError): self
+    {
+        $this->mediaError = $mediaError;
+
+        return $this;
+    }
+
+    public function hasPhoto(): bool
+    {
+        return !empty($this->photoPaths);
+    }
+
+    public function getPhotoCount(): int
+    {
+        return count($this->getPhotoPaths());
+    }
+
+    public function hasVideo(): bool
+    {
+        return $this->videoPath !== null;
+    }
+
+    public function hasMedia(): bool
+    {
+        return $this->hasPhoto() || $this->hasVideo();
     }
 }

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -108,6 +108,16 @@ class Profile
     private ?string $additionalData = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['profile:read', 'profile:write'])]
+    #[ApiProperty(description: 'Whether to automatically download photos for new feed items.')]
+    private bool $savePhotos = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['profile:read', 'profile:write'])]
+    #[ApiProperty(description: 'Whether to automatically download videos for new feed items.')]
+    private bool $saveVideos = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
     #[Groups(['profile:read'])]
     #[ApiProperty(description: 'Whether this profile has been soft-deleted. Soft-deleted profiles are excluded from collection responses.', readable: true, writable: false)]
     private bool $deleted = false;
@@ -259,6 +269,30 @@ class Profile
     public function setAdditionalData(?array $additionalData): self
     {
         $this->additionalData = $additionalData !== null ? json_encode($additionalData) : null;
+
+        return $this;
+    }
+
+    public function isSavePhotos(): bool
+    {
+        return $this->savePhotos;
+    }
+
+    public function setSavePhotos(bool $savePhotos): self
+    {
+        $this->savePhotos = $savePhotos;
+
+        return $this;
+    }
+
+    public function isSaveVideos(): bool
+    {
+        return $this->saveVideos;
+    }
+
+    public function setSaveVideos(bool $saveVideos): self
+    {
+        $this->saveVideos = $saveVideos;
 
         return $this;
     }

--- a/src/FeedFetcher/FeedFetcher.php
+++ b/src/FeedFetcher/FeedFetcher.php
@@ -2,11 +2,32 @@
 
 namespace App\FeedFetcher;
 
+use App\FeedItemPersister\FeedItemPersisterInterface;
+use App\MediaDownloader\MediaDownloadService;
 use App\NetworkFeedFetcher\NetworkFeedFetcherInterface;
 use App\Model\Profile;
+use App\ProfileFetcher\ProfileFetcherInterface;
+use App\ProfilePersister\ProfilePersisterInterface;
+use App\Repository\ProfileRepository;
+use App\SourceFetcher\SourceFetcher;
 
 class FeedFetcher extends AbstractFeedFetcher
 {
+    private MediaDownloadService $mediaDownloadService;
+    private ProfileRepository $profileRepository;
+
+    public function __construct(
+        FeedItemPersisterInterface $feedItemPersister,
+        ProfileFetcherInterface $profileFetcher,
+        ProfilePersisterInterface $profilePersister,
+        SourceFetcher $sourceFetcher,
+        MediaDownloadService $mediaDownloadService,
+        ProfileRepository $profileRepository,
+    ) {
+        parent::__construct($feedItemPersister, $profileFetcher, $profilePersister, $sourceFetcher);
+        $this->mediaDownloadService = $mediaDownloadService;
+        $this->profileRepository = $profileRepository;
+    }
     protected function getFeedFetcherForProfile(Profile $profile): ?NetworkFeedFetcherInterface
     {
         /** @var NetworkFeedFetcherInterface $fetcher */
@@ -43,6 +64,13 @@ class FeedFetcher extends AbstractFeedFetcher
                     ->setCounterFetched(count($feedItemList));
 
                 $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+
+                // Download media if profile has savePhotos or saveVideos enabled
+                $entityProfile = $this->profileRepository->find($profile->getId());
+
+                if ($entityProfile && ($entityProfile->isSavePhotos() || $entityProfile->isSaveVideos())) {
+                    $this->mediaDownloadService->downloadNewItemsForProfile($entityProfile);
+                }
 
                 $callback($fetchResult);
             }

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -49,6 +49,14 @@ class ProfileType extends AbstractType
                 'label' => 'Quelltext laden',
                 'required' => false,
             ])
+            ->add('savePhotos', CheckboxType::class, [
+                'label' => 'Fotos speichern',
+                'required' => false,
+            ])
+            ->add('saveVideos', CheckboxType::class, [
+                'label' => 'Videos speichern',
+                'required' => false,
+            ])
             ->add('additionalData', TextareaType::class, [
                 'label' => 'Zusätzliche Daten (JSON)',
                 'required' => false,

--- a/src/MediaDownloader/MediaDownloadService.php
+++ b/src/MediaDownloader/MediaDownloadService.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\MediaDownloader;
+
+use App\Entity\Item;
+use App\Entity\Profile;
+use App\Repository\ItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class MediaDownloadService
+{
+    public function __construct(
+        private readonly MediaUrlExtractor $mediaUrlExtractor,
+        private readonly PhotoDownloader $photoDownloader,
+        private readonly VideoDownloader $videoDownloader,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ItemRepository $itemRepository,
+    ) {
+    }
+
+    public function downloadMedia(Item $item, bool $photo = true, bool $video = true): void
+    {
+        $profile = $item->getProfile();
+
+        if (!$profile) {
+            return;
+        }
+
+        $item->setMediaStatus('downloading');
+        $item->setMediaError(null);
+        $this->entityManager->flush();
+
+        $errors = [];
+
+        if ($photo) {
+            try {
+                $photoUrls = $this->mediaUrlExtractor->extractPhotoUrls($item);
+
+                if (!empty($photoUrls)) {
+                    $paths = [];
+
+                    foreach ($photoUrls as $index => $url) {
+                        $paths[] = $this->photoDownloader->download($url, $profile->getId(), $item->getId(), $index);
+                    }
+
+                    $item->setPhotoPaths($paths);
+                }
+            } catch (\Exception $e) {
+                $errors[] = 'Photo: ' . $e->getMessage();
+            }
+        }
+
+        if ($video) {
+            try {
+                $videoUrl = $this->mediaUrlExtractor->extractVideoUrl($item);
+
+                if ($videoUrl && $this->videoDownloader->isAvailable()) {
+                    $path = $this->videoDownloader->download($videoUrl, $profile->getId(), $item->getId());
+                    $item->setVideoPath($path);
+                }
+            } catch (\Exception $e) {
+                $errors[] = 'Video: ' . $e->getMessage();
+            }
+        }
+
+        if (!empty($errors)) {
+            $item->setMediaStatus('failed');
+            $item->setMediaError(implode("\n", $errors));
+        } else {
+            $item->setMediaStatus('completed');
+        }
+
+        $this->entityManager->flush();
+    }
+
+    public function downloadNewItemsForProfile(Profile $profile): void
+    {
+        $items = $this->itemRepository->findBy([
+            'profile' => $profile,
+            'mediaStatus' => null,
+        ]);
+
+        foreach ($items as $item) {
+            $this->downloadMedia($item, $profile->isSavePhotos(), $profile->isSaveVideos());
+        }
+    }
+}

--- a/src/MediaDownloader/MediaUrlExtractor.php
+++ b/src/MediaDownloader/MediaUrlExtractor.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace App\MediaDownloader;
+
+use App\Entity\Item;
+
+class MediaUrlExtractor
+{
+    /**
+     * @return list<string>
+     */
+    public function extractPhotoUrls(Item $item): array
+    {
+        $raw = $item->getRaw();
+
+        if ($raw === null) {
+            return [];
+        }
+
+        $data = json_decode($raw, true);
+
+        if (!is_array($data)) {
+            return [];
+        }
+
+        // RSS.app format: single thumbnail field
+        if (isset($data['thumbnail']) && is_string($data['thumbnail']) && $data['thumbnail'] !== '') {
+            return [$data['thumbnail']];
+        }
+
+        // Bluesky format: embed.images array
+        if (isset($data['embed']['images']) && is_array($data['embed']['images'])) {
+            $urls = [];
+
+            foreach ($data['embed']['images'] as $image) {
+                if (isset($image['fullsize'])) {
+                    $urls[] = $image['fullsize'];
+                } elseif (isset($image['thumb'])) {
+                    $urls[] = $image['thumb'];
+                }
+            }
+
+            if (!empty($urls)) {
+                return $urls;
+            }
+        }
+
+        // Mastodon format: media_attachments array
+        if (isset($data['media_attachments']) && is_array($data['media_attachments'])) {
+            $urls = [];
+
+            foreach ($data['media_attachments'] as $attachment) {
+                if (isset($attachment['type']) && $attachment['type'] === 'image' && isset($attachment['url'])) {
+                    $urls[] = $attachment['url'];
+                }
+            }
+
+            if (!empty($urls)) {
+                return $urls;
+            }
+        }
+
+        return [];
+    }
+
+    public function extractVideoUrl(Item $item): ?string
+    {
+        return $item->getPermalink();
+    }
+}

--- a/src/MediaDownloader/PhotoDownloader.php
+++ b/src/MediaDownloader/PhotoDownloader.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\MediaDownloader;
+
+use League\Flysystem\FilesystemOperator;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class PhotoDownloader
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly FilesystemOperator $defaultStorage,
+    ) {
+    }
+
+    public function download(string $url, int $profileId, int $itemId, int $index = 0): string
+    {
+        $response = $this->httpClient->request('GET', $url);
+        $contentType = $response->getHeaders()['content-type'][0] ?? '';
+        $content = $response->getContent();
+
+        $extension = $this->resolveExtension($contentType, $url);
+        $path = sprintf('%d/%d/photo_%d.%s', $profileId, $itemId, $index, $extension);
+
+        $this->defaultStorage->write($path, $content);
+
+        return $path;
+    }
+
+    private function resolveExtension(string $contentType, string $url): string
+    {
+        $map = [
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            'image/avif' => 'avif',
+        ];
+
+        foreach ($map as $mime => $ext) {
+            if (str_contains($contentType, $mime)) {
+                return $ext;
+            }
+        }
+
+        // Try from URL
+        $urlPath = parse_url($url, PHP_URL_PATH);
+
+        if ($urlPath) {
+            $ext = strtolower(pathinfo($urlPath, PATHINFO_EXTENSION));
+
+            if (in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif'], true)) {
+                return $ext === 'jpeg' ? 'jpg' : $ext;
+            }
+        }
+
+        return 'jpg';
+    }
+}

--- a/src/MediaDownloader/VideoDownloader.php
+++ b/src/MediaDownloader/VideoDownloader.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\MediaDownloader;
+
+use Symfony\Component\Process\Process;
+
+class VideoDownloader
+{
+    public function __construct(
+        private readonly string $mediaDirectory,
+    ) {
+    }
+
+    public function download(string $url, int $profileId, int $itemId): string
+    {
+        $outputDir = sprintf('%s/%d/%d', $this->mediaDirectory, $profileId, $itemId);
+
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $outputTemplate = sprintf('%s/video.%%(ext)s', $outputDir);
+
+        $process = new Process([
+            'yt-dlp',
+            '--no-playlist',
+            '--max-filesize', '100M',
+            '-o', $outputTemplate,
+            $url,
+        ]);
+
+        $process->setTimeout(300);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf('yt-dlp failed: %s', $process->getErrorOutput() ?: $process->getOutput()));
+        }
+
+        // Find the output file
+        $files = glob(sprintf('%s/video.*', $outputDir));
+
+        if (empty($files)) {
+            throw new \RuntimeException('yt-dlp produced no output file');
+        }
+
+        // Return relative path
+        $absolutePath = $files[0];
+
+        return ltrim(str_replace($this->mediaDirectory, '', $absolutePath), '/');
+    }
+
+    public function isAvailable(): bool
+    {
+        $process = new Process(['yt-dlp', '--version']);
+        $process->setTimeout(5);
+
+        try {
+            $process->run();
+
+            return $process->isSuccessful();
+        } catch (\Exception) {
+            return false;
+        }
+    }
+}

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -13,6 +13,8 @@ class Profile
     protected ?string $lastFetchFailureError = null;
     protected bool $autoFetch = true;
     protected bool $fetchSource = false;
+    protected bool $savePhotos = false;
+    protected bool $saveVideos = false;
     protected ?string $additionalData = null;
 
     public function getId(): ?int
@@ -126,6 +128,30 @@ class Profile
     public function setFetchSource(bool $fetchSource): self
     {
         $this->fetchSource = $fetchSource;
+
+        return $this;
+    }
+
+    public function isSavePhotos(): bool
+    {
+        return $this->savePhotos;
+    }
+
+    public function setSavePhotos(bool $savePhotos): self
+    {
+        $this->savePhotos = $savePhotos;
+
+        return $this;
+    }
+
+    public function isSaveVideos(): bool
+    {
+        return $this->saveVideos;
+    }
+
+    public function setSaveVideos(bool $saveVideos): self
+    {
+        $this->saveVideos = $saveVideos;
 
         return $this;
     }

--- a/src/ProfileFetcher/DoctrineProfileFetcher.php
+++ b/src/ProfileFetcher/DoctrineProfileFetcher.php
@@ -69,6 +69,8 @@ class DoctrineProfileFetcher implements ProfileFetcherInterface
 
         $model->setLastFetchFailureError($entity->getLastFetchFailureError());
         $model->setFetchSource($entity->isFetchSource());
+        $model->setSavePhotos($entity->isSavePhotos());
+        $model->setSaveVideos($entity->isSaveVideos());
 
         $additionalData = $entity->getAdditionalData();
         if ($additionalData) {

--- a/symfony.lock
+++ b/symfony.lock
@@ -126,6 +126,19 @@
     "jublonet/codebird-php": {
         "version": "3.1.0"
     },
+    "league/flysystem-bundle": {
+        "version": "3.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "913dc3d7a5a1af0d2b044c5ac3a16e2f851d7380"
+        },
+        "files": [
+            "config/packages/flysystem.yaml",
+            "var/storage/.gitignore"
+        ]
+    },
     "mashape/unirest-php": {
         "version": "v3.0.4"
     },

--- a/templates/item/index.html.twig
+++ b/templates/item/index.html.twig
@@ -117,6 +117,7 @@
                                 <th>Profil</th>
                                 <th>Text</th>
                                 <th>Datum</th>
+                                <th>Medien</th>
                                 <th>Status</th>
                                 <th>Aktionen</th>
                             </tr>
@@ -124,7 +125,7 @@
                         <tbody data-item-list-target="tableBody">
                             {% set toggleToken = csrf_token('toggle-item') %}
                             {% if items is empty %}
-                                <tr><td colspan="7" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
+                                <tr><td colspan="8" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
                             {% else %}
                                 {% for item in items %}
                                     <tr id="item-row-{{ item.id }}"
@@ -153,6 +154,17 @@
                                             </a>
                                         </td>
                                         <td>{{ item.dateTime|date('d.m.Y H:i') }}</td>
+                                        <td>
+                                            {% if item.hasPhoto %}
+                                                <i class="fas fa-camera text-success" title="{{ item.photoCount }} Foto(s) heruntergeladen"></i>
+                                                {% if item.photoCount > 1 %}
+                                                    <small class="text-success">{{ item.photoCount }}</small>
+                                                {% endif %}
+                                            {% endif %}
+                                            {% if item.hasVideo %}
+                                                <i class="fas fa-video text-success" title="Video heruntergeladen"></i>
+                                            {% endif %}
+                                        </td>
                                         <td>
                                             <button class="btn btn-sm {{ item.hidden ? 'btn-warning' : 'btn-outline-warning' }}"
                                                     data-action="toggle#toggleHidden"
@@ -215,6 +227,13 @@
                 </td>
                 <td>{{dateTime}}</td>
                 <td>
+                    {{#if hasPhoto}}
+                        <i class="fas fa-camera text-success" title="{{photoCount}} Foto(s) heruntergeladen"></i>
+                        {{#if (gt photoCount 1)}}<small class="text-success">{{photoCount}}</small>{{/if}}
+                    {{/if}}
+                    {{#if hasVideo}}<i class="fas fa-video text-success" title="Video heruntergeladen"></i>{{/if}}
+                </td>
+                <td>
                     <button class="btn btn-sm {{#if hidden}}btn-warning{{else}}btn-outline-warning{{/if}}"
                             data-action="toggle#toggleHidden"
                             data-toggle-target="hiddenBtn"
@@ -242,7 +261,7 @@
         </template>
 
         <template data-item-list-target="emptyTemplate">
-            <tr><td colspan="7" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
+            <tr><td colspan="8" class="text-center text-muted py-4">Keine Items gefunden.</td></tr>
         </template>
 
         <template data-item-list-target="paginationTemplate">

--- a/templates/item/index.html.twig
+++ b/templates/item/index.html.twig
@@ -187,6 +187,14 @@
                                                 <a href="{{ path('app_item_edit', {id: item.id}) }}" class="btn btn-outline-secondary" title="Bearbeiten">
                                                     <i class="fas fa-edit"></i>
                                                 </a>
+                                                <button class="btn btn-outline-info"
+                                                        title="Medien herunterladen"
+                                                        data-controller="media-download"
+                                                        data-media-download-url-value="{{ path('app_item_download_media', {id: item.id}) }}"
+                                                        data-media-download-token-value="{{ csrf_token('download-media-' ~ item.id) }}"
+                                                        data-action="media-download#download">
+                                                    <i class="fas fa-download"></i>
+                                                </button>
                                             </div>
                                         </td>
                                     </tr>
@@ -255,6 +263,14 @@
                         <a href="{{editUrl}}" class="btn btn-outline-secondary" title="Bearbeiten">
                             <i class="fas fa-edit"></i>
                         </a>
+                        <button class="btn btn-outline-info"
+                                title="Medien herunterladen"
+                                data-controller="media-download"
+                                data-media-download-url-value="{{downloadMediaUrl}}"
+                                data-media-download-token-value="{{downloadMediaToken}}"
+                                data-action="media-download#download">
+                            <i class="fas fa-download"></i>
+                        </button>
                     </div>
                 </td>
             </tr>
@@ -296,5 +312,20 @@
             {{/if}}
         </template>
         {% endverbatim %}
+    </div>
+
+    <div class="modal fade" id="mediaDownloadModal" tabindex="-1" aria-labelledby="mediaDownloadModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="mediaDownloadModalLabel">Medien herunterladen</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer d-none">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
+                </div>
+            </div>
+        </div>
     </div>
 {% endblock %}

--- a/templates/item/show.html.twig
+++ b/templates/item/show.html.twig
@@ -31,6 +31,60 @@
                 </div>
             </div>
 
+            <div class="data-card mb-4" id="media-card">
+                <div class="data-card-header">Medien</div>
+                <div class="data-card-body">
+                    <div class="media-content">
+                        {% if item.photoPaths|length > 0 %}
+                            <div class="row g-2 mb-3">
+                                {% for photoPath in item.photoPaths %}
+                                    <div class="col-{{ item.photoPaths|length == 1 ? '12' : '6' }}">
+                                        <img src="/media/{{ photoPath }}" class="img-fluid rounded" alt="Foto {{ loop.index }}">
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                        {% if item.videoPath %}
+                            <div class="mb-3">
+                                <video src="/media/{{ item.videoPath }}" controls class="w-100 rounded"></video>
+                            </div>
+                        {% endif %}
+                        {% if item.photoPaths|length == 0 and not item.videoPath %}
+                            <p class="text-muted mb-0">Keine Medien heruntergeladen.</p>
+                        {% endif %}
+                    </div>
+                    {% if item.mediaStatus == 'failed' and item.mediaError %}
+                        <div class="alert alert-danger mt-3 mb-0">
+                            <i class="fas fa-exclamation-triangle me-1"></i>{{ item.mediaError }}
+                        </div>
+                    {% endif %}
+                    {% if item.mediaStatus %}
+                        <div class="mt-2">
+                            <small class="text-muted">Status: </small>
+                            {% if item.mediaStatus == 'completed' %}
+                                <span class="badge bg-success">{{ item.mediaStatus }}</span>
+                            {% elseif item.mediaStatus == 'failed' %}
+                                <span class="badge bg-danger">{{ item.mediaStatus }}</span>
+                            {% elseif item.mediaStatus == 'downloading' %}
+                                <span class="badge bg-info">{{ item.mediaStatus }}</span>
+                            {% else %}
+                                <span class="badge bg-secondary">{{ item.mediaStatus }}</span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    <div class="mt-3">
+                        <button type="button"
+                                class="btn btn-outline-primary w-100"
+                                data-controller="media-download"
+                                data-media-download-url-value="{{ path('app_item_download_media', {id: item.id}) }}"
+                                data-media-download-token-value="{{ csrf_token('download-media-' ~ item.id) }}"
+                                data-action="media-download#download">
+                            <i class="fas fa-download me-1"></i>Medien herunterladen
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             {% if item.raw %}
                 <div class="data-card mb-4">
                     <div class="data-card-header">Rohdaten</div>
@@ -109,6 +163,21 @@
                         <i class="fas fa-trash me-1"></i>
                         <span data-toggle-target="deletedLabel">{{ item.deleted ? 'Gelöscht' : 'Nicht gelöscht' }}</span>
                     </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="mediaDownloadModal" tabindex="-1" aria-labelledby="mediaDownloadModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="mediaDownloadModalLabel">Medien herunterladen</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer d-none">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Schließen</button>
                 </div>
             </div>
         </div>

--- a/templates/profile/_form.html.twig
+++ b/templates/profile/_form.html.twig
@@ -11,8 +11,16 @@
                 <div class="col-md-6">
                     {{ form_row(form.autoFetch) }}
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-4">
                     {{ form_row(form.fetchSource) }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">
+                    {{ form_row(form.savePhotos) }}
+                </div>
+                <div class="col-md-4">
+                    {{ form_row(form.saveVideos) }}
                 </div>
             </div>
             {{ form_row(form.additionalData) }}

--- a/templates/profile/_partials/_profile_table_body.html.twig
+++ b/templates/profile/_partials/_profile_table_body.html.twig
@@ -19,6 +19,12 @@
         <td>
             {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'fetchSource', state: profile.fetchSource } %}
         </td>
+        <td>
+            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'savePhotos', state: profile.savePhotos } %}
+        </td>
+        <td>
+            {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'saveVideos', state: profile.saveVideos } %}
+        </td>
         <td data-fetch-status>
             {% if profile.lastFetchSuccessDateTime %}
                 <span class="text-success" title="{{ profile.lastFetchSuccessDateTime|date('d.m.Y H:i:s') }}">
@@ -63,6 +69,6 @@
     </tr>
 {% else %}
     <tr>
-        <td colspan="7" class="text-center text-muted py-4">Keine Profile gefunden.</td>
+        <td colspan="9" class="text-center text-muted py-4">Keine Profile gefunden.</td>
     </tr>
 {% endfor %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -113,6 +113,8 @@
                         <th>Profil</th>
                         <th>Auto-Fetch</th>
                         <th>Quelltext</th>
+                        <th>Fotos</th>
+                        <th>Videos</th>
                         <th>Letzter Fetch</th>
                         <th>Aktionen</th>
                     </tr>

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -62,6 +62,18 @@
                             </td>
                         </tr>
                         <tr>
+                            <th>Fotos speichern</th>
+                            <td>
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'savePhotos', state: profile.savePhotos } %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Videos speichern</th>
+                            <td>
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'saveVideos', state: profile.saveVideos } %}
+                            </td>
+                        </tr>
+                        <tr>
                             <th>Erstellt am</th>
                             <td>{{ profile.createdAt ? profile.createdAt|date('d.m.Y H:i:s') : '-' }}</td>
                         </tr>

--- a/tests/MediaDownloader/MediaDownloadServiceTest.php
+++ b/tests/MediaDownloader/MediaDownloadServiceTest.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\MediaDownloader;
+
+use App\Entity\Item;
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\MediaDownloader\MediaDownloadService;
+use App\MediaDownloader\MediaUrlExtractor;
+use App\MediaDownloader\PhotoDownloader;
+use App\MediaDownloader\VideoDownloader;
+use App\Repository\ItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class MediaDownloadServiceTest extends TestCase
+{
+    private MediaUrlExtractor $extractor;
+    private PhotoDownloader $photoDownloader;
+    private VideoDownloader $videoDownloader;
+    private EntityManagerInterface $em;
+    private ItemRepository $itemRepository;
+    private MediaDownloadService $service;
+
+    protected function setUp(): void
+    {
+        $this->extractor = $this->createMock(MediaUrlExtractor::class);
+        $this->photoDownloader = $this->createMock(PhotoDownloader::class);
+        $this->videoDownloader = $this->createMock(VideoDownloader::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->itemRepository = $this->createMock(ItemRepository::class);
+
+        $this->service = new MediaDownloadService(
+            $this->extractor,
+            $this->photoDownloader,
+            $this->videoDownloader,
+            $this->em,
+            $this->itemRepository,
+        );
+    }
+
+    private function createItem(): Item
+    {
+        $network = new Network();
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setNetwork($network);
+        $profile->setIdentifier('test');
+
+        $item = new Item();
+        $ref = new \ReflectionProperty(Item::class, 'id');
+        $ref->setValue($item, 100);
+        $item->setProfile($profile);
+
+        return $item;
+    }
+
+    public function testDownloadMediaSinglePhoto(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->method('extractPhotoUrls')->willReturn(['https://example.com/photo.jpg']);
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+
+        $this->photoDownloader->expects($this->once())
+            ->method('download')
+            ->with('https://example.com/photo.jpg', 42, 100, 0)
+            ->willReturn('42/100/photo_0.jpg');
+
+        $this->em->expects($this->exactly(2))->method('flush');
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertSame(['42/100/photo_0.jpg'], $item->getPhotoPaths());
+        $this->assertNull($item->getMediaError());
+    }
+
+    public function testDownloadMediaMultiplePhotos(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->method('extractPhotoUrls')->willReturn([
+            'https://example.com/photo1.jpg',
+            'https://example.com/photo2.jpg',
+            'https://example.com/photo3.jpg',
+        ]);
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+
+        $this->photoDownloader->expects($this->exactly(3))
+            ->method('download')
+            ->willReturnCallback(fn (string $url, int $profileId, int $itemId, int $index) =>
+                sprintf('%d/%d/photo_%d.jpg', $profileId, $itemId, $index)
+            );
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertSame([
+            '42/100/photo_0.jpg',
+            '42/100/photo_1.jpg',
+            '42/100/photo_2.jpg',
+        ], $item->getPhotoPaths());
+    }
+
+    public function testDownloadMediaSetsFailedOnError(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->method('extractPhotoUrls')->willReturn(['https://example.com/photo.jpg']);
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+
+        $this->photoDownloader->method('download')
+            ->willThrowException(new \RuntimeException('Network error'));
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('failed', $item->getMediaStatus());
+        $this->assertStringContainsString('Network error', $item->getMediaError());
+    }
+
+    public function testDownloadMediaSkipsPhotoWhenFlagIsFalse(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->expects($this->never())->method('extractPhotoUrls');
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+        $this->videoDownloader->method('isAvailable')->willReturn(false);
+
+        $this->service->downloadMedia($item, photo: false, video: true);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+    }
+
+    public function testDownloadMediaSkipsVideoWhenFlagIsFalse(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->method('extractPhotoUrls')->willReturn([]);
+        $this->extractor->expects($this->never())->method('extractVideoUrl');
+
+        $this->service->downloadMedia($item, photo: true, video: false);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+    }
+
+    public function testDownloadMediaSkipsItemWithoutProfile(): void
+    {
+        $item = new Item();
+
+        $this->em->expects($this->never())->method('flush');
+
+        $this->service->downloadMedia($item);
+    }
+
+    public function testDownloadNewItemsForProfile(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+        $profile->setSavePhotos(true);
+        $profile->setSaveVideos(false);
+
+        $item = $this->createItem();
+
+        $this->itemRepository->method('findBy')
+            ->with(['profile' => $profile, 'mediaStatus' => null])
+            ->willReturn([$item]);
+
+        $this->extractor->method('extractPhotoUrls')->willReturn([]);
+
+        $this->service->downloadNewItemsForProfile($profile);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+    }
+}

--- a/tests/MediaDownloader/MediaUrlExtractorTest.php
+++ b/tests/MediaDownloader/MediaUrlExtractorTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\MediaDownloader;
+
+use App\Entity\Item;
+use App\MediaDownloader\MediaUrlExtractor;
+use PHPUnit\Framework\TestCase;
+
+class MediaUrlExtractorTest extends TestCase
+{
+    private MediaUrlExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        $this->extractor = new MediaUrlExtractor();
+    }
+
+    public function testExtractPhotoUrlsFromRssAppFormat(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'thumbnail' => 'https://example.com/photo.jpg',
+            'title' => 'Test',
+        ]));
+
+        $this->assertSame(['https://example.com/photo.jpg'], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsFromBlueskyMultipleImages(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'embed' => [
+                'images' => [
+                    ['fullsize' => 'https://bsky.example.com/image1.jpg', 'thumb' => 'https://bsky.example.com/thumb1.jpg'],
+                    ['fullsize' => 'https://bsky.example.com/image2.jpg', 'thumb' => 'https://bsky.example.com/thumb2.jpg'],
+                    ['fullsize' => 'https://bsky.example.com/image3.jpg'],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([
+            'https://bsky.example.com/image1.jpg',
+            'https://bsky.example.com/image2.jpg',
+            'https://bsky.example.com/image3.jpg',
+        ], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsFromBlueskyThumbFallback(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'embed' => [
+                'images' => [
+                    ['thumb' => 'https://bsky.example.com/thumb.jpg'],
+                ],
+            ],
+        ]));
+
+        $this->assertSame(['https://bsky.example.com/thumb.jpg'], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsFromMastodonMultipleAttachments(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'media_attachments' => [
+                ['type' => 'image', 'url' => 'https://mastodon.example.com/media/photo1.png'],
+                ['type' => 'video', 'url' => 'https://mastodon.example.com/media/video.mp4'],
+                ['type' => 'image', 'url' => 'https://mastodon.example.com/media/photo2.png'],
+            ],
+        ]));
+
+        $this->assertSame([
+            'https://mastodon.example.com/media/photo1.png',
+            'https://mastodon.example.com/media/photo2.png',
+        ], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsReturnsEmptyForNoRaw(): void
+    {
+        $item = new Item();
+
+        $this->assertSame([], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsReturnsEmptyForEmptyJson(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode(['title' => 'No image here']));
+
+        $this->assertSame([], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsReturnsEmptyForInvalidJson(): void
+    {
+        $item = new Item();
+        $item->setRaw('not json');
+
+        $this->assertSame([], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractPhotoUrlsSkipsEmptyThumbnail(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode(['thumbnail' => '']));
+
+        $this->assertSame([], $this->extractor->extractPhotoUrls($item));
+    }
+
+    public function testExtractVideoUrlReturnsPermalink(): void
+    {
+        $item = new Item();
+        $item->setPermalink('https://instagram.com/p/abc123');
+
+        $this->assertSame('https://instagram.com/p/abc123', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullWithoutPermalink(): void
+    {
+        $item = new Item();
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+}

--- a/tests/MediaDownloader/PhotoDownloaderTest.php
+++ b/tests/MediaDownloader/PhotoDownloaderTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\MediaDownloader;
+
+use App\MediaDownloader\PhotoDownloader;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class PhotoDownloaderTest extends TestCase
+{
+    public function testDownloadWritesFileAndReturnsPath(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-type' => ['image/jpeg']]);
+        $response->method('getContent')->willReturn('fake-image-data');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')
+            ->with('GET', 'https://example.com/photo.jpg')
+            ->willReturn($response);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects($this->once())
+            ->method('write')
+            ->with('42/100/photo_0.jpg', 'fake-image-data');
+
+        $downloader = new PhotoDownloader($httpClient, $storage);
+        $path = $downloader->download('https://example.com/photo.jpg', 42, 100, 0);
+
+        $this->assertSame('42/100/photo_0.jpg', $path);
+    }
+
+    public function testDownloadWithIndexCreatesNumberedFile(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-type' => ['image/jpeg']]);
+        $response->method('getContent')->willReturn('fake-image-data');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects($this->once())
+            ->method('write')
+            ->with('42/100/photo_2.jpg', 'fake-image-data');
+
+        $downloader = new PhotoDownloader($httpClient, $storage);
+        $path = $downloader->download('https://example.com/photo.jpg', 42, 100, 2);
+
+        $this->assertSame('42/100/photo_2.jpg', $path);
+    }
+
+    public function testDownloadResolvesExtensionFromContentType(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-type' => ['image/png']]);
+        $response->method('getContent')->willReturn('png-data');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects($this->once())
+            ->method('write')
+            ->with('1/2/photo_0.png', 'png-data');
+
+        $downloader = new PhotoDownloader($httpClient, $storage);
+        $path = $downloader->download('https://example.com/image', 1, 2, 0);
+
+        $this->assertSame('1/2/photo_0.png', $path);
+    }
+
+    public function testDownloadResolvesExtensionFromUrl(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-type' => ['application/octet-stream']]);
+        $response->method('getContent')->willReturn('webp-data');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects($this->once())
+            ->method('write')
+            ->with('1/2/photo_0.webp', 'webp-data');
+
+        $downloader = new PhotoDownloader($httpClient, $storage);
+        $path = $downloader->download('https://example.com/image.webp', 1, 2, 0);
+
+        $this->assertSame('1/2/photo_0.webp', $path);
+    }
+
+    public function testDownloadDefaultsToJpg(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-type' => ['application/octet-stream']]);
+        $response->method('getContent')->willReturn('data');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        $storage = $this->createMock(FilesystemOperator::class);
+        $storage->expects($this->once())
+            ->method('write')
+            ->with('1/2/photo_0.jpg', 'data');
+
+        $downloader = new PhotoDownloader($httpClient, $storage);
+        $path = $downloader->download('https://example.com/image', 1, 2);
+
+        $this->assertSame('1/2/photo_0.jpg', $path);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the full media download stack:
- **Flysystem bundle** with local adapter at `public/media/`
- **Profile flags** `savePhotos` and `saveVideos` (with migration)
- **Item fields** `photoPaths`, `videoPath`, `mediaStatus`, `mediaError`
- **`MediaDownloadService`** orchestrating photo/video downloads with status lifecycle
- **`MediaUrlExtractor`** that pulls URLs from RSS.app `description_html`/`thumbnail`, Bluesky `embed.images`, Mastodon `media_attachments`
- **`PhotoDownloader`** (HttpClient → file)
- **`VideoDownloader`** (yt-dlp process)
- **`DownloadMediaCommand`** CLI for bulk downloads (`--profile`, `--retry-failed`, `--photos-only`, `--videos-only`)
- **Web UI integration** via Stimulus `media_download_controller`, plus a button on the item list view
- Auto-download triggers after feed fetch when the profile has the flags set

**PR 16 of 17**. Stacked on #35.

## Commits

- `(d5ebb19)` Add Flysystem bundle for media storage
- `(8744ae4)` Add media download fields to Profile and Item entities
- `206bb84` Add media download services
- `17925f5` Integrate media download into Web UI and feed fetcher
- `29e5c97` Add download-media command, tests, and documentation
- `bcb00ba` Add media download button to item list view

## Test plan

- [x] `bin/phpunit` — **140 tests, 330 assertions**, no errors/failures (after `bin/console doctrine:schema:create --env=test` to add the new media columns)
- [ ] Reviewer to confirm `yt-dlp` graceful fallback when not installed

## Stack

- Previous: #35 (`feat/profile-title-and-cleanup`)
- Next: B18 (Fetch tracking + dashboard counts + bug fixes — **the final PR in the stack**)