### PR TITLE
API: slim default response + absolute media URLs (PR 2/4)

### DIFF
--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -49,6 +49,7 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
         $profileShared->setIdentifier('https://mastodon.social/@shared');
         $profileShared->setNetwork($networkMastodon);
         $profileShared->setCreatedAt(new \DateTimeImmutable());
+        $profileShared->setAdditionalData(['rss_feed_id' => 'fixture-feed-shared']);
         $manager->persist($profileShared);
         $clientA->addProfile($profileShared);
         $clientB->addProfile($profileShared);
@@ -89,6 +90,12 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
             $item->setPermalink(sprintf('https://mastodon.social/@shared/%d', $i + 1));
             $item->setText(sprintf('Shared item %d', $i + 1));
             $item->setDateTime($now->modify(sprintf('-%d hours', $hoursAgo)));
+            // First item carries raw payloads so the item:detail group is testable
+            if ($i === 0) {
+                $item->setRaw('{"raw":"shared-1"}');
+                $item->setRawSource('<html>shared-1</html>');
+                $item->setParsedSource('parsed-shared-1');
+            }
             $manager->persist($item);
         }
 

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -44,7 +44,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             paginationEnabled: false,
         ),
         new Get(
-            description: 'Returns a single feed item by ID. Returns 404 if the item belongs to a profile not linked to the authenticated client.',
+            description: 'Returns a single feed item by ID, including the heavy raw/rawSource/parsedSource payloads (item:detail group). Returns 404 if the item belongs to a profile not linked to the authenticated client.',
+            normalizationContext: ['groups' => ['item:read', 'item:detail']],
         ),
         new Post(
             description: 'Creates a new feed item.',
@@ -53,7 +54,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
             description: 'Updates an existing feed item.',
         ),
     ],
-    description: 'A feed item (post, tweet, etc.) fetched from a social network profile. Items are scoped to profiles linked to the authenticated API client.',
+    description: 'A feed item (post, tweet, etc.) fetched from a social network profile. Items are scoped to profiles linked to the authenticated API client. The collection responses use the slim item:read group (no raw payloads). The single-item GET adds item:detail which includes raw, rawSource and parsedSource.',
     normalizationContext: ['groups' => ['item:read']],
     denormalizationContext: ['groups' => ['item:write']],
     order: ['dateTime' => 'DESC'],
@@ -125,29 +126,44 @@ class Item
     private \DateTimeImmutable $createdAt;
 
     #[ORM\Column(type: 'text', nullable: true)]
-    #[Groups(['item:read', 'item:write'])]
-    #[ApiProperty(description: 'Raw JSON response from the social network API for this item.')]
+    #[Groups(['item:detail', 'item:write'])]
+    #[ApiProperty(description: 'Raw JSON response from the social network API for this item. Only included on the single-item endpoint, not in collections.')]
     private ?string $raw = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
-    #[Groups(['item:read', 'item:write'])]
-    #[ApiProperty(description: 'Raw HTML source of the original page, if fetchSource was enabled on the profile.')]
+    #[Groups(['item:detail', 'item:write'])]
+    #[ApiProperty(description: 'Raw HTML source of the original page, if fetchSource was enabled on the profile. Only included on the single-item endpoint.')]
     private ?string $rawSource = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
-    #[Groups(['item:read', 'item:write'])]
-    #[ApiProperty(description: 'Parsed/processed version of the source content.')]
+    #[Groups(['item:detail', 'item:write'])]
+    #[ApiProperty(description: 'Parsed/processed version of the source content. Only included on the single-item endpoint.')]
     private ?string $parsedSource = null;
 
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['item:read'])]
-    #[ApiProperty(description: 'Relative paths to downloaded photo files.', readable: true, writable: false)]
+    #[ApiProperty(description: 'Relative paths to downloaded photo files. Use photoUrls for absolute URLs.', readable: true, writable: false)]
     private ?array $photoPaths = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Groups(['item:read'])]
-    #[ApiProperty(description: 'Relative path to the downloaded video file.', readable: true, writable: false)]
+    #[ApiProperty(description: 'Relative path to the downloaded video file. Use videoUrl for the absolute URL.', readable: true, writable: false)]
     private ?string $videoPath = null;
+
+    /**
+     * Populated at serialization time by ItemMediaUrlNormalizer based on photoPaths.
+     * @var list<string>
+     */
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Absolute URLs of downloaded photo files. Built from photoPaths against the current request host. Empty array when no photos have been downloaded.', readable: true, writable: false)]
+    public array $photoUrls = [];
+
+    /**
+     * Populated at serialization time by ItemMediaUrlNormalizer based on videoPath.
+     */
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Absolute URL of the downloaded video file. Built from videoPath against the current request host. Null when no video has been downloaded.', readable: true, writable: false)]
+    public ?string $videoUrl = null;
 
     #[ORM\Column(type: 'string', length: 20, nullable: true)]
     #[Groups(['item:read'])]

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -27,7 +27,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
             description: 'Returns all profiles linked to the authenticated client. Soft-deleted profiles are excluded. See available filters below.',
         ),
         new Get(
-            description: 'Returns a single profile by ID. Returns 404 if the profile is not linked to the authenticated client.',
+            description: 'Returns a single profile by ID, including the additionalData payload (profile:detail group). Returns 404 if the profile is not linked to the authenticated client.',
+            normalizationContext: ['groups' => ['profile:read', 'profile:detail']],
         ),
         new Post(
             processor: ClientScopedProfileProcessor::class,
@@ -109,8 +110,8 @@ class Profile
     private bool $fetchSource = false;
 
     #[ORM\Column(type: 'text', nullable: true)]
-    #[Groups(['profile:read', 'profile:write'])]
-    #[ApiProperty(description: 'Arbitrary JSON data for network-specific configuration (e.g. RSS.app feed ID).')]
+    #[Groups(['profile:detail', 'profile:write'])]
+    #[ApiProperty(description: 'Arbitrary JSON data for network-specific configuration (e.g. RSS.app feed ID). Only included on the single-profile endpoint, not in collections.')]
     private ?string $additionalData = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => false])]

--- a/src/Serializer/Normalizer/ItemMediaUrlNormalizer.php
+++ b/src/Serializer/Normalizer/ItemMediaUrlNormalizer.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use App\Entity\Item;
+use Symfony\Component\HttpFoundation\UrlHelper;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ItemMediaUrlNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const ALREADY_CALLED = 'ITEM_MEDIA_URL_NORMALIZER_ALREADY_CALLED';
+    private const MEDIA_PATH_PREFIX = '/media/';
+
+    public function __construct(private readonly UrlHelper $urlHelper)
+    {
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null
+    {
+        $context[self::ALREADY_CALLED] = true;
+
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        if (!is_array($data) || !$object instanceof Item) {
+            return $data;
+        }
+
+        $photoPaths = $object->getPhotoPaths();
+        $videoPath = $object->getVideoPath();
+
+        $data['photoUrls'] = array_values(array_map(
+            fn(string $path) => $this->buildAbsoluteUrl($path),
+            $photoPaths,
+        ));
+
+        $data['videoUrl'] = $videoPath !== null ? $this->buildAbsoluteUrl($videoPath) : null;
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        if (isset($context[self::ALREADY_CALLED])) {
+            return false;
+        }
+
+        return $data instanceof Item;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Item::class => false];
+    }
+
+    private function buildAbsoluteUrl(string $relativePath): string
+    {
+        return $this->urlHelper->getAbsoluteUrl(self::MEDIA_PATH_PREFIX . ltrim($relativePath, '/'));
+    }
+}

--- a/tests/Functional/Api/ItemApiTest.php
+++ b/tests/Functional/Api/ItemApiTest.php
@@ -157,6 +157,48 @@ class ItemApiTest extends AbstractApiTestCase
         }
     }
 
+    public function testCollectionResponseExcludesRawPayloads(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/items');
+        $data = $response->toArray();
+        $items = $data['hydra:member'] ?? $data['member'] ?? [];
+
+        $this->assertNotEmpty($items);
+        foreach ($items as $item) {
+            $this->assertArrayNotHasKey('raw', $item);
+            $this->assertArrayNotHasKey('rawSource', $item);
+            $this->assertArrayNotHasKey('parsedSource', $item);
+        }
+    }
+
+    public function testSingleItemResponseIncludesRawPayloads(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/items');
+        $data = $response->toArray();
+        $items = $data['hydra:member'] ?? $data['member'] ?? [];
+        $itemId = $items[0]['id'];
+
+        $detail = $this->requestAsClientA('GET', '/api/items/' . $itemId)->toArray();
+
+        $this->assertArrayHasKey('raw', $detail);
+        $this->assertArrayHasKey('rawSource', $detail);
+        $this->assertArrayHasKey('parsedSource', $detail);
+    }
+
+    public function testCollectionResponseIncludesMediaUrlFields(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/items');
+        $data = $response->toArray();
+        $items = $data['hydra:member'] ?? $data['member'] ?? [];
+
+        $this->assertNotEmpty($items);
+        foreach ($items as $item) {
+            $this->assertArrayHasKey('photoUrls', $item);
+            $this->assertIsArray($item['photoUrls']);
+            $this->assertArrayHasKey('videoUrl', $item);
+        }
+    }
+
     public function testFilterByDateTimeAfter(): void
     {
         $cutoff = (new \DateTimeImmutable('-6 hours'))->format(\DateTimeImmutable::ATOM);

--- a/tests/Functional/Api/ProfileApiTest.php
+++ b/tests/Functional/Api/ProfileApiTest.php
@@ -199,6 +199,30 @@ class ProfileApiTest extends AbstractApiTestCase
         }
     }
 
+    public function testCollectionResponseExcludesAdditionalData(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/profiles');
+        $data = $response->toArray();
+        $members = $data['hydra:member'] ?? $data['member'] ?? [];
+
+        $this->assertNotEmpty($members);
+        foreach ($members as $profile) {
+            $this->assertArrayNotHasKey('additionalData', $profile);
+        }
+    }
+
+    public function testSingleProfileResponseIncludesAdditionalData(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/profiles');
+        $data = $response->toArray();
+        $members = $data['hydra:member'] ?? $data['member'] ?? [];
+        $profileId = $members[0]['id'];
+
+        $detail = $this->requestAsClientA('GET', '/api/profiles/' . $profileId)->toArray();
+
+        $this->assertArrayHasKey('additionalData', $detail);
+    }
+
     public function testFilterProfilesByNetworkIdentifier(): void
     {
         $response = $this->requestAsClientA('GET', '/api/profiles?network.identifier=bluesky_profile');


### PR DESCRIPTION
Second of four PRs aimed at making the REST API usable from external sites (WordPress, static generators, …). Focus here: **payload size on collection endpoints** and **absolute media URLs**.

## Summary

### Slim collection responses
Collection endpoints (`/api/items`, `/api/timeline`, `/api/profiles`) used to return `raw`, `rawSource`, `parsedSource` (Item) and `additionalData` (Profile) on every record. For a 50-item page this can balloon by megabytes when items carry full HTML or social-network JSON dumps. Now:

- `Item.raw`, `rawSource`, `parsedSource` are tagged with the **new `item:detail` group** and dropped from `item:read`. The `Get` operation on `/api/items/{id}` overrides `normalizationContext` to `['item:read', 'item:detail']`, so the heavy fields are only sent on the per-id endpoint.
- `Profile.additionalData` is tagged with **`profile:detail`** and dropped from `profile:read`. Same per-id override on `/api/profiles/{id}`.
- `item:write` and `profile:write` are unchanged — `POST`/`PUT` still accept these fields.

### Absolute media URLs
New virtual fields on `Item`:

- `photoUrls`: array of absolute URLs (built from `photoPaths` against the current request host)
- `videoUrl`: absolute URL (or null)

Implemented as a decorator normalizer (`src/Serializer/Normalizer/ItemMediaUrlNormalizer.php`) using `Symfony\Component\HttpFoundation\UrlHelper`, so the host/scheme follow whatever the API is being served from. Existing `photoPaths` / `videoPath` (relative) stay in `item:read` for backwards compatibility.

### Tests
- Fixtures: `profileShared` gets `additionalData={"rss_feed_id":"fixture-feed-shared"}` and its newest item carries `raw`/`rawSource`/`parsedSource` so the `item:detail` / `profile:detail` split is testable.
- 3 new in `ItemApiTest`: collection excludes raw blobs, single item includes them, collection responses always carry `photoUrls`/`videoUrl`.
- 2 new in `ProfileApiTest`: collection excludes `additionalData`, single profile includes it.
- Full suite: 172 tests, 477 assertions; same 1 pre-existing failure (`WahlkampfImporterTest::testDryRunPersistsNothing`, also fails on `main`).

## Example
Collection response per item now looks roughly like:
```json
{
  "@id": "/api/items/42",
  "id": 42,
  "text": "…",
  "permalink": "https://mastodon.social/@x/123",
  "dateTime": "2026-05-18T08:00:00+00:00",
  "photoPaths": ["42/100/photo_0.jpg"],
  "photoUrls": ["https://your-host/media/42/100/photo_0.jpg"],
  "videoPath": null,
  "videoUrl": null,
  "profile": { "id": 100, "identifier": "https://mastodon.social/@x", "network": {...} }
}
```
(No more `raw`, `rawSource`, `parsedSource`.) Hit `/api/items/42` to retrieve those.

## Next planned PRs
- **PR 3**: Timeline pagination + createdAt-based polling endpoint for incremental sync
- **PR 4**: RSS/Atom output for Timeline and per-profile items

🤖 Generated with [Claude Code](https://claude.com/claude-code)