### PR TITLE
Fix rssapp-profiles freeze: guard DataTable init against Stimulus reconnect

### DIFF
--- a/assets/controllers/rssapp_table_controller.js
+++ b/assets/controllers/rssapp_table_controller.js
@@ -1,14 +1,21 @@
 import { Controller } from '@hotwired/stimulus';
 import DataTable from 'datatables.net-bs5';
 
+const initialized = new WeakSet();
+
 export default class extends Controller {
     connect() {
+        if (initialized.has(this.element)) {
+            return;
+        }
+        initialized.add(this.element);
         this.dt = new DataTable(this.element, {
             paging: true,
             pageLength: 50,
             lengthMenu: [25, 50, 100, 200],
             searching: true,
             order: [[4, 'desc']],
+            deferRender: true,
             language: {
                 search: 'Suche:',
                 lengthMenu: '_MENU_ Einträge anzeigen',
@@ -20,12 +27,5 @@ export default class extends Controller {
                 zeroRecords: 'Keine passenden Einträge gefunden.',
             },
         });
-    }
-
-    disconnect() {
-        if (this.dt) {
-            this.dt.destroy();
-            this.dt = null;
-        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the browser freeze on `/rssapp-profiles` (~38 s tab hang on Prod with 298 rows). DataTables wraps the table element in a `<div class="dt-container">`, which moves it in the DOM and triggers a Stimulus disconnect + reconnect. Each reconnect creates a fresh controller instance with `this.dt === undefined`, so the existing guard didn't help — `new DataTable()` ran again, wrapped again, looped again.

- Track init state in a module-scoped `WeakSet` keyed by the table element so all controller instances share the flag. WeakSet releases the entry when the element is GC'd, no leak.
- Drop the `disconnect()` destroy — it would tear down the DataTable while WeakSet still says "initialized", leaving the page sortless.
- Enable `deferRender: true` so DataTables only builds DOM for the current 50-row page instead of all 298 up front.

## Test plan

- [x] Local repro with 298 seed profiles — was: tab freezes indefinitely. Now: page loads in ~660 ms, pagination shows "1–50 von 298 Einträgen", sort headers active.
- [x] `bin/phpunit` — 153 tests, no new failures (existing risky/notice warnings unrelated).
- [ ] Deploy on Prod requires `bin/console asset-map:compile` + `cache:clear --env=prod` for the new controller hash to be served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)