### PR TITLE
Add page listing RSS.app feeds without a local profile

### DIFF
--- a/src/Controller/RssAppOrphanFeedController.php
+++ b/src/Controller/RssAppOrphanFeedController.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\ProfileRepository;
+use App\RssApp\RssAppInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/rssapp/orphan-feeds')]
+class RssAppOrphanFeedController extends AbstractController
+{
+    public function __construct(
+        private readonly RssAppInterface $rssApp,
+        private readonly ProfileRepository $profileRepository,
+    ) {
+    }
+
+    #[Route('', name: 'app_rssapp_orphan_feed_index', methods: ['GET'])]
+    public function index(): Response
+    {
+        $feeds = $this->rssApp->listFeeds();
+        $profiles = $this->profileRepository->findAll();
+
+        $knownFeedIds = [];
+        $knownSourceUrls = [];
+
+        foreach ($profiles as $profile) {
+            $additionalData = $profile->getAdditionalData() ?? [];
+            $feedId = $additionalData['rss_feed_id'] ?? null;
+            if ($feedId !== null) {
+                $knownFeedIds[$feedId] = true;
+            }
+
+            $identifier = $profile->getIdentifier();
+            if ($identifier !== null) {
+                $knownSourceUrls[$this->normalizeUrl($identifier)] = true;
+            }
+        }
+
+        $orphans = [];
+        foreach ($feeds as $feed) {
+            $feedId = $feed['id'] ?? null;
+            $sourceUrl = $feed['source_url'] ?? null;
+
+            if ($feedId !== null && isset($knownFeedIds[$feedId])) {
+                continue;
+            }
+
+            if ($sourceUrl !== null && isset($knownSourceUrls[$this->normalizeUrl($sourceUrl)])) {
+                continue;
+            }
+
+            $orphans[] = $feed;
+        }
+
+        return $this->render('rssapp_orphan_feed/index.html.twig', [
+            'orphans' => $orphans,
+            'totalFeeds' => count($feeds),
+        ]);
+    }
+
+    #[Route('/{feedId}/delete', name: 'app_rssapp_orphan_feed_delete', methods: ['POST'])]
+    public function delete(Request $request, string $feedId): Response
+    {
+        if ($this->isCsrfTokenValid('rssapp-orphan-' . $feedId, $request->request->getString('_token'))) {
+            $this->rssApp->deleteFeed($feedId);
+            $this->addFlash('success', 'Feed wurde bei RSS.app entfernt.');
+        }
+
+        return $this->redirectToRoute('app_rssapp_orphan_feed_index');
+    }
+
+    private function normalizeUrl(string $url): string
+    {
+        $url = strtolower(trim($url));
+        $url = rtrim($url, '/');
+        $url = preg_replace('#^https?://(www\.)?#', '', $url);
+
+        return $url;
+    }
+}

--- a/templates/_partials/_sidebar.html.twig
+++ b/templates/_partials/_sidebar.html.twig
@@ -31,6 +31,10 @@
             <span class="nav-icon"><i class="fas fa-id-badge"></i></span>
             Clients
         </a></li>
+        <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
+            <span class="nav-icon"><i class="fas fa-unlink"></i></span>
+            RSS.app Verwaiste Feeds
+        </a></li>
     </ul>
 
     <div class="sidebar-footer">

--- a/templates/_partials/_sidebar.html.twig
+++ b/templates/_partials/_sidebar.html.twig
@@ -27,6 +27,10 @@
             <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
             RSS.app
         </a></li>
+        <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
+            <span class="nav-icon"><i class="fas fa-unlink"></i></span>
+            RSS.app Verwaiste Feeds
+        </a></li>
         <li><a href="{{ path('app_item_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_item' %}active{% endif %}">
             <span class="nav-icon"><i class="fas fa-stream"></i></span>
             Items
@@ -34,10 +38,6 @@
         <li><a href="{{ path('app_client_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_client' %}active{% endif %}">
             <span class="nav-icon"><i class="fas fa-id-badge"></i></span>
             Clients
-        </a></li>
-        <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-unlink"></i></span>
-            RSS.app Verwaiste Feeds
         </a></li>
     </ul>
 

--- a/templates/rssapp_orphan_feed/index.html.twig
+++ b/templates/rssapp_orphan_feed/index.html.twig
@@ -1,0 +1,70 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}RSS.app Verwaiste Feeds - Social Network Fetcher{% endblock %}
+
+{% block page_title %}RSS.app Verwaiste Feeds{% endblock %}
+
+{% block body %}
+    <div class="alert alert-info mb-3">
+        <i class="fas fa-info-circle me-1"></i>
+        {{ orphans|length }} von {{ totalFeeds }} Feed{{ totalFeeds == 1 ? '' : 's' }} bei RSS.app haben kein passendes Profil in dieser Anwendung.
+    </div>
+
+    {% if orphans is empty %}
+        <div class="alert alert-success">
+            <i class="fas fa-check-circle me-1"></i>
+            Alle RSS.app-Feeds haben ein passendes Profil.
+        </div>
+    {% else %}
+        <div class="data-card">
+            <div class="data-card-body">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Feed-ID</th>
+                            <th>Titel</th>
+                            <th>Source URL</th>
+                            <th>Erstellt</th>
+                            <th>Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for feed in orphans %}
+                            <tr>
+                                <td><code>{{ feed.id ?? '-' }}</code></td>
+                                <td>{{ feed.title ?? '-' }}</td>
+                                <td>
+                                    {% if feed.source_url is defined and feed.source_url %}
+                                        <a href="{{ feed.source_url }}" target="_blank" rel="noopener noreferrer">
+                                            {{ feed.source_url }}
+                                        </a>
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if feed.created_at is defined and feed.created_at %}
+                                        {{ feed.created_at }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <form method="post" action="{{ path('app_rssapp_orphan_feed_delete', {feedId: feed.id}) }}"
+                                          class="d-inline"
+                                          data-controller="confirm"
+                                          data-confirm-message-value="Feed &quot;{{ feed.id }}&quot; wirklich bei RSS.app löschen?">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('rssapp-orphan-' ~ feed.id) }}">
+                                        <button type="submit" class="action-btn" title="Bei RSS.app entfernen">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- New `/rssapp/orphan-feeds` page lists every feed that exists at RSS.app but has no matching local `Profile`. Cross-checks both directions: by `additionalData.rss_feed_id` and by `Profile.identifier` matched against the feed's `source_url` (URL normalisation mirrors `SyncRssAppFeedIdsCommand`).
- Each row offers a CSRF-protected delete button that removes the orphan feed at RSS.app.
- Sidebar gains a "RSS.app Verwaiste Feeds" entry, grouped directly below the existing "RSS.app" overview link so both RSS.app pages sit together.

## Test plan
- [x] `bin/phpunit` — 147 tests, 351 assertions, OK
- [x] `php bin/console lint:twig templates/rssapp_orphan_feed/` — valid
- [x] `php bin/console debug:router | grep rssapp_orphan` — both routes registered
- [x] `php bin/console debug:container App\\Controller\\RssAppOrphanFeedController` — autowired with `RssAppInterface` + `ProfileRepository`
- [ ] Manual: log in at `/login`, open `/rssapp/orphan-feeds`, verify the count message, table rows, and orphan vs. linked classification (use `app:rssapp:sync-feed-ids --dry-run` to cross-check)
- [ ] Manual: click the trash button on an orphan row, confirm in the modal, verify the feed is gone from RSS.app and the row disappears after the redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)