### PR TITLE
Auto-register RSS.app feed when creating profiles via Web UI

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -12,6 +12,7 @@ use App\Model\Profile as ModelProfile;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
+use App\RssApp\FeedRegistrar;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -76,7 +77,7 @@ class ProfileController extends AbstractController
     }
 
     #[Route('/new', name: 'app_profile_new')]
-    public function new(Request $request, EntityManagerInterface $em): Response
+    public function new(Request $request, EntityManagerInterface $em, FeedRegistrar $feedRegistrar): Response
     {
         $profile = new Profile();
         $profile->setCreatedAt(new \DateTimeImmutable());
@@ -86,9 +87,15 @@ class ProfileController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $em->persist($profile);
+
+            $registered = $feedRegistrar->registerIfNeeded($profile);
+
             $em->flush();
 
-            $this->addFlash('success', 'Profil wurde erstellt.');
+            $this->addFlash('success', $registered
+                ? 'Profil wurde erstellt und bei RSS.app registriert.'
+                : 'Profil wurde erstellt.'
+            );
 
             return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
         }

--- a/src/RssApp/FeedRegistrar.php
+++ b/src/RssApp/FeedRegistrar.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\RssApp;
+
+use App\Entity\Profile;
+use Psr\Log\LoggerInterface;
+
+class FeedRegistrar
+{
+    public const RSS_APP_NETWORKS = ['instagram_profile', 'facebook_profile', 'thread'];
+
+    public function __construct(
+        private readonly RssAppInterface $rssApp,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function registerIfNeeded(Profile $profile): bool
+    {
+        $networkIdentifier = $profile->getNetwork()?->getIdentifier();
+
+        if (!in_array($networkIdentifier, self::RSS_APP_NETWORKS, true)) {
+            return false;
+        }
+
+        $additionalData = $profile->getAdditionalData() ?? [];
+
+        if (isset($additionalData['rss_feed_id'])) {
+            return false;
+        }
+
+        try {
+            $feedData = $this->rssApp->createFeed($profile->getIdentifier());
+            $additionalData['rss_feed_id'] = $feedData['id'];
+            $profile->setAdditionalData($additionalData);
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->error('RSS.app feed registration failed for {identifier}: {message}', [
+                'identifier' => $profile->getIdentifier(),
+                'message' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+}

--- a/src/State/ClientScopedProfileProcessor.php
+++ b/src/State/ClientScopedProfileProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\Client;
 use App\Entity\Profile;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
+use App\RssApp\FeedRegistrar;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -18,14 +19,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /** @implements ProcessorInterface<Profile, Profile|null> */
 class ClientScopedProfileProcessor implements ProcessorInterface
 {
-    private const RSS_APP_NETWORKS = ['instagram_profile', 'facebook_profile', 'thread'];
-
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly Security $security,
         private readonly ProfileRepository $profileRepository,
         private readonly NetworkRepository $networkRepository,
         private readonly RssAppInterface $rssApp,
+        private readonly FeedRegistrar $feedRegistrar,
     ) {
     }
 
@@ -72,7 +72,7 @@ class ClientScopedProfileProcessor implements ProcessorInterface
             $existingProfile->setDeletedAt(null);
             $client->addProfile($existingProfile);
 
-            $this->registerRssAppIfNeeded($existingProfile);
+            $this->feedRegistrar->registerIfNeeded($existingProfile);
 
             $this->em->flush();
 
@@ -83,7 +83,7 @@ class ClientScopedProfileProcessor implements ProcessorInterface
         $this->em->persist($data);
         $client->addProfile($data);
 
-        $this->registerRssAppIfNeeded($data);
+        $this->feedRegistrar->registerIfNeeded($data);
 
         $this->em->flush();
 
@@ -118,29 +118,6 @@ class ClientScopedProfileProcessor implements ProcessorInterface
         }
 
         return null;
-    }
-
-    private function registerRssAppIfNeeded(Profile $profile): void
-    {
-        $networkIdentifier = $profile->getNetwork()?->getIdentifier();
-
-        if (!in_array($networkIdentifier, self::RSS_APP_NETWORKS, true)) {
-            return;
-        }
-
-        $additionalData = $profile->getAdditionalData() ?? [];
-
-        if (isset($additionalData['rss_feed_id'])) {
-            return;
-        }
-
-        try {
-            $feedData = $this->rssApp->createFeed($profile->getIdentifier());
-            $additionalData['rss_feed_id'] = $feedData['id'];
-            $profile->setAdditionalData($additionalData);
-        } catch (\Throwable) {
-            // RSS.app registration failure should not block profile creation
-        }
     }
 
     private function deleteRssAppFeedIfNeeded(Profile $profile): void


### PR DESCRIPTION
## Summary
- Extracts the RSS.app feed registration (network whitelist, idempotency check, `createFeed` call) from `ClientScopedProfileProcessor` into a new `App\RssApp\FeedRegistrar` service so the same logic can be reused outside the API path.
- Wires `FeedRegistrar` into `ProfileController::new()` so creating an Instagram/Facebook/Threads profile through the Web UI automatically registers a feed at RSS.app — same behavior the REST API already had. Flash message reflects whether registration happened.
- Failures during `createFeed` no longer fail silently: the registrar logs an error so we can see when RSS.app rejects a URL, while still letting the profile creation succeed.

## Test plan
- [x] `bin/phpunit` — 147 tests, 351 assertions, OK
- [x] `php bin/console debug:container App\\RssApp\\FeedRegistrar` — autowired with `RssAppInterface` + `LoggerInterface`
- [ ] Manual: log in at `/login`, open `/profiles/new`, create a new Instagram profile with a real Instagram URL, verify the success flash mentions RSS.app and the profile detail shows an `rss_feed_id` (no longer the manual button)
- [ ] Manual: create a Mastodon profile via the same form, verify the flash is the plain success message and no RSS.app feed was created
- [ ] Manual: POST `/api/profiles` with an Instagram URL, verify behavior is unchanged (regression check on the API path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)