### PR TITLE
Import last 100 items when new profile already has an RSS.app feed

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -13,6 +13,7 @@ use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
 use App\RssApp\FeedRegistrar;
+use App\RssApp\RegistrationResult;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -87,15 +88,13 @@ class ProfileController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $em->persist($profile);
+            $em->flush();
 
-            $registered = $feedRegistrar->registerIfNeeded($profile);
+            $result = $feedRegistrar->registerIfNeeded($profile);
 
             $em->flush();
 
-            $this->addFlash('success', $registered
-                ? 'Profil wurde erstellt und bei RSS.app registriert.'
-                : 'Profil wurde erstellt.'
-            );
+            $this->addFlash('success', $this->buildCreationFlashMessage($result));
 
             return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
         }
@@ -103,6 +102,23 @@ class ProfileController extends AbstractController
         return $this->render('profile/new.html.twig', [
             'form' => $form,
         ]);
+    }
+
+    private function buildCreationFlashMessage(RegistrationResult $result): string
+    {
+        if (!$result->registered) {
+            return 'Profil wurde erstellt.';
+        }
+
+        if ($result->linkedToExistingFeed) {
+            return sprintf(
+                'Profil wurde erstellt, mit bestehendem RSS.app-Feed verknüpft und %d Item%s importiert.',
+                $result->importedItems,
+                $result->importedItems === 1 ? '' : 's',
+            );
+        }
+
+        return 'Profil wurde erstellt und bei RSS.app registriert.';
     }
 
     #[Route('/{id}', name: 'app_profile_show', requirements: ['id' => '\d+'])]

--- a/src/RssApp/FeedRegistrar.php
+++ b/src/RssApp/FeedRegistrar.php
@@ -3,45 +3,124 @@
 namespace App\RssApp;
 
 use App\Entity\Profile;
+use App\FeedFetcher\FeedFetcherInterface;
+use App\FeedFetcher\FetchInfo;
+use App\FeedFetcher\FetchResult;
+use App\FeedItemPersister\FeedItemPersisterInterface;
+use App\Model\Profile as ModelProfile;
 use Psr\Log\LoggerInterface;
 
 class FeedRegistrar
 {
     public const RSS_APP_NETWORKS = ['instagram_profile', 'facebook_profile', 'thread'];
+    public const INITIAL_IMPORT_COUNT = 100;
 
     public function __construct(
         private readonly RssAppInterface $rssApp,
         private readonly LoggerInterface $logger,
+        private readonly FeedFetcherInterface $feedFetcher,
+        private readonly FeedItemPersisterInterface $feedItemPersister,
     ) {
     }
 
-    public function registerIfNeeded(Profile $profile): bool
+    public function registerIfNeeded(Profile $profile): RegistrationResult
     {
         $networkIdentifier = $profile->getNetwork()?->getIdentifier();
 
         if (!in_array($networkIdentifier, self::RSS_APP_NETWORKS, true)) {
-            return false;
+            return RegistrationResult::notApplicable();
         }
 
         $additionalData = $profile->getAdditionalData() ?? [];
 
         if (isset($additionalData['rss_feed_id'])) {
-            return false;
+            return RegistrationResult::notApplicable();
+        }
+
+        $sourceUrl = $profile->getIdentifier();
+
+        if ($sourceUrl === null) {
+            return RegistrationResult::notApplicable();
         }
 
         try {
-            $feedData = $this->rssApp->createFeed($profile->getIdentifier());
+            $existingFeedId = $this->rssApp->findRssAppFeedIdBySourceUrl($sourceUrl);
+
+            if ($existingFeedId !== null) {
+                $additionalData['rss_feed_id'] = $existingFeedId;
+                $profile->setAdditionalData($additionalData);
+
+                $importedCount = $this->importInitialItems($profile);
+
+                return RegistrationResult::linkedToExisting($importedCount);
+            }
+
+            $feedData = $this->rssApp->createFeed($sourceUrl);
             $additionalData['rss_feed_id'] = $feedData['id'];
             $profile->setAdditionalData($additionalData);
 
-            return true;
+            return RegistrationResult::newlyCreated();
         } catch (\Throwable $e) {
             $this->logger->error('RSS.app feed registration failed for {identifier}: {message}', [
+                'identifier' => $sourceUrl,
+                'message' => $e->getMessage(),
+            ]);
+
+            return RegistrationResult::notApplicable();
+        }
+    }
+
+    private function importInitialItems(Profile $profile): int
+    {
+        if ($profile->getId() === null) {
+            $this->logger->warning('Cannot import initial RSS.app items: profile has no ID yet ({identifier}).', [
+                'identifier' => $profile->getIdentifier(),
+            ]);
+
+            return 0;
+        }
+
+        $modelProfile = new ModelProfile();
+        $modelProfile->setId($profile->getId());
+        $modelProfile->setIdentifier($profile->getIdentifier());
+        $modelProfile->setNetwork($profile->getNetwork()->getIdentifier());
+        $modelProfile->setAdditionalData($profile->getAdditionalData());
+
+        $fetcher = null;
+        foreach ($this->feedFetcher->getNetworkFetcherList() as $networkFetcher) {
+            if ($networkFetcher->supports($modelProfile)) {
+                $fetcher = $networkFetcher;
+                break;
+            }
+        }
+
+        if ($fetcher === null) {
+            $this->logger->warning('No fetcher available for network "{network}" — skipping initial RSS.app import.', [
+                'network' => $modelProfile->getNetwork(),
+            ]);
+
+            return 0;
+        }
+
+        $fetchInfo = new FetchInfo();
+        $fetchInfo->setCount(self::INITIAL_IMPORT_COUNT);
+
+        try {
+            $feedItemList = $fetcher->fetch($modelProfile, $fetchInfo);
+        } catch (\Throwable $e) {
+            $this->logger->error('Initial RSS.app import failed for {identifier}: {message}', [
                 'identifier' => $profile->getIdentifier(),
                 'message' => $e->getMessage(),
             ]);
 
-            return false;
+            return 0;
         }
+
+        $fetchResult = new FetchResult();
+        $fetchResult->setProfile($modelProfile)->setCounterFetched(count($feedItemList));
+
+        $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+
+        return count($feedItemList);
     }
 }

--- a/src/RssApp/RegistrationResult.php
+++ b/src/RssApp/RegistrationResult.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\RssApp;
+
+final class RegistrationResult
+{
+    public function __construct(
+        public readonly bool $registered,
+        public readonly bool $linkedToExistingFeed,
+        public readonly int $importedItems,
+    ) {
+    }
+
+    public static function notApplicable(): self
+    {
+        return new self(false, false, 0);
+    }
+
+    public static function newlyCreated(): self
+    {
+        return new self(true, false, 0);
+    }
+
+    public static function linkedToExisting(int $importedItems): self
+    {
+        return new self(true, true, $importedItems);
+    }
+}

--- a/src/State/ClientScopedProfileProcessor.php
+++ b/src/State/ClientScopedProfileProcessor.php
@@ -82,6 +82,7 @@ class ClientScopedProfileProcessor implements ProcessorInterface
         $data->setCreatedAt(new \DateTimeImmutable());
         $this->em->persist($data);
         $client->addProfile($data);
+        $this->em->flush();
 
         $this->feedRegistrar->registerIfNeeded($data);
 

--- a/tests/Unit/RssApp/FeedRegistrarTest.php
+++ b/tests/Unit/RssApp/FeedRegistrarTest.php
@@ -1,0 +1,174 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\RssApp;
+
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\FeedFetcher\FeedFetcherInterface;
+use App\FeedItemPersister\FeedItemPersisterInterface;
+use App\Model\Item as ItemModel;
+use App\Model\Profile as ModelProfile;
+use App\NetworkFeedFetcher\NetworkFeedFetcherInterface;
+use App\RssApp\FeedRegistrar;
+use App\RssApp\RssAppInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FeedRegistrarTest extends TestCase
+{
+    private RssAppInterface $rssApp;
+    private FeedFetcherInterface $feedFetcher;
+    private FeedItemPersisterInterface $feedItemPersister;
+    private FeedRegistrar $registrar;
+
+    protected function setUp(): void
+    {
+        $this->rssApp = $this->createMock(RssAppInterface::class);
+        $this->feedFetcher = $this->createMock(FeedFetcherInterface::class);
+        $this->feedItemPersister = $this->createMock(FeedItemPersisterInterface::class);
+
+        $this->registrar = new FeedRegistrar(
+            $this->rssApp,
+            new NullLogger(),
+            $this->feedFetcher,
+            $this->feedItemPersister,
+        );
+    }
+
+    public function testNotApplicableWhenNetworkNotInWhitelist(): void
+    {
+        $profile = $this->makeProfile('mastodon', 'https://mastodon.social/@foo');
+
+        $this->rssApp->expects($this->never())->method('findRssAppFeedIdBySourceUrl');
+        $this->rssApp->expects($this->never())->method('createFeed');
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertFalse($result->registered);
+        $this->assertFalse($result->linkedToExistingFeed);
+        $this->assertSame(0, $result->importedItems);
+    }
+
+    public function testNotApplicableWhenFeedIdAlreadySet(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/foo');
+        $profile->setAdditionalData(['rss_feed_id' => 'preset-id']);
+
+        $this->rssApp->expects($this->never())->method('findRssAppFeedIdBySourceUrl');
+        $this->rssApp->expects($this->never())->method('createFeed');
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertFalse($result->registered);
+        $this->assertSame('preset-id', $profile->getAdditionalData()['rss_feed_id']);
+    }
+
+    public function testCreatesNewFeedWhenNoneFoundAtRssApp(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/foo', 42);
+
+        $this->rssApp->expects($this->once())
+            ->method('findRssAppFeedIdBySourceUrl')
+            ->with('https://instagram.com/foo')
+            ->willReturn(null);
+
+        $this->rssApp->expects($this->once())
+            ->method('createFeed')
+            ->with('https://instagram.com/foo')
+            ->willReturn(['id' => 'new-feed-123']);
+
+        $this->feedItemPersister->expects($this->never())->method('flush');
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertTrue($result->registered);
+        $this->assertFalse($result->linkedToExistingFeed);
+        $this->assertSame(0, $result->importedItems);
+        $this->assertSame('new-feed-123', $profile->getAdditionalData()['rss_feed_id']);
+    }
+
+    public function testLinksToExistingFeedAndImportsInitialItems(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/foo', 42);
+
+        $this->rssApp->expects($this->once())
+            ->method('findRssAppFeedIdBySourceUrl')
+            ->with('https://instagram.com/foo')
+            ->willReturn('existing-feed-99');
+
+        $this->rssApp->expects($this->never())->method('createFeed');
+
+        $items = [new ItemModel(), new ItemModel(), new ItemModel()];
+
+        $networkFetcher = $this->createMock(NetworkFeedFetcherInterface::class);
+        $networkFetcher->method('supports')->willReturn(true);
+        $networkFetcher->expects($this->once())
+            ->method('fetch')
+            ->willReturnCallback(function (ModelProfile $modelProfile, $fetchInfo) use ($items): array {
+                $this->assertSame(42, $modelProfile->getId());
+                $this->assertSame('instagram_profile', $modelProfile->getNetwork());
+                $this->assertSame(FeedRegistrar::INITIAL_IMPORT_COUNT, $fetchInfo->getCount());
+                return $items;
+            });
+
+        $this->feedFetcher->method('getNetworkFetcherList')->willReturn([$networkFetcher]);
+
+        $this->feedItemPersister->expects($this->once())
+            ->method('persistFeedItemList')
+            ->with($items)
+            ->willReturnSelf();
+        $this->feedItemPersister->expects($this->once())->method('flush')->willReturnSelf();
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertTrue($result->registered);
+        $this->assertTrue($result->linkedToExistingFeed);
+        $this->assertSame(3, $result->importedItems);
+        $this->assertSame('existing-feed-99', $profile->getAdditionalData()['rss_feed_id']);
+    }
+
+    public function testReturnsNotApplicableWhenRssAppLookupThrows(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/foo', 42);
+
+        $this->rssApp->method('findRssAppFeedIdBySourceUrl')
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertFalse($result->registered);
+        $this->assertArrayNotHasKey('rss_feed_id', $profile->getAdditionalData() ?? []);
+    }
+
+    public function testNotApplicableWhenIdentifierIsNull(): void
+    {
+        $network = new Network();
+        $network->setIdentifier('instagram_profile');
+
+        $profile = new Profile();
+        $profile->setNetwork($network);
+
+        $this->rssApp->expects($this->never())->method('findRssAppFeedIdBySourceUrl');
+
+        $result = $this->registrar->registerIfNeeded($profile);
+
+        $this->assertFalse($result->registered);
+    }
+
+    private function makeProfile(string $networkIdentifier, string $url, ?int $id = null): Profile
+    {
+        $network = new Network();
+        $network->setIdentifier($networkIdentifier);
+
+        $profile = new Profile();
+        $profile->setNetwork($network);
+        $profile->setIdentifier($url);
+
+        if ($id !== null) {
+            $reflection = new \ReflectionProperty(Profile::class, 'id');
+            $reflection->setValue($profile, $id);
+        }
+
+        return $profile;
+    }
+}


### PR DESCRIPTION
## Summary
- When a new Instagram/Facebook/Threads profile is created (Web UI or REST API), `FeedRegistrar` now asks RSS.app first whether a feed already exists for that source URL. If so, the profile is linked to the existing feed and the last 100 items are immediately fetched and persisted — closing the gap where you used to have to wait for the next scheduled fetch to see anything.
- `registerIfNeeded` now returns a `RegistrationResult` (registered / linkedToExistingFeed / importedItems) instead of a bool. The Web UI flash message is richer: "Profil wurde erstellt, mit bestehendem RSS.app-Feed verknüpft und N Items importiert."
- Both call sites (`ProfileController::new`, `ClientScopedProfileProcessor`) now flush the EM before `registerIfNeeded` so the new profile has an ID by the time items get persisted (Item→profile FK).
- RSS.app failures (lookup or createFeed) are still non-blocking; they're logged and treated as "not applicable" so profile creation always succeeds.

## Test plan
- [x] `bin/phpunit` — 153 tests, 382 assertions, OK (6 new unit tests for `FeedRegistrar` covering whitelist filter, already-set feed-id, link-to-existing + import, create-new, lookup exception, missing identifier)
- [x] `php bin/console debug:container App\\RssApp\\FeedRegistrar` — autowired with RssApp + Logger + FeedFetcher + DoctrineFeedItemPersister
- [ ] Manual: at `/profiles/new`, create an Instagram profile whose URL is already registered at RSS.app (e.g. one you previously created and then deleted locally). Verify flash mentions "verknüpft" + import count, and that items show up on the profile detail immediately.
- [ ] Manual: at `/profiles/new`, create an Instagram profile whose URL is NOT yet at RSS.app. Verify flash says "registriert" (no import count) and a new feed is created at RSS.app.
- [ ] Manual: at `/profiles/new`, create a Mastodon profile. Verify the plain "Profil wurde erstellt." flash and no RSS.app calls (regression check).
- [ ] Manual: `POST /api/profiles` with an Instagram URL already at RSS.app. Verify items are persisted and visible via `GET /api/timeline?network=instagram_profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)