### PR TITLE
Hide dashboard cards for networks without profiles

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -30,6 +30,9 @@ class DashboardController extends AbstractController
         $networkStats = [];
         foreach ($networks as $network) {
             $profiles = $profileRepository->findBy(['network' => $network]);
+            if (count($profiles) === 0) {
+                continue;
+            }
             $itemCount = 0;
             foreach ($profiles as $profile) {
                 $itemCount += $itemRepository->count(['profile' => $profile]);


### PR DESCRIPTION
## Summary
- `DashboardController` überspringt Netzwerke ohne Profile vor dem Aufbau von `networkStats`.
- Spart außerdem die Item-Zählung pro Interval für leere Netzwerke.

## Test plan
- [ ] Dashboard öffnen: nur Networks mit mindestens einem Profil haben eine Card
- [ ] Networks ohne Profile (z.B. Discord-Chat, flickr, Threads-Beitrag) sind nicht mehr sichtbar
- [ ] Kachel „Netzwerke" in den Stat-Cards zeigt weiterhin alle registrierten Networks