### PR TITLE
Hide dashboard cards for networks with no active profiles and no items

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -32,13 +32,22 @@ class DashboardController extends AbstractController
         $networkStats = [];
         foreach ($networks as $network) {
             $profiles = $profileRepository->findBy(['network' => $network]);
-            if (count($profiles) === 0) {
-                continue;
+            $activeProfileCount = 0;
+            foreach ($profiles as $profile) {
+                if (!$profile->isDeleted()) {
+                    $activeProfileCount++;
+                }
             }
+
             $itemCount = 0;
             foreach ($profiles as $profile) {
                 $itemCount += $itemRepository->count(['profile' => $profile]);
             }
+
+            if ($activeProfileCount === 0 && $itemCount === 0) {
+                continue;
+            }
+
             $networkStats[] = [
                 'network' => $network,
                 'profileCount' => count($profiles),


### PR DESCRIPTION
## Summary
- Tightens the dashboard's "hide inactive network" rule. Previously a network was hidden only when `findBy` returned 0 profiles, which still counted soft-deleted ones. Now the network card is skipped iff **both** `activeProfileCount == 0` **and** `itemCount == 0`.
- Net effect:
  - Network has at least one non-deleted profile → shown (even with 0 items)
  - Network has only soft-deleted profiles and 0 items → hidden
  - Network has only soft-deleted profiles but historical items in DB → shown (so the items remain reachable via the card)

## Test plan
- [x] `bin/phpunit` — same 1 pre-existing failure on `WahlkampfImporterTest::testDryRunPersistsNothing` as on `main` (date-related, unrelated to this change); no new failures
- [x] `php bin/console lint:container` — OK
- [ ] Manual: open `/`, verify the previously-visible cards for networks with only soft-deleted profiles and no items are gone, and that active networks still show with their full stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)