### PR TITLE
Add kebab menu to dashboard network cards with fetch-all action

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -261,6 +261,35 @@ body.login-page .main {
 }
 
 /* ===== Network Cards ===== */
+.network-card-wrapper {
+    position: relative;
+}
+
+.network-card-menu {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+}
+
+.network-card-menu-btn {
+    background: transparent;
+    border: 0;
+    padding: 6px 10px;
+    border-radius: 8px;
+    color: #9ca3af;
+    cursor: pointer;
+    line-height: 1;
+    transition: background 0.15s, color 0.15s;
+}
+
+.network-card-menu-btn:hover,
+.network-card-menu-btn:focus {
+    background: rgba(0, 0, 0, 0.05);
+    color: #4b5563;
+    outline: none;
+}
+
 .network-card {
     background: white;
     border-radius: 12px;

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\FeedFetcher\FeedFetcher;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
@@ -16,6 +17,7 @@ class DashboardController extends AbstractController
         NetworkRepository $networkRepository,
         ProfileRepository $profileRepository,
         ItemRepository $itemRepository,
+        FeedFetcher $feedFetcher,
     ): Response {
         $networks = $networkRepository->findAll();
 
@@ -44,12 +46,18 @@ class DashboardController extends AbstractController
 
         $latestItems = $itemRepository->findBy([], ['createdAt' => 'DESC'], 10);
 
+        $fetchableNetworkIdentifiers = [];
+        foreach ($feedFetcher->getNetworkFetcherList() as $fetcher) {
+            $fetchableNetworkIdentifiers[] = $fetcher->getNetworkIdentifier();
+        }
+
         return $this->render('dashboard/index.html.twig', [
             'networkCount' => count($networks),
             'profileCount' => $profileRepository->count([]),
             'itemCount' => $itemRepository->count([]),
             'networkStats' => $networkStats,
             'latestItems' => $latestItems,
+            'fetchableNetworkIdentifiers' => $fetchableNetworkIdentifiers,
         ]);
     }
 }

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -84,4 +84,26 @@ class NetworkController extends AbstractController
 
         return $this->redirectToRoute('app_network_index');
     }
+
+    #[Route('/{id}/fetch-all', name: 'app_network_fetch_all', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function fetchAll(Request $request, Network $network): Response
+    {
+        if (!$this->isCsrfTokenValid('fetch-all-' . $network->getId(), $request->request->getString('_token'))) {
+            $this->addFlash('danger', 'Ungültiges CSRF-Token.');
+
+            return $this->redirectToRoute('app_dashboard');
+        }
+
+        $projectDir = $this->getParameter('kernel.project_dir');
+        $cmd = sprintf(
+            'nohup php %s fetch-feed %s > /dev/null 2>&1 &',
+            escapeshellarg($projectDir . '/bin/console'),
+            escapeshellarg($network->getIdentifier()),
+        );
+        exec($cmd);
+
+        $this->addFlash('success', sprintf('Import für Netzwerk "%s" wurde im Hintergrund gestartet.', $network->getName()));
+
+        return $this->redirectToRoute('app_dashboard');
+    }
 }

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -47,44 +47,65 @@
     <div class="row g-3 mb-4">
         {% for stat in networkStats %}
             <div class="col-md-4 col-lg-3">
-                <a href="{{ path('app_profile_index', {network: stat.network.id}) }}" class="network-card">
-                    <div class="network-card-header">
-                        <div class="network-card-icon" style="background: {{ stat.network.backgroundColor }};">
-                            <i class="{{ stat.network.icon }}"></i>
-                        </div>
-                        <div class="network-card-info">
-                            <h5>{{ stat.network.name }}</h5>
-                        </div>
+                <div class="network-card-wrapper">
+                    <div class="network-card-menu dropdown">
+                        <button class="network-card-menu-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Aktionen">
+                            <i class="fas fa-ellipsis-v"></i>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            {% if stat.network.identifier in fetchableNetworkIdentifiers %}
+                                <li>
+                                    <form method="post" action="{{ path('app_network_fetch_all', {id: stat.network.id}) }}" class="m-0">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('fetch-all-' ~ stat.network.id) }}">
+                                        <button type="submit" class="dropdown-item">
+                                            <i class="fas fa-sync-alt me-2"></i>Alle Profile abrufen
+                                        </button>
+                                    </form>
+                                </li>
+                            {% else %}
+                                <li><span class="dropdown-item-text text-muted small">Keine Aktionen verfügbar</span></li>
+                            {% endif %}
+                        </ul>
                     </div>
-                    <div class="network-card-stats">
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.profileCount }}</div>
-                            <div class="network-card-stat-label">Profile</div>
+                    <a href="{{ path('app_profile_index', {network: stat.network.id}) }}" class="network-card">
+                        <div class="network-card-header">
+                            <div class="network-card-icon" style="background: {{ stat.network.backgroundColor }};">
+                                <i class="{{ stat.network.icon }}"></i>
+                            </div>
+                            <div class="network-card-info">
+                                <h5>{{ stat.network.name }}</h5>
+                            </div>
                         </div>
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.itemCount }}</div>
-                            <div class="network-card-stat-label">Items</div>
+                        <div class="network-card-stats">
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.profileCount }}</div>
+                                <div class="network-card-stat-label">Profile</div>
+                            </div>
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.itemCount }}</div>
+                                <div class="network-card-stat-label">Items</div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="network-card-stats mt-2">
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.itemCounts.last24h }}</div>
-                            <div class="network-card-stat-label">24h</div>
+                        <div class="network-card-stats mt-2">
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.itemCounts.last24h }}</div>
+                                <div class="network-card-stat-label">24h</div>
+                            </div>
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.itemCounts.last7d }}</div>
+                                <div class="network-card-stat-label">7 Tage</div>
+                            </div>
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.itemCounts.last31d }}</div>
+                                <div class="network-card-stat-label">31 Tage</div>
+                            </div>
+                            <div class="network-card-stat">
+                                <div class="network-card-stat-value">{{ stat.itemCounts.last365d }}</div>
+                                <div class="network-card-stat-label">365 Tage</div>
+                            </div>
                         </div>
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.itemCounts.last7d }}</div>
-                            <div class="network-card-stat-label">7 Tage</div>
-                        </div>
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.itemCounts.last31d }}</div>
-                            <div class="network-card-stat-label">31 Tage</div>
-                        </div>
-                        <div class="network-card-stat">
-                            <div class="network-card-stat-value">{{ stat.itemCounts.last365d }}</div>
-                            <div class="network-card-stat-label">365 Tage</div>
-                        </div>
-                    </div>
-                </a>
+                    </a>
+                </div>
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- Jede Network-Card auf dem Dashboard bekommt oben rechts ein Kebab-Dropdown (Bootstrap).
- Für Netzwerke mit registriertem `NetworkFeedFetcher` erscheint der Eintrag „Alle Profile abrufen" — ein POST auf `app_network_fetch_all` spawnt `php bin/console fetch-feed <identifier>` via `nohup ... &` detachiert.
- Cards ohne Fetcher zeigen „Keine Aktionen verfügbar".
- CSRF-geschützt (`fetch-all-<id>`), Flash-Meldung auf dem Dashboard.

## Test plan
- [ ] Dashboard öffnen: jede Card hat oben rechts drei Punkte
- [ ] Klick auf Kebab einer fetchbaren Card (z.B. Homepage, Bluesky-Profil, Mastodon, Instagram/Threads/Facebook): Dropdown zeigt „Alle Profile abrufen"
- [ ] Klick auf Kebab einer nicht-fetchbaren Card (z.B. Twitter, Telegram-Chat): Dropdown zeigt „Keine Aktionen verfügbar"
- [ ] „Alle Profile abrufen" absenden → Flash-Meldung „Import … wurde im Hintergrund gestartet." erscheint, `ps aux | grep fetch-feed` zeigt laufenden Prozess
- [ ] Klick auf die Card-Fläche selbst (nicht auf den Kebab) navigiert weiterhin auf die Profilliste des Netzwerks