### PR TITLE
Group RSS.app sidebar entries into a collapsible dropdown

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -131,6 +131,60 @@ body {
     color: white;
 }
 
+.sidebar-nav .nav-group > details > summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    color: var(--sidebar-text);
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    list-style: none;
+    transition: all 0.15s;
+}
+
+.sidebar-nav .nav-group > details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.sidebar-nav .nav-group > details > summary:hover {
+    background: var(--sidebar-hover);
+    color: var(--sidebar-text-active);
+}
+
+.sidebar-nav .nav-group > details > summary.active-group {
+    color: var(--sidebar-text-active);
+}
+
+.sidebar-nav .nav-group > details > summary .nav-icon {
+    width: 20px;
+    text-align: center;
+    font-size: 15px;
+}
+
+.sidebar-nav .nav-group .nav-chevron {
+    margin-left: auto;
+    font-size: 11px;
+    transition: transform 0.15s;
+}
+
+.sidebar-nav .nav-group > details[open] > summary .nav-chevron {
+    transform: rotate(90deg);
+}
+
+.sidebar-subnav {
+    list-style: none;
+    padding: 4px 0 4px 12px;
+    margin: 0;
+}
+
+.sidebar-subnav li a {
+    font-size: 13px;
+    padding: 8px 12px;
+}
+
 .sidebar-footer {
     margin-top: auto;
     padding: 16px;

--- a/templates/_partials/_sidebar.html.twig
+++ b/templates/_partials/_sidebar.html.twig
@@ -23,14 +23,26 @@
             <span class="nav-icon"><i class="fas fa-users"></i></span>
             Profiles
         </a></li>
-        <li><a href="{{ path('app_rssapp_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_profile' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
-            RSS.app
-        </a></li>
-        <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-unlink"></i></span>
-            RSS.app Verwaiste Feeds
-        </a></li>
+        {% set rssappRoute = app.request.attributes.get('_route') starts with 'app_rssapp_' %}
+        <li class="nav-group">
+            <details{% if rssappRoute %} open{% endif %}>
+                <summary class="{% if rssappRoute %}active-group{% endif %}">
+                    <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
+                    RSS.app
+                    <span class="nav-chevron"><i class="fas fa-chevron-right"></i></span>
+                </summary>
+                <ul class="sidebar-subnav">
+                    <li><a href="{{ path('app_rssapp_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_profile' %}active{% endif %}">
+                        <span class="nav-icon"><i class="fas fa-list"></i></span>
+                        Übersicht
+                    </a></li>
+                    <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
+                        <span class="nav-icon"><i class="fas fa-unlink"></i></span>
+                        Verwaiste Feeds
+                    </a></li>
+                </ul>
+            </details>
+        </li>
         <li><a href="{{ path('app_item_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_item' %}active{% endif %}">
             <span class="nav-icon"><i class="fas fa-stream"></i></span>
             Items


### PR DESCRIPTION
## Summary
- Replaces the two flat sidebar entries ("RSS.app", "RSS.app Verwaiste Feeds") with a single collapsible "RSS.app" group containing two sub-items ("Übersicht", "Verwaiste Feeds").
- Implemented with native `<details>/<summary>` — no JS controller, no Bootstrap collapse, fully keyboard-accessible.
- Auto-expands when the current route starts with `app_rssapp_` (so navigating to either page lands you with the group open). Chevron rotates 90° to indicate open state.

## Test plan
- [x] `bin/phpunit` — 153/382, OK
- [x] `php bin/console lint:twig` on `_sidebar.html.twig` — valid
- [ ] Manual: open `/dashboard`, group is collapsed showing only "RSS.app" with a right-facing chevron. Click it: expands to the two sub-items.
- [ ] Manual: open `/rssapp-profiles` directly, sidebar group is already open and "Übersicht" sub-item highlighted.
- [ ] Manual: open `/rssapp/orphan-feeds`, sidebar group is already open and "Verwaiste Feeds" sub-item highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)