### PR TITLE
Fetch tracking, dashboard counts, bug fixes, photo extraction, error messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ bin/phpunit                                          # run all tests
 bin/phpunit --filter testParseHandleFormat            # run single test
 bin/phpunit tests/NetworkFeedFetcher/Bluesky/         # run test directory
 
-php bin/console feeds:fetch mastodon -c 50            # fetch feeds
+php bin/console fetch-feed mastodon -c 50              # fetch feeds (actual command name)
+php bin/console fetch-feed bluesky_profile --count=100 # fetch specific network
 php bin/console feed:list instagram_profile           # list profiles
 php bin/console network:list                          # list registered fetchers
 php bin/console app:fetch-scheduled                   # run scheduled fetches (cron-based)
@@ -50,12 +51,14 @@ php bin/console app:download-media --videos-only      # only videos
 ### Feed Fetching Flow
 
 ```
-Command → FeedFetcher → ProfileFetcher (loads profiles from criticalmass.in API)
+Command → FeedFetcher → ProfileFetcher (loads profiles)
                       → NetworkFeedFetcher.fetch() (per profile, network-specific)
-                      → FeedItemPersister (pushes items to criticalmass.in API)
-                      → ProfilePersister (updates profile metadata)
+                      → FeedItemPersister (persists items)
+                      → ProfilePersister (updates profile metadata + fetch timestamps)
                       → MediaDownloadService (downloads photos/videos if profile flags set)
 ```
+
+After each fetch, `FeedFetcher` updates `lastFetchSuccessDateTime` / `lastFetchFailureDateTime` / `lastFetchFailureError` on the profile. Errors caught via exception or `markAsFailed()` (e.g. invalid identifier) are both persisted.
 
 ### Service Wiring
 
@@ -83,10 +86,11 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 Profiles can opt into automatic photo/video downloads via `savePhotos` and `saveVideos` flags. Media is stored via Flysystem (local adapter at `public/media/`).
 
-- **`MediaUrlExtractor`** — extracts photo URLs from `raw` JSON (RSS.app `thumbnail`, Bluesky `embed.images[]`, Mastodon `media_attachments[]`). Supports multiple photos per item. Video URL is the item's `permalink`.
+- **`MediaUrlExtractor`** — extracts photo URLs from `raw` JSON (RSS.app `description_html` img tags, RSS.app `thumbnail` fallback, Bluesky `embed.images[]`, Mastodon `media_attachments[]`). Supports multiple photos per item. Video URL is the item's `permalink`.
 - **`PhotoDownloader`** — downloads images via HttpClient, stores as `{profileId}/{itemId}/photo_{index}.{ext}` in Flysystem
+- **`YtDlpPhotoDownloader`** — extracts photos (including carousel/album images) via `yt-dlp` in original quality. Used for Instagram, Threads, and Facebook where RSS.app only provides a single thumbnail. Falls back to `PhotoDownloader` if `yt-dlp` is unavailable or returns no results.
 - **`VideoDownloader`** — downloads videos via `yt-dlp` process, stores as `{profileId}/{itemId}/video.{ext}` on disk. Requires `yt-dlp` to be installed; gracefully skips if unavailable.
-- **`MediaDownloadService`** — orchestrates downloads, manages `mediaStatus` lifecycle (`downloading` → `completed`/`failed`)
+- **`MediaDownloadService`** — orchestrates downloads, manages `mediaStatus` lifecycle (`downloading` → `completed`/`failed`). Selects download strategy per network: `yt-dlp` for RSS.app-based networks (Instagram, Threads, Facebook), direct URL download for Bluesky/Mastodon.
 - **`DownloadMediaCommand`** — CLI for bulk downloads with `--profile`, `--retry-failed`, `--photos-only`, `--videos-only` options
 - Auto-download triggers after feed fetch when profile has `savePhotos`/`saveVideos` enabled
 - Manual download via button on item detail page (Stimulus `media_download_controller`)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Symfony 8 application that fetches social media feeds from various networks and 
 - PHP 8.5+
 - Composer
 - Docker & Docker Compose (for PostgreSQL)
-- yt-dlp (optional, for video downloads)
+- yt-dlp (optional, for video downloads and Instagram/Threads/Facebook photo extraction)
 
 ## Installation
 
@@ -74,7 +74,7 @@ The application is accessible at `https://127.0.0.1:8000`.
 | Network | Identifier | API | Auth required |
 |---|---|---|---|
 | Mastodon | `mastodon` | Mastodon API v1 | No |
-| Bluesky | `bluesky` | AT Protocol (public) | No |
+| Bluesky | `bluesky_profile` | AT Protocol (public) | No |
 | Homepage/RSS | `homepage` | Direct RSS/Atom feed | No |
 | Instagram | `instagram_profile` | via RSS.app | Yes (RSS.app) |
 | Facebook | `facebook_page` | via RSS.app | Yes (RSS.app) |
@@ -86,19 +86,19 @@ The application is accessible at `https://127.0.0.1:8000`.
 
 ```bash
 # Fetch all networks
-php bin/console feeds:fetch
+php bin/console fetch-feed
 
 # Fetch specific networks
-php bin/console feeds:fetch mastodon bluesky
+php bin/console fetch-feed mastodon bluesky_profile
 
 # Fetch with options
-php bin/console feeds:fetch instagram_profile --count=50 --citySlug=hamburg
+php bin/console fetch-feed instagram_profile --count=50
 
 # Run scheduled fetches (based on cron expressions per network)
 php bin/console app:fetch-scheduled
 ```
 
-Options for `feeds:fetch`:
+Options for `fetch-feed`:
 
 | Option | Short | Description |
 |---|---|---|
@@ -106,7 +106,6 @@ Options for `feeds:fetch`:
 | `--fromDateTime` | `-f` | Start date filter |
 | `--untilDateTime` | `-u` | End date filter |
 | `--includeOldItems` | `-i` | Include already fetched items |
-| `--citySlug` | | Filter by city slug |
 
 ### Profile & network management
 
@@ -150,7 +149,7 @@ php bin/console app:rssapp:sync-feed-ids --force      # re-check existing feed I
 
 ### Media download
 
-Download photos and videos for feed items. Photos are extracted from the raw API response (supports multiple photos per post for Bluesky and Mastodon). Videos are downloaded via `yt-dlp` from the item's permalink URL.
+Download photos and videos for feed items. For Instagram, Threads, and Facebook, photos (including carousel/album images) are extracted in original quality via `yt-dlp`, with a fallback to the RSS.app thumbnail. Bluesky and Mastodon photos are downloaded directly from their API response (supports multiple photos per post natively). Videos are downloaded via `yt-dlp` from the item's permalink URL.
 
 ```bash
 php bin/console app:download-media                    # all profiles with savePhotos/saveVideos enabled
@@ -166,7 +165,7 @@ Media files are stored in `public/media/{profileId}/{itemId}/`. Profiles must ha
 
 The admin interface is accessible after login at `/login`. It provides:
 
-- **Dashboard** — Overview with network statistics, profile/item counts, and a table of recent items
+- **Dashboard** — Overview with network statistics (item counts per 24h/7d/31d/365d by publication date), profile/item counts, and a table of recent items
 - **Networks** — CRUD for social networks (name, icon, color, cron schedule)
 - **Profiles** — Searchable/filterable list with auto-fetch toggle, save photos/videos toggles, fetch status, manual fetch trigger, RSS.app registration
 - **Items** — Searchable/filterable list with hide/delete toggles, media status indicators, network and profile filters, manual media download
@@ -219,20 +218,24 @@ Profiles are shared across clients via a join table. Each client sees only its l
 ### Feed fetching flow
 
 ```
-feeds:fetch command
+fetch-feed command
     |
     v
 FeedFetcher (orchestrator)
     |
-    +-- ProfileFetcher -----------> criticalmass.in API (load profiles)
+    +-- ProfileFetcher -----------> Load profiles (DB or API)
     |
     +-- NetworkFeedFetcher -------> Network API (fetch feed items)
     |   (Mastodon, Bluesky, ...)
     |
-    +-- FeedItemPersister --------> criticalmass.in API (push items)
+    +-- FeedItemPersister --------> Persist items
     |
-    +-- ProfilePersister ---------> criticalmass.in API (update metadata)
+    +-- ProfilePersister ---------> Update profile metadata + fetch timestamps
+    |
+    +-- MediaDownloadService -----> Download photos/videos (if profile flags set)
 ```
+
+After each fetch, the profile's `lastFetchSuccessDateTime` or `lastFetchFailureDateTime`/`lastFetchFailureError` fields are updated.
 
 ### Service wiring
 

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,9 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.6",
         "doctrine/doctrine-fixtures-bundle": "^4.3",
+        "phpunit/phpunit": "^13.0",
+        "symfony/browser-kit": "^8.0",
+        "symfony/css-selector": "^8.0",
         "symfony/stopwatch": "^8.0",
         "symfony/web-profiler-bundle": "^8.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -2627,6 +2627,229 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/897b5986ece6b4f9d8413fea345c7d49c757d6bf",
+                "reference": "897b5986ece6b4f9d8413fea345c7d49c757d6bf",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.2"
+            },
+            "time": "2026-03-01T18:43:49+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -6118,6 +6341,106 @@
             "time": "2026-02-25T16:59:43+00:00"
         },
         {
+            "name": "symfony/security-bundle",
+            "version": "v8.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-bundle.git",
+                "reference": "73ba33c215a5e4516c7045c26f6fec71e4ab5727"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/73ba33c215a5e4516c7045c26f6fec71e4ab5727",
+                "reference": "73ba33c215a5e4516c7045c26f6fec71e4ab5727",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.4",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/password-hasher": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
+                "symfony/security-http": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/asset": "^7.4|^8.0",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/css-selector": "^7.4|^8.0",
+                "symfony/dom-crawler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/ldap": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "symfony/twig-bridge": "^7.4|^8.0",
+                "symfony/twig-bundle": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0",
+                "web-token/jwt-library": "^3.3.2|^4.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\SecurityBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-bundle/tree/v8.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-22T22:01:53+00:00"
+        },
+        {
             "name": "symfony/security-core",
             "version": "v8.0.4",
             "source": {
@@ -6269,6 +6592,93 @@
                 }
             ],
             "time": "2026-02-13T09:57:13+00:00"
+        },
+        {
+            "name": "symfony/security-http",
+            "version": "v8.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-http.git",
+                "reference": "ff6cdab586fed68f1ebc2a2ed42ae0dffafada1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/ff6cdab586fed68f1ebc2a2ed42ae0dffafada1f",
+                "reference": "ff6cdab586fed68f1ebc2a2ed42ae0dffafada1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/security-core": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/clock": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/http-client-contracts": "^3.0",
+                "symfony/rate-limiter": "^7.4|^8.0",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/security-csrf": "^7.4|^8.0",
+                "symfony/translation": "^7.4|^8.0",
+                "web-token/jwt-library": "^3.3.2|^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Http\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - HTTP Integration",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-http/tree/v8.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-17T13:07:04+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -7538,6 +7948,68 @@
             "time": "2026-01-23T21:00:41+00:00"
         },
         {
+            "name": "webmozart/assert",
+            "version": "2.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
+            },
+            "time": "2026-02-27T10:28:38+00:00"
+        },
+        {
             "name": "willdurand/negotiation",
             "version": "3.1.0",
             "source": {
@@ -7592,9 +8064,172 @@
                 "source": "https://github.com/willdurand/Negotiation/tree/3.1.0"
             },
             "time": "2022-01-30T20:08:53+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "5.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "098223019f764a16715f64089a58606096719c98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/098223019f764a16715f64089a58606096719c98",
+                "reference": "098223019f764a16715f64089a58606096719c98",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=7.4",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^9.0",
+                "rector/rector": "^1.0 || ^2.3.1",
+                "vimeo/psalm": "^4.30 || ^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "^2.0",
+                "radebatz/type-info-extras": "^1.0.2"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/5.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-02T00:47:18+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
+        },
         {
             "name": "doctrine/data-fixtures",
             "version": "2.2.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,3 +38,6 @@ services:
 
     App\RssApp\RssAppInterface:
         alias: App\RssApp\RssApp
+
+    App\FeedFetcher\FeedFetcherInterface:
+        alias: App\FeedFetcher\FeedFetcher

--- a/src/Command/ImportItemsCommand.php
+++ b/src/Command/ImportItemsCommand.php
@@ -228,6 +228,7 @@ class ImportItemsCommand extends Command
         $item->setPermalink($data['permalink'] ?? null);
         $item->setTitle($data['title'] ?? null);
         $item->setText($data['text']);
+        $item->setDateTime((new \DateTimeImmutable())->setTimestamp((int) $data['date_time']));
         $item->setHidden($data['hidden'] ?? false);
         $item->setDeleted($data['deleted'] ?? false);
         $item->setRaw($data['raw'] ?? null);

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -19,6 +19,14 @@ class DashboardController extends AbstractController
     ): Response {
         $networks = $networkRepository->findAll();
 
+        $now = new \DateTimeImmutable();
+        $intervals = [
+            'last24h' => $now->modify('-24 hours'),
+            'last7d' => $now->modify('-7 days'),
+            'last31d' => $now->modify('-31 days'),
+            'last365d' => $now->modify('-365 days'),
+        ];
+
         $networkStats = [];
         foreach ($networks as $network) {
             $profiles = $profileRepository->findBy(['network' => $network]);
@@ -30,6 +38,7 @@ class DashboardController extends AbstractController
                 'network' => $network,
                 'profileCount' => count($profiles),
                 'itemCount' => $itemCount,
+                'itemCounts' => $itemRepository->countByNetworkSince($network, $intervals),
             ];
         }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -31,6 +31,10 @@ class ProfileController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $search = trim($request->query->getString('search', ''));
         $networkIds = array_map('intval', (array) $request->query->all('networks'));
+
+        if ($networkIds === [] && $request->query->has('network')) {
+            $networkIds = [$request->query->getInt('network')];
+        }
         $status = $request->query->getString('status', '');
 
         $total = $profileRepository->countFiltered($networkIds, $search, $status);

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -294,14 +294,14 @@ class Item
         return $this;
     }
 
-    public function getSource(): ?string
+    public function getParsedSource(): ?string
     {
-        return $this->source;
+        return $this->parsedSource;
     }
 
-    public function setSource(?string $source): self
+    public function setParsedSource(?string $parsedSource): self
     {
-        $this->source = $source;
+        $this->parsedSource = $parsedSource;
 
         return $this;
     }

--- a/src/FeedFetcher/FeedFetcher.php
+++ b/src/FeedFetcher/FeedFetcher.php
@@ -52,27 +52,45 @@ class FeedFetcher extends AbstractFeedFetcher
             $fetcher = $this->getFeedFetcherForProfile($profile);
 
             if ($fetcher) {
-                $feedItemList = $fetcher->fetch($profile, $fetchInfo);
+                try {
+                    $failureErrorBefore = $profile->getLastFetchFailureError();
+                    $feedItemList = $fetcher->fetch($profile, $fetchInfo);
 
-                foreach ($feedItemList as $feedItem) {
-                    $this->sourceFetcher->fetch($feedItem, $profile);
+                    // Check if the fetcher marked the profile as failed (e.g. invalid identifier)
+                    $fetcherMarkedAsFailed = $profile->getLastFetchFailureError() !== $failureErrorBefore;
+
+                    foreach ($feedItemList as $feedItem) {
+                        $this->sourceFetcher->fetch($feedItem, $profile);
+                    }
+
+                    $fetchResult = new FetchResult();
+                    $fetchResult
+                        ->setProfile($profile)
+                        ->setCounterFetched(count($feedItemList));
+
+                    $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+
+                    if (!$fetcherMarkedAsFailed) {
+                        $profile->setLastFetchSuccessDateTime(new \DateTime());
+                        $profile->setLastFetchFailureDateTime(null);
+                        $profile->setLastFetchFailureError(null);
+                    }
+
+                    $this->profilePersister->persistProfile($profile);
+
+                    // Download media if profile has savePhotos or saveVideos enabled
+                    $entityProfile = $this->profileRepository->find($profile->getId());
+
+                    if ($entityProfile && ($entityProfile->isSavePhotos() || $entityProfile->isSaveVideos())) {
+                        $this->mediaDownloadService->downloadNewItemsForProfile($entityProfile);
+                    }
+
+                    $callback($fetchResult);
+                } catch (\Exception $e) {
+                    $profile->setLastFetchFailureDateTime(new \DateTime());
+                    $profile->setLastFetchFailureError($e->getMessage());
+                    $this->profilePersister->persistProfile($profile);
                 }
-
-                $fetchResult = new FetchResult();
-                $fetchResult
-                    ->setProfile($profile)
-                    ->setCounterFetched(count($feedItemList));
-
-                $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
-
-                // Download media if profile has savePhotos or saveVideos enabled
-                $entityProfile = $this->profileRepository->find($profile->getId());
-
-                if ($entityProfile && ($entityProfile->isSavePhotos() || $entityProfile->isSaveVideos())) {
-                    $this->mediaDownloadService->downloadNewItemsForProfile($entityProfile);
-                }
-
-                $callback($fetchResult);
             }
         }
 

--- a/src/FeedFetcher/FeedFetcher.php
+++ b/src/FeedFetcher/FeedFetcher.php
@@ -71,7 +71,7 @@ class FeedFetcher extends AbstractFeedFetcher
                     $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
 
                     if (!$fetcherMarkedAsFailed) {
-                        $profile->setLastFetchSuccessDateTime(new \DateTime());
+                        $profile->setLastFetchSuccessDateTime(new \DateTimeImmutable());
                         $profile->setLastFetchFailureDateTime(null);
                         $profile->setLastFetchFailureError(null);
                     }
@@ -87,7 +87,7 @@ class FeedFetcher extends AbstractFeedFetcher
 
                     $callback($fetchResult);
                 } catch (\Exception $e) {
-                    $profile->setLastFetchFailureDateTime(new \DateTime());
+                    $profile->setLastFetchFailureDateTime(new \DateTimeImmutable());
                     $profile->setLastFetchFailureError($e->getMessage());
                     $this->profilePersister->persistProfile($profile);
                 }

--- a/src/FeedItemPersister/DoctrineFeedItemPersister.php
+++ b/src/FeedItemPersister/DoctrineFeedItemPersister.php
@@ -64,7 +64,7 @@ class DoctrineFeedItemPersister implements FeedItemPersisterInterface
             ->setDeleted((bool) $feedItem->getDeleted())
             ->setRaw($feedItem->getRaw())
             ->setRawSource($feedItem->getRawSource())
-            ->setSource($feedItem->getSource());
+            ->setParsedSource($feedItem->getParsedSource());
 
         $this->entityManager->persist($entity);
 

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -46,7 +46,7 @@ class ProfileType extends AbstractType
                 'required' => false,
             ])
             ->add('fetchSource', CheckboxType::class, [
-                'label' => 'Quelltext laden',
+                'label' => 'Quellcode einlesen',
                 'required' => false,
             ])
             ->add('savePhotos', CheckboxType::class, [

--- a/src/MediaDownloader/MediaDownloadService.php
+++ b/src/MediaDownloader/MediaDownloadService.php
@@ -9,10 +9,13 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class MediaDownloadService
 {
+    private const YTDLP_PHOTO_NETWORKS = ['instagram_profile', 'threads_profile', 'facebook_page'];
+
     public function __construct(
         private readonly MediaUrlExtractor $mediaUrlExtractor,
         private readonly PhotoDownloader $photoDownloader,
         private readonly VideoDownloader $videoDownloader,
+        private readonly YtDlpPhotoDownloader $ytDlpPhotoDownloader,
         private readonly EntityManagerInterface $entityManager,
         private readonly ItemRepository $itemRepository,
     ) {
@@ -34,15 +37,8 @@ class MediaDownloadService
 
         if ($photo) {
             try {
-                $photoUrls = $this->mediaUrlExtractor->extractPhotoUrls($item);
-
-                if (!empty($photoUrls)) {
-                    $paths = [];
-
-                    foreach ($photoUrls as $index => $url) {
-                        $paths[] = $this->photoDownloader->download($url, $profile->getId(), $item->getId(), $index);
-                    }
-
+                $paths = $this->downloadPhotos($item, $profile);
+                if (!empty($paths)) {
                     $item->setPhotoPaths($paths);
                 }
             } catch (\Exception $e) {
@@ -71,6 +67,38 @@ class MediaDownloadService
         }
 
         $this->entityManager->flush();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function downloadPhotos(Item $item, Profile $profile): array
+    {
+        $networkIdentifier = $profile->getNetwork()?->getIdentifier();
+        $permalink = $item->getPermalink();
+
+        // Use yt-dlp for networks where it can extract carousel/original photos
+        if ($permalink
+            && $networkIdentifier
+            && in_array($networkIdentifier, self::YTDLP_PHOTO_NETWORKS, true)
+            && $this->ytDlpPhotoDownloader->isAvailable()
+        ) {
+            $paths = $this->ytDlpPhotoDownloader->download($permalink, $profile->getId(), $item->getId());
+
+            if (!empty($paths)) {
+                return $paths;
+            }
+        }
+
+        // Fallback: extract URLs from raw data and download directly
+        $photoUrls = $this->mediaUrlExtractor->extractPhotoUrls($item);
+        $paths = [];
+
+        foreach ($photoUrls as $index => $url) {
+            $paths[] = $this->photoDownloader->download($url, $profile->getId(), $item->getId(), $index);
+        }
+
+        return $paths;
     }
 
     public function downloadNewItemsForProfile(Profile $profile): void

--- a/src/MediaDownloader/MediaUrlExtractor.php
+++ b/src/MediaDownloader/MediaUrlExtractor.php
@@ -23,7 +23,14 @@ class MediaUrlExtractor
             return [];
         }
 
-        // RSS.app format: single thumbnail field
+        // RSS.app format: extract images from description_html (carousel support + original quality)
+        $htmlUrls = $this->extractImageUrlsFromHtml($data['description_html'] ?? '');
+
+        if (!empty($htmlUrls)) {
+            return $htmlUrls;
+        }
+
+        // RSS.app fallback: single thumbnail field
         if (isset($data['thumbnail']) && is_string($data['thumbnail']) && $data['thumbnail'] !== '') {
             return [$data['thumbnail']];
         }
@@ -66,5 +73,31 @@ class MediaUrlExtractor
     public function extractVideoUrl(Item $item): ?string
     {
         return $item->getPermalink();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractImageUrlsFromHtml(string $html): array
+    {
+        if ($html === '') {
+            return [];
+        }
+
+        if (!preg_match_all('/<img[^>]+src=["\']([^"\']+)["\']/', $html, $matches)) {
+            return [];
+        }
+
+        $urls = [];
+
+        foreach ($matches[1] as $url) {
+            if (!str_starts_with($url, 'http')) {
+                continue;
+            }
+
+            $urls[] = $url;
+        }
+
+        return array_values(array_unique($urls));
     }
 }

--- a/src/MediaDownloader/YtDlpPhotoDownloader.php
+++ b/src/MediaDownloader/YtDlpPhotoDownloader.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace App\MediaDownloader;
+
+use Symfony\Component\Process\Process;
+
+class YtDlpPhotoDownloader
+{
+    public function __construct(
+        private readonly string $mediaDirectory,
+    ) {
+    }
+
+    /**
+     * @return list<string> Relative paths of downloaded photos
+     */
+    public function download(string $url, int $profileId, int $itemId): array
+    {
+        $outputDir = sprintf('%s/%d/%d', $this->mediaDirectory, $profileId, $itemId);
+
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $outputTemplate = sprintf('%s/photo_%%(autonumber)s.%%(ext)s', $outputDir);
+
+        $process = new Process([
+            'yt-dlp',
+            '--no-playlist',
+            '--write-thumbnail',
+            '--skip-download',
+            '--convert-thumbnails', 'jpg',
+            '-o', $outputTemplate,
+            $url,
+        ]);
+
+        $process->setTimeout(120);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf('yt-dlp photo extraction failed: %s', $process->getErrorOutput() ?: $process->getOutput()));
+        }
+
+        $files = glob(sprintf('%s/photo_*.*', $outputDir));
+
+        if (empty($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        $paths = [];
+
+        foreach ($files as $file) {
+            $paths[] = ltrim(str_replace($this->mediaDirectory, '', $file), '/');
+        }
+
+        return $paths;
+    }
+
+    public function isAvailable(): bool
+    {
+        $process = new Process(['yt-dlp', '--version']);
+        $process->setTimeout(5);
+
+        try {
+            $process->run();
+
+            return $process->isSuccessful();
+        } catch (\Exception) {
+            return false;
+        }
+    }
+}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -16,7 +16,7 @@ class Item
     protected ?\DateTime $createdAt = null;
     protected ?string $raw = null;
     protected ?string $rawSource = null;
-    protected ?string $source = null;
+    protected ?string $parsedSource = null;
 
     public function __construct()
     {
@@ -167,14 +167,14 @@ class Item
         return $this;
     }
 
-    public function getSource(): ?string
+    public function getParsedSource(): ?string
     {
-        return $this->source;
+        return $this->parsedSource;
     }
 
-    public function setSource(?string $source): Item
+    public function setParsedSource(?string $parsedSource): Item
     {
-        $this->source = $source;
+        $this->parsedSource = $parsedSource;
 
         return $this;
     }

--- a/src/NetworkFeedFetcher/Bluesky/BlueskyFeedFetcher.php
+++ b/src/NetworkFeedFetcher/Bluesky/BlueskyFeedFetcher.php
@@ -21,7 +21,7 @@ class BlueskyFeedFetcher extends AbstractNetworkFeedFetcher
 
     public function getNetworkIdentifier(): string
     {
-        return 'bluesky';
+        return 'bluesky_profile';
     }
 
     public function fetch(Profile $profile, FetchInfo $fetchInfo): array

--- a/src/NetworkFeedFetcher/Mastodon/MastodonFeedFetcher.php
+++ b/src/NetworkFeedFetcher/Mastodon/MastodonFeedFetcher.php
@@ -30,9 +30,7 @@ class MastodonFeedFetcher extends AbstractNetworkFeedFetcher
             $accountInfo = $this->getAccountInfo($account);
             $timeline = $this->fetchTimeline($account, $accountInfo, $fetchInfo->getCount());
 
-            $feedItemList = $this->convertTimeline($profile, $timeline);
-
-            return $feedItemList;
+            return $this->convertTimeline($profile, $timeline);
         } catch (\Exception $exception) {
             $this->markAsFailed($profile, sprintf('Failed to fetch social network profile %d: %s', $profile->getId(), $exception->getMessage()));
 

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -62,6 +62,28 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return array<string, int>
+     */
+    public function countByNetworkSince(\App\Entity\Network $network, array $intervals): array
+    {
+        $counts = [];
+
+        foreach ($intervals as $key => $since) {
+            $qb = $this->createQueryBuilder('i')
+                ->select('COUNT(i.id)')
+                ->join('i.profile', 'p')
+                ->where('p.network = :network')
+                ->andWhere('i.dateTime >= :since')
+                ->setParameter('network', $network)
+                ->setParameter('since', $since);
+
+            $counts[$key] = (int) $qb->getQuery()->getSingleScalarResult();
+        }
+
+        return $counts;
+    }
+
+    /**
      * @param list<int> $networkIds
      */
     private function applyFilters(QueryBuilder $qb, ?int $profileId, array $networkIds, string $search, string $status): void

--- a/src/RssApp/Fetcher.php
+++ b/src/RssApp/Fetcher.php
@@ -29,6 +29,7 @@ abstract class Fetcher extends AbstractNetworkFeedFetcher
         $feedId = $additionalData['rss_feed_id'] ?? null;
 
         if ($feedId && !$this->rssApp->feedExists($feedId)) {
+            $this->logger->notice(sprintf('RSS.app Feed %s existiert nicht mehr für %s, suche neu.', $feedId, $sourceUrl));
             $feedId = null;
             unset($additionalData['rss_feed_id']);
         }
@@ -60,7 +61,13 @@ abstract class Fetcher extends AbstractNetworkFeedFetcher
             return $feedItemList;
 
         } catch (\Throwable $e) {
-            $this->markAsFailed($profile, 'Fehler bei RSS.app: ' . $e->getMessage());
+            $this->markAsFailed($profile, sprintf(
+                'RSS.app-Fehler für %s (Feed-ID: %s, URL: https://api.rss.app/v1/feeds/%s): %s',
+                $sourceUrl,
+                $feedId,
+                $feedId,
+                $e->getMessage(),
+            ));
             return [];
         }
     }

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -66,6 +66,24 @@
                             <div class="network-card-stat-label">Items</div>
                         </div>
                     </div>
+                    <div class="network-card-stats mt-2">
+                        <div class="network-card-stat">
+                            <div class="network-card-stat-value">{{ stat.itemCounts.last24h }}</div>
+                            <div class="network-card-stat-label">24h</div>
+                        </div>
+                        <div class="network-card-stat">
+                            <div class="network-card-stat-value">{{ stat.itemCounts.last7d }}</div>
+                            <div class="network-card-stat-label">7 Tage</div>
+                        </div>
+                        <div class="network-card-stat">
+                            <div class="network-card-stat-value">{{ stat.itemCounts.last31d }}</div>
+                            <div class="network-card-stat-label">31 Tage</div>
+                        </div>
+                        <div class="network-card-stat">
+                            <div class="network-card-stat-value">{{ stat.itemCounts.last365d }}</div>
+                            <div class="network-card-stat-label">365 Tage</div>
+                        </div>
+                    </div>
                 </a>
             </div>
         {% endfor %}

--- a/templates/profile/_form.html.twig
+++ b/templates/profile/_form.html.twig
@@ -8,7 +8,7 @@
             {{ form_row(form.identifier) }}
             {{ form_row(form.title) }}
             <div class="row">
-                <div class="col-md-6">
+                <div class="col-md-4">
                     {{ form_row(form.autoFetch) }}
                 </div>
                 <div class="col-md-4">

--- a/tests/MediaDownloader/MediaDownloadServiceTest.php
+++ b/tests/MediaDownloader/MediaDownloadServiceTest.php
@@ -9,6 +9,7 @@ use App\MediaDownloader\MediaDownloadService;
 use App\MediaDownloader\MediaUrlExtractor;
 use App\MediaDownloader\PhotoDownloader;
 use App\MediaDownloader\VideoDownloader;
+use App\MediaDownloader\YtDlpPhotoDownloader;
 use App\Repository\ItemRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ class MediaDownloadServiceTest extends TestCase
     private MediaUrlExtractor $extractor;
     private PhotoDownloader $photoDownloader;
     private VideoDownloader $videoDownloader;
+    private YtDlpPhotoDownloader $ytDlpPhotoDownloader;
     private EntityManagerInterface $em;
     private ItemRepository $itemRepository;
     private MediaDownloadService $service;
@@ -27,6 +29,7 @@ class MediaDownloadServiceTest extends TestCase
         $this->extractor = $this->createMock(MediaUrlExtractor::class);
         $this->photoDownloader = $this->createMock(PhotoDownloader::class);
         $this->videoDownloader = $this->createMock(VideoDownloader::class);
+        $this->ytDlpPhotoDownloader = $this->createMock(YtDlpPhotoDownloader::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->itemRepository = $this->createMock(ItemRepository::class);
 
@@ -34,6 +37,7 @@ class MediaDownloadServiceTest extends TestCase
             $this->extractor,
             $this->photoDownloader,
             $this->videoDownloader,
+            $this->ytDlpPhotoDownloader,
             $this->em,
             $this->itemRepository,
         );
@@ -151,6 +155,67 @@ class MediaDownloadServiceTest extends TestCase
         $this->em->expects($this->never())->method('flush');
 
         $this->service->downloadMedia($item);
+    }
+
+    public function testDownloadMediaUsesYtDlpForInstagram(): void
+    {
+        $network = new Network();
+        $network->setIdentifier('instagram_profile');
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setNetwork($network);
+        $profile->setIdentifier('test');
+
+        $item = new Item();
+        $ref = new \ReflectionProperty(Item::class, 'id');
+        $ref->setValue($item, 100);
+        $item->setProfile($profile);
+        $item->setPermalink('https://www.instagram.com/p/abc123');
+
+        $this->ytDlpPhotoDownloader->method('isAvailable')->willReturn(true);
+        $this->ytDlpPhotoDownloader->expects($this->once())
+            ->method('download')
+            ->with('https://www.instagram.com/p/abc123', 42, 100)
+            ->willReturn(['42/100/photo_00001.jpg', '42/100/photo_00002.jpg']);
+
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertSame(['42/100/photo_00001.jpg', '42/100/photo_00002.jpg'], $item->getPhotoPaths());
+    }
+
+    public function testDownloadMediaFallsBackToThumbnailWhenYtDlpFails(): void
+    {
+        $network = new Network();
+        $network->setIdentifier('instagram_profile');
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setNetwork($network);
+        $profile->setIdentifier('test');
+
+        $item = new Item();
+        $ref = new \ReflectionProperty(Item::class, 'id');
+        $ref->setValue($item, 100);
+        $item->setProfile($profile);
+        $item->setPermalink('https://www.instagram.com/p/abc123');
+
+        $this->ytDlpPhotoDownloader->method('isAvailable')->willReturn(true);
+        $this->ytDlpPhotoDownloader->method('download')->willReturn([]);
+
+        $this->extractor->method('extractPhotoUrls')->willReturn(['https://example.com/thumb.jpg']);
+        $this->extractor->method('extractVideoUrl')->willReturn(null);
+
+        $this->photoDownloader->expects($this->once())
+            ->method('download')
+            ->with('https://example.com/thumb.jpg', 42, 100, 0)
+            ->willReturn('42/100/photo_0.jpg');
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertSame(['42/100/photo_0.jpg'], $item->getPhotoPaths());
     }
 
     public function testDownloadNewItemsForProfile(): void

--- a/tests/MediaDownloader/MediaUrlExtractorTest.php
+++ b/tests/MediaDownloader/MediaUrlExtractorTest.php
@@ -77,6 +77,66 @@ class MediaUrlExtractorTest extends TestCase
         ], $this->extractor->extractPhotoUrls($item));
     }
 
+    public function testExtractPhotoUrlsFromRssAppHtmlSingleImage(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'description_html' => '<p>Caption</p><img src="https://scontent.cdninstagram.com/v/original_photo.jpg?query=1" />',
+            'thumbnail' => 'https://example.com/low_res_thumb.jpg',
+        ]));
+
+        $urls = $this->extractor->extractPhotoUrls($item);
+        $this->assertSame(['https://scontent.cdninstagram.com/v/original_photo.jpg?query=1'], $urls);
+    }
+
+    public function testExtractPhotoUrlsFromRssAppHtmlCarousel(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'description_html' => '<img src="https://cdn.example.com/photo1.jpg" /><img src="https://cdn.example.com/photo2.jpg" /><img src="https://cdn.example.com/photo3.jpg" />',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+        ]));
+
+        $urls = $this->extractor->extractPhotoUrls($item);
+        $this->assertCount(3, $urls);
+        $this->assertSame('https://cdn.example.com/photo1.jpg', $urls[0]);
+        $this->assertSame('https://cdn.example.com/photo2.jpg', $urls[1]);
+        $this->assertSame('https://cdn.example.com/photo3.jpg', $urls[2]);
+    }
+
+    public function testExtractPhotoUrlsFromRssAppHtmlDeduplicates(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'description_html' => '<img src="https://cdn.example.com/photo.jpg" /><img src="https://cdn.example.com/photo.jpg" />',
+        ]));
+
+        $urls = $this->extractor->extractPhotoUrls($item);
+        $this->assertCount(1, $urls);
+    }
+
+    public function testExtractPhotoUrlsFromRssAppHtmlSkipsRelativeUrls(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'description_html' => '<img src="/local/image.jpg" /><img src="https://cdn.example.com/photo.jpg" />',
+        ]));
+
+        $urls = $this->extractor->extractPhotoUrls($item);
+        $this->assertSame(['https://cdn.example.com/photo.jpg'], $urls);
+    }
+
+    public function testExtractPhotoUrlsFallsBackToThumbnailWhenNoHtmlImages(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'description_html' => '<p>Text only, no images</p>',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+        ]));
+
+        $this->assertSame(['https://example.com/thumb.jpg'], $this->extractor->extractPhotoUrls($item));
+    }
+
     public function testExtractPhotoUrlsReturnsEmptyForNoRaw(): void
     {
         $item = new Item();


### PR DESCRIPTION
## Summary

Final PR in the standalone-split stack. Mixed bag of late fixes and improvements that landed on `standalone` between Mar 25 and Mar 26:
- **Fetch tracking**: `lastFetchSuccessDateTime` / `lastFetchFailureDateTime` / `lastFetchFailureError` on `Profile`, displayed on the dashboard
- **Dashboard counts**: item count per time period on the network cards
- **Bug fixes**: network filter on profile list when linked from dashboard, Bluesky fetcher network identifier mismatch, DateTime type mismatch in FeedFetcher persistence, import not updating items' dateTime
- **Photo extraction improvements**: extract carousel/album images from RSS.app `description_html`, plus a `YtDlpPhotoDownloader` for Instagram/Threads/Facebook to get original-quality photos via yt-dlp
- **Error messages**: include feed URL and source URL in RSS.app error messages
- **Doc update**: CLAUDE.md and README.md refresh
- **Final reconciliation commit**: pulls in main fixes that earlier cherry-picks regressed (`phpunit`/`browser-kit`/`css-selector` in composer.json, `FeedFetcherInterface` alias in services.yaml, MastodonFeedFetcher HttpClient changes), and renames source-fetcher methods from `getSource`/`setSource` to `getParsedSource`/`setParsedSource`

After this PR, ``git diff main standalone`` is empty.

**PR 17 of 17 — final PR in the stack.** Stacked on #36.

## Commits

- `1055280` Fix network filter on profile list when linked from dashboard
- `a47e5df` Fix Bluesky fetcher network identifier to match database
- `e57489f` Track fetch success and failure timestamps on profiles
- `cc3efb5` Add item count per time period to dashboard network cards
- `d007956` Fix DateTime type mismatch in FeedFetcher profile persistence
- `b2bd5d0` Fix import updating items without updating dateTime
- `abb219c` Extract photo URLs from RSS.app description_html for carousel and original quality
- `5a80eda` Use yt-dlp for Instagram/Threads/Facebook photo downloads
- `d3be3d0` Update CLAUDE.md and README.md with recent changes
- `05fca99` Include feed URL and source URL in RSS.app error messages
- `609fdc3` Sync remaining drift with standalone tip *(synthesized final reconciliation)*

## Test plan

- [x] `bin/phpunit` — **147 tests, 351 assertions**, no errors/failures
- [x] `git diff HEAD standalone` is empty (verified)

## Stack

- Previous: #36 (`feat/media-download`)
- After this PR is merged, ``main`` equals today's ``standalone`` tip and the ``standalone`` branch can be retired.