### PR TITLE
Show item count per profile in profile list

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -26,7 +26,7 @@ class ProfileController extends AbstractController
     private const PROFILES_PER_PAGE = 50;
 
     #[Route('', name: 'app_profile_index')]
-    public function index(Request $request, ProfileRepository $profileRepository, NetworkRepository $networkRepository): Response
+    public function index(Request $request, ProfileRepository $profileRepository, NetworkRepository $networkRepository, ItemRepository $itemRepository): Response
     {
         $page = max(1, $request->query->getInt('page', 1));
         $search = trim($request->query->getString('search', ''));
@@ -42,10 +42,14 @@ class ProfileController extends AbstractController
         $page = min($page, $pages);
         $profiles = $profileRepository->findPaginated($page, self::PROFILES_PER_PAGE, $networkIds, $search, $status);
 
+        $profileIds = array_map(static fn ($p) => $p->getId(), $profiles);
+        $itemCounts = $itemRepository->countByProfileIds($profileIds);
+
         if ($request->headers->get('X-Requested-With') === 'XMLHttpRequest') {
             return new JsonResponse([
                 'html' => $this->renderView('profile/_partials/_profile_table_body.html.twig', [
                     'profiles' => $profiles,
+                    'itemCounts' => $itemCounts,
                 ]),
                 'paginationHtml' => $this->renderView('_partials/_pagination.html.twig', [
                     'page' => $page,
@@ -60,6 +64,7 @@ class ProfileController extends AbstractController
 
         return $this->render('profile/index.html.twig', [
             'profiles' => $profiles,
+            'itemCounts' => $itemCounts,
             'networks' => $networkRepository->findBy([], ['name' => 'ASC']),
             'page' => $page,
             'pages' => $pages,

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -62,6 +62,32 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * @param list<int> $profileIds
+     * @return array<int, int> map of profile id => item count (missing keys mean zero)
+     */
+    public function countByProfileIds(array $profileIds): array
+    {
+        if ($profileIds === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('i')
+            ->select('IDENTITY(i.profile) AS profileId, COUNT(i.id) AS itemCount')
+            ->where('i.profile IN (:profileIds)')
+            ->setParameter('profileIds', $profileIds)
+            ->groupBy('i.profile')
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['profileId']] = (int) $row['itemCount'];
+        }
+
+        return $counts;
+    }
+
+    /**
      * @return array<string, int>
      */
     public function countByNetworkSince(\App\Entity\Network $network, array $intervals): array

--- a/templates/profile/_partials/_profile_table_body.html.twig
+++ b/templates/profile/_partials/_profile_table_body.html.twig
@@ -13,6 +13,9 @@
                 {{ profile.displayName }}
             </a>
         </td>
+        <td class="text-end">
+            {{ itemCounts[profile.id]|default(0)|number_format(0, ',', '.') }}
+        </td>
         <td>
             {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'autoFetch', state: profile.autoFetch } %}
         </td>
@@ -69,6 +72,6 @@
     </tr>
 {% else %}
     <tr>
-        <td colspan="9" class="text-center text-muted py-4">Keine Profile gefunden.</td>
+        <td colspan="10" class="text-center text-muted py-4">Keine Profile gefunden.</td>
     </tr>
 {% endfor %}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -111,6 +111,7 @@
                         <th>ID</th>
                         <th>Netzwerk</th>
                         <th>Profil</th>
+                        <th>Beiträge</th>
                         <th>Auto-Fetch</th>
                         <th>Quelltext</th>
                         <th>Fotos</th>
@@ -120,7 +121,7 @@
                     </tr>
                 </thead>
                 <tbody data-profile-list-target="tableBody">
-                    {% include 'profile/_partials/_profile_table_body.html.twig' with { profiles: profiles } %}
+                    {% include 'profile/_partials/_profile_table_body.html.twig' with { profiles: profiles, itemCounts: itemCounts } %}
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
## Summary
- Neue Spalte „Beiträge" in der Profile-Übersicht zwischen Profil-Name und Auto-Fetch.
- `ItemRepository::countByProfileIds()` holt die Zählungen für alle sichtbaren Profile in einer aggregierten Query (GROUP BY).
- AJAX-Pagination/Filter funktionieren weiterhin — der Controller übergibt `itemCounts` auch im XHR-Branch an das Body-Partial.

## Test plan
- [ ] `/profiles` öffnen: Spalte „Beiträge" mit Zahlen ist sichtbar
- [ ] Nach Netzwerk filtern (z.B. Homepage): Zahlen stimmen mit den Item-Zählern in der Profil-Detailansicht überein
- [ ] Seiten blättern: AJAX-Reload zeigt weiterhin die Beiträge-Spalte
- [ ] Leere Liste (z.B. Netzwerk ohne Profile): „Keine Profile gefunden." überspannt alle 10 Spalten