### PR TITLE
Add RSS.app profile overview with sortable DataTable and delete action

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,11 @@ The admin interface is accessible after login at `/login`. It provides:
 - **Dashboard** — Overview with network statistics (item counts per 24h/7d/31d/365d by publication date), profile/item counts, and a table of recent items
 - **Networks** — CRUD for social networks (name, icon, color, cron schedule)
 - **Profiles** — Searchable/filterable list with auto-fetch toggle, save photos/videos toggles, fetch status, manual fetch trigger, RSS.app registration
+- **RSS.app** — Overview of all profiles linked to an RSS.app feed (sortable DataTable), showing feed ID and last-post date. Per-row button to delete the feed at RSS.app and unlink it locally.
 - **Items** — Searchable/filterable list with hide/delete toggles, media status indicators, network and profile filters, manual media download
 - **Clients** — API client management with token display, enable/disable
 
-The frontend uses Bootstrap 5, Stimulus controllers for interactive features (toggles, AJAX pagination, search), and Handlebars for client-side template rendering. Assets are managed via Symfony Asset Mapper (no build step needed).
+The frontend uses Bootstrap 5, Stimulus controllers for interactive features (toggles, AJAX pagination, search), Handlebars for client-side template rendering, and DataTables for client-side sortable tables (RSS.app overview). Assets are managed via Symfony Asset Mapper (no build step needed).
 
 ## REST API
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,5 @@
 import './stimulus_bootstrap.js';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap';
+import 'datatables.net-bs5/css/dataTables.bootstrap5.min.css';
 import './styles/app.css';

--- a/assets/controllers/rssapp_table_controller.js
+++ b/assets/controllers/rssapp_table_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus';
+import DataTable from 'datatables.net-bs5';
+
+export default class extends Controller {
+    connect() {
+        this.dt = new DataTable(this.element, {
+            paging: true,
+            pageLength: 50,
+            lengthMenu: [25, 50, 100, 200],
+            searching: true,
+            order: [[4, 'desc']],
+            language: {
+                search: 'Suche:',
+                lengthMenu: '_MENU_ Einträge anzeigen',
+                info: '_START_–_END_ von _TOTAL_ Einträgen',
+                infoEmpty: 'Keine Einträge',
+                infoFiltered: '(gefiltert aus _MAX_)',
+                paginate: { first: 'Erste', last: 'Letzte', next: 'Weiter', previous: 'Zurück' },
+                emptyTable: 'Keine Profile mit RSS.app-Verknüpfung vorhanden.',
+                zeroRecords: 'Keine passenden Einträge gefunden.',
+            },
+        });
+    }
+
+    disconnect() {
+        if (this.dt) {
+            this.dt.destroy();
+            this.dt = null;
+        }
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -35,4 +35,17 @@ return [
     'handlebars' => [
         'version' => '4.7.8',
     ],
+    'datatables.net' => [
+        'version' => '2.3.7',
+    ],
+    'datatables.net-bs5' => [
+        'version' => '2.3.7',
+    ],
+    'jquery' => [
+        'version' => '4.0.0',
+    ],
+    'datatables.net-bs5/css/dataTables.bootstrap5.min.css' => [
+        'version' => '2.3.7',
+        'type' => 'css',
+    ],
 ];

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -158,22 +158,39 @@ class ProfileController extends AbstractController
     #[Route('/{id}/rssapp-delete', name: 'app_profile_rssapp_delete', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function rssappDelete(Request $request, Profile $profile, RssAppInterface $rssApp, EntityManagerInterface $em): Response
     {
-        if ($this->isCsrfTokenValid('rssapp-' . $profile->getId(), $request->request->getString('_token'))) {
-            $additionalData = $profile->getAdditionalData() ?? [];
-
-            if (isset($additionalData['rss_feed_id'])) {
-                $rssApp->deleteFeed($additionalData['rss_feed_id']);
-
-                unset($additionalData['rss_feed_id']);
-                $profile->setAdditionalData($additionalData);
-
-                $em->flush();
-
-                $this->addFlash('success', 'Feed wurde von RSS.app entfernt.');
-            }
-        }
+        $this->unlinkRssAppFeed($request, $profile, $rssApp, $em);
 
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
+    #[Route('/{id}/rssapp-delete-from-list', name: 'app_rssapp_profile_delete', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function rssappDeleteFromList(Request $request, Profile $profile, RssAppInterface $rssApp, EntityManagerInterface $em): Response
+    {
+        $this->unlinkRssAppFeed($request, $profile, $rssApp, $em);
+
+        return $this->redirectToRoute('app_rssapp_profile_index');
+    }
+
+    private function unlinkRssAppFeed(Request $request, Profile $profile, RssAppInterface $rssApp, EntityManagerInterface $em): void
+    {
+        if (!$this->isCsrfTokenValid('rssapp-' . $profile->getId(), $request->request->getString('_token'))) {
+            return;
+        }
+
+        $additionalData = $profile->getAdditionalData() ?? [];
+
+        if (!isset($additionalData['rss_feed_id'])) {
+            return;
+        }
+
+        $rssApp->deleteFeed($additionalData['rss_feed_id']);
+
+        unset($additionalData['rss_feed_id']);
+        $profile->setAdditionalData($additionalData);
+
+        $em->flush();
+
+        $this->addFlash('success', 'Feed wurde von RSS.app entfernt.');
     }
 
     #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource|savePhotos|saveVideos'], methods: ['POST'])]

--- a/src/Controller/RssAppProfileController.php
+++ b/src/Controller/RssAppProfileController.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\ItemRepository;
+use App\Repository\ProfileRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/rssapp-profiles')]
+class RssAppProfileController extends AbstractController
+{
+    #[Route('', name: 'app_rssapp_profile_index')]
+    public function index(ProfileRepository $profileRepository, ItemRepository $itemRepository): Response
+    {
+        $profiles = $profileRepository->findWithRssAppFeedId();
+        $profileIds = array_map(static fn ($p) => $p->getId(), $profiles);
+        $lastItemDates = $itemRepository->findLastItemDateByProfileIds($profileIds);
+
+        return $this->render('rssapp_profile/index.html.twig', [
+            'profiles' => $profiles,
+            'lastItemDates' => $lastItemDates,
+        ]);
+    }
+}

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -62,6 +62,35 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * @param list<int> $profileIds
+     * @return array<int, \DateTimeImmutable> map of profile id => last item dateTime
+     */
+    public function findLastItemDateByProfileIds(array $profileIds): array
+    {
+        if ($profileIds === []) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('i')
+            ->select('IDENTITY(i.profile) AS profileId, MAX(i.dateTime) AS lastDate')
+            ->where('i.profile IN (:profileIds)')
+            ->setParameter('profileIds', $profileIds)
+            ->groupBy('i.profile')
+            ->getQuery()
+            ->getArrayResult();
+
+        $dates = [];
+        foreach ($rows as $row) {
+            if ($row['lastDate'] === null) {
+                continue;
+            }
+            $dates[(int) $row['profileId']] = new \DateTimeImmutable((string) $row['lastDate']);
+        }
+
+        return $dates;
+    }
+
+    /**
      * @return array<string, int>
      */
     public function countByNetworkSince(\App\Entity\Network $network, array $intervals): array

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -21,6 +21,22 @@ class ProfileRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return list<Profile>
+     */
+    public function findWithRssAppFeedId(): array
+    {
+        return $this->createQueryBuilder('p')
+            ->leftJoin('p.network', 'n')
+            ->addSelect('n')
+            ->where('p.additionalData LIKE :key')
+            ->andWhere('p.deleted = false')
+            ->setParameter('key', '%"rss_feed_id"%')
+            ->orderBy('p.identifier', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * @param list<int> $networkIds
      * @return list<Profile>
      */

--- a/templates/_partials/_sidebar.html.twig
+++ b/templates/_partials/_sidebar.html.twig
@@ -23,6 +23,10 @@
             <span class="nav-icon"><i class="fas fa-users"></i></span>
             Profiles
         </a></li>
+        <li><a href="{{ path('app_rssapp_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_profile' %}active{% endif %}">
+            <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
+            RSS.app
+        </a></li>
         <li><a href="{{ path('app_item_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_item' %}active{% endif %}">
             <span class="nav-icon"><i class="fas fa-stream"></i></span>
             Items

--- a/templates/rssapp_profile/index.html.twig
+++ b/templates/rssapp_profile/index.html.twig
@@ -1,0 +1,74 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}RSS.app-Profile - Social Network Fetcher{% endblock %}
+
+{% block page_title %}RSS.app-Profile <span class="badge text-bg-secondary fs-6">{{ profiles|length }}</span>{% endblock %}
+
+{% block body %}
+    <div class="data-card">
+        <div class="data-card-body">
+            <table class="data-table table" data-controller="rssapp-table">
+                <thead>
+                    <tr>
+                        <th>Netzwerk</th>
+                        <th>Profil</th>
+                        <th>Identifier</th>
+                        <th>RSS-Feed-ID</th>
+                        <th>Letzter Beitrag</th>
+                        <th data-orderable="false">Aktionen</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for profile in profiles %}
+                        {% set feedId = profile.additionalData.rss_feed_id|default('') %}
+                        {% set lastDate = lastItemDates[profile.id]|default(null) %}
+                        <tr>
+                            <td>
+                                {% if profile.network %}
+                                    <span class="badge badge-network" style="background-color: {{ profile.network.backgroundColor }}; color: {{ profile.network.textColor }};">
+                                        <i class="{{ profile.network.icon }} me-1"></i>{{ profile.network.name }}
+                                    </span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <a href="{{ path('app_profile_show', {id: profile.id}) }}">
+                                    {{ profile.displayName }}
+                                </a>
+                            </td>
+                            <td>
+                                <a href="{{ profile.identifier }}" target="_blank" rel="noopener" class="text-muted">
+                                    {{ profile.identifier }}
+                                </a>
+                            </td>
+                            <td><code>{{ feedId }}</code></td>
+                            <td data-order="{{ lastDate ? lastDate.timestamp : 0 }}">
+                                {% if lastDate %}
+                                    <span title="{{ lastDate|date('d.m.Y H:i:s') }}">{{ lastDate|date('d.m.Y H:i') }}</span>
+                                {% else %}
+                                    <span class="text-muted">–</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <div class="d-flex gap-1">
+                                    <a href="{{ path('app_profile_show', {id: profile.id}) }}" class="action-btn" title="Profil anzeigen">
+                                        <i class="fas fa-eye"></i>
+                                    </a>
+                                    <form method="post" action="{{ path('app_rssapp_profile_delete', {id: profile.id}) }}"
+                                          data-controller="confirm"
+                                          data-confirm-message-value="Feed für &quot;{{ profile.displayName }}&quot; bei RSS.app wirklich löschen?">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('rssapp-' ~ profile.id) }}">
+                                        <button type="submit" class="action-btn" title="Bei RSS.app löschen">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    {% include '_partials/_delete_modal.html.twig' %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- New `/rssapp-profiles` page lists all profiles linked to an RSS.app feed with columns for network, display name, identifier, feed ID and last-post date, plus a per-row delete button that removes the feed at RSS.app and unlinks it locally.
- DataTables (client-side) drives sorting, search and pagination; the last-post column uses `data-order` with epoch timestamps so sorting is timestamp-correct regardless of formatted display.
- Reuses the existing unlink logic from `ProfileController::rssappDelete` by extracting it into a shared private helper and adding a list-scoped route that redirects back to the overview instead of the profile page.

## Test plan
- [x] `bin/phpunit` — 147 tests, 351 assertions, OK
- [x] `php bin/console lint:twig` on the new templates — valid
- [x] `php bin/console lint:container` — OK
- [x] `php bin/console debug:router` — `app_rssapp_profile_index` and `app_rssapp_profile_delete` registered
- [ ] Manual: log in at `/login`, open `/rssapp-profiles`, check that rows, sorting (especially "Letzter Beitrag" desc default), search and pagination work
- [ ] Manual: click the trash button on one row, confirm in modal, verify the row disappears, a success flash is shown, the profile detail page offers "Bei RSS.app registrieren" again, and the feed is actually gone from RSS.app (e.g. via `php bin/console app:rssapp:sync-feed-ids --dry-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)