### PR TITLE
API: comprehensive /api/doc and /api/docs landing pages

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -1,33 +1,85 @@
 api_platform:
     title: Social Network Fetcher API
     description: |
-        REST API for managing social network profiles and their feed items.
+        REST API for managing social-network profiles and their feed items.
+        Speaks JSON-LD (Hydra), plain JSON, and RSS 2.0 under `/api/feeds/…`.
 
         ## Authentication
 
-        All endpoints under `/api/` (except `/api/docs`) require a Bearer token.
-        Tokens are issued per client via the CLI command `app:client:create <name>`.
+        Every request under `/api/` (except `/api/doc`, `/api/docs`) requires a Bearer token issued via:
 
-        Include the token in the `Authorization` header:
+        ```
+        bin/console app:client:create <name>
+        ```
 
-            Authorization: Bearer <token>
+        Include the token in every request:
 
-        Requests without a valid token receive a `401 Unauthorized` response.
+        ```
+        Authorization: Bearer <your-token>
+        ```
+
+        Missing, invalid or disabled-client tokens → **401**.
 
         ## Multi-Tenancy
 
-        Each API client sees only its own profiles and their items.
-        Profiles can be shared between clients — a profile is only soft-deleted
-        when the last client removes it.
+        Each client sees only its own profiles and items. Profiles may be shared between clients.
+        A profile is only soft-deleted when the last client removes it.
+        Profiles and items are never physically deleted — historical data is preserved.
 
-        ## Profile Lifecycle
+        ## Response visibility defaults
 
-        - **POST /api/profiles** — Creates a new profile or links an existing one to the authenticated client.
-          If a profile with the same network + identifier already exists, it is linked (idempotent).
-          If the existing profile was soft-deleted, it is reactivated.
-        - **DELETE /api/profiles/{id}** — Unlinks the profile from the client.
-          If no other client references it, the profile is soft-deleted and its RSS.app feed is removed.
-        - Profiles and items are never physically deleted — historical data is preserved.
+        - `/api/items` and `/api/timeline` exclude `hidden=true` and `deleted=true` items by
+          default. Override with `?hidden=true` / `?deleted=true`.
+        - `/api/profiles` excludes soft-deleted profiles always.
+
+        ## Slim vs. detail responses
+
+        Collections return the slim `item:read` / `profile:read` group. The heavy fields
+        — `raw`, `rawSource`, `parsedSource` (Item) and `additionalData` (Profile) — are
+        in the detail group and only land on the single-resource GET endpoint.
+
+        ## Media URLs
+
+        Items expose both relative paths (`photoPaths`, `videoPath`) and absolute URLs
+        (`photoUrls`, `videoUrl`) built from the current request host. Use the absolute
+        ones for embedding.
+
+        ## Filtering & sorting
+
+        See the per-operation parameter list. Items support filters on `profile`,
+        `profile.network`, `profile.network.identifier`, `text` (partial), `title`
+        (partial), `hidden`, `deleted`, date ranges on `dateTime` and `createdAt`,
+        and ordering by `dateTime` / `createdAt`. Profiles support filters on
+        `network`, `network.identifier`, `identifier` (partial), `title` (partial),
+        `autoFetch`, plus ordering by `identifier`, `title`, `createdAt`,
+        `lastFetchSuccessDateTime`.
+
+        ## Incremental sync (recommended for WordPress polling)
+
+        For periodic polling, prefer `createdAt` over `dateTime`:
+
+        ```
+        GET /api/items?createdAt[strictly_after]=2026-05-18T10:00:00Z&order[createdAt]=asc&itemsPerPage=200
+        ```
+
+        Store the largest `createdAt` you've seen and use it as the cursor next time.
+
+        ## RSS feeds
+
+        - `GET /api/feeds/timeline.rss` — aggregated feed across all linked profiles
+        - `GET /api/feeds/profiles/{id}.rss` — per-profile feed
+
+        Both honor the same Bearer-token auth. WordPress feed plugins typically support
+        custom request headers — set `Authorization: Bearer <token>` and you're done.
+
+        ## Error responses (RFC 7807)
+
+        | Status | Meaning |
+        |--------|---------|
+        | 400 | Invalid request body / parameters |
+        | 401 | Missing or invalid Bearer token |
+        | 404 | Resource not found or not linked to your client |
+        | 422 | Validation error on POST/PUT |
 
     version: 1.0.0
     defaults:

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -4,61 +4,229 @@ nelmio_api_doc:
             title: Social Network Fetcher API
             version: 1.0.0
             description: |
-                REST API for managing social network profiles and their feed items.
+                REST API for managing social-network profiles and their feed items.
+                The API speaks **JSON-LD (Hydra)** for programmatic clients, plain
+                **JSON**, and **RSS 2.0** under `/api/feeds/…` for feed-aggregator
+                tooling (WordPress, RSS readers, IFTTT, Zapier, static-site generators).
+
+                ## Quick start
+
+                ```bash
+                # 1. Create a client and grab the token
+                bin/console app:client:create my-wordpress
+
+                # 2. Probe a public endpoint to confirm auth works
+                curl -H 'Authorization: Bearer <token>' https://your-host/api/networks
+
+                # 3. List your profiles
+                curl -H 'Authorization: Bearer <token>' https://your-host/api/profiles
+
+                # 4. Pull latest items
+                curl -H 'Authorization: Bearer <token>' \
+                  'https://your-host/api/items?itemsPerPage=20'
+                ```
 
                 ## Authentication
 
-                All endpoints under `/api/` (except documentation) require a Bearer token.
-                Tokens are issued per client via the CLI command:
+                Every request under `/api/` (except `/api/doc` and `/api/docs`) requires a
+                Bearer token. Tokens are 64-char hex strings issued per *client* via:
 
-                    bin/console app:client:create <name>
+                ```
+                bin/console app:client:create <name>
+                ```
 
                 Include the token in every request:
 
-                    Authorization: Bearer <your-token>
+                ```
+                Authorization: Bearer <your-token>
+                ```
 
-                Requests without a valid token receive a **401 Unauthorized** response.
-                Disabled clients also receive **401**, even with a correct token.
+                - Missing or malformed token → **401 Unauthorized**
+                - Token for a disabled client → **401 Unauthorized** as well
+                - Token for a deleted client → **401**
+
+                List, regenerate, enable / disable tokens via the matching `app:client:*` CLI commands.
 
                 ## Multi-Tenancy
 
-                Each API client sees **only its own profiles** and their items.
+                Each client sees **only its own profiles** and the items belonging to them.
 
-                - Profiles can be shared between clients — the same profile may appear in multiple client scopes.
-                - A profile is only soft-deleted when the **last** client removes it.
-                - Items belong to profiles and inherit the client scope transitively.
+                - Profiles may be shared between clients (same profile in multiple client scopes).
+                - A profile is only **soft-deleted** when the **last** client removes it.
+                - Items inherit the client scope transitively via their profile.
+                - Profiles and items are **never physically deleted** — historical data is preserved.
 
-                ## Profile Lifecycle
+                ## Response visibility defaults
 
-                | Action | Behavior |
-                |--------|----------|
-                | **POST /api/profiles** | Creates a new profile **or** links an existing one to the authenticated client (idempotent). Reactivates soft-deleted profiles. |
-                | **DELETE /api/profiles/{id}** | Unlinks the profile from the client. If no other client references it, the profile is soft-deleted and its RSS.app feed is removed. |
-                | **PUT /api/profiles/{id}** | Updates profile properties (identifier, network, flags). |
+                - `/api/items` and `/api/timeline` exclude **hidden** items (`hidden=true`) and
+                  **soft-deleted** items (`deleted=true`) by default. Pass `?hidden=true` or
+                  `?deleted=true` to include them.
+                - `/api/profiles` excludes soft-deleted profiles always (they can be reactivated
+                  by POSTing the same network + identifier).
 
-                Profiles and items are **never physically deleted** — historical data is preserved.
+                ## Slim vs. detail responses
 
-                ## Filtering & Sorting
+                Collection responses use the slim **`item:read`** / **`profile:read`** group.
+                The heavy payloads — `raw`, `rawSource`, `parsedSource` on Item and
+                `additionalData` on Profile — are tagged with the detail group and only
+                appear on the **single-resource** endpoint (`GET /api/items/{id}`,
+                `GET /api/profiles/{id}`). This keeps `/api/items?itemsPerPage=50` responses
+                well under 1 MB even when items carry full HTML or social-network JSON dumps.
 
-                - **Profiles**: Filter by network: `?network=<id>`
-                - **Items**: Filter by profile: `?profile=<id>`, order by `dateTime` or `createdAt`
-                - **Pagination**: Items are paginated (50 per page by default)
+                ## Media URLs
 
-                ## Response Formats
+                Item responses carry both relative and absolute media URLs:
 
-                The API supports the following response formats via the `Accept` header:
+                - `photoPaths`: array of strings, e.g. `["42/100/photo_0.jpg"]`
+                - `photoUrls`: array of absolute URLs built from the current request host,
+                  e.g. `["https://your-host/media/42/100/photo_0.jpg"]`
+                - `videoPath` / `videoUrl`: equivalent for the (optional) video
 
-                - `application/json` — plain JSON
-                - `application/ld+json` — JSON-LD (Hydra)
+                Use `photoUrls` / `videoUrl` directly for embedding into WordPress posts.
 
-                ## Error Responses
+                ## Filtering
+
+                ### Items
+
+                | Filter | Type | Example |
+                |---|---|---|
+                | `profile` | exact | `?profile=/api/profiles/42` |
+                | `profile.network` | exact | `?profile.network=/api/networks/3` |
+                | `profile.network.identifier` | exact | `?profile.network.identifier=mastodon` |
+                | `text` | partial | `?text=demo` |
+                | `title` | partial | `?title=announcement` |
+                | `hidden` | boolean | `?hidden=true` |
+                | `deleted` | boolean | `?deleted=true` |
+                | `dateTime` | date range | `?dateTime[after]=2026-05-01T00:00:00Z` |
+                | `dateTime` | date range | `?dateTime[before]=2026-05-31T23:59:59Z` |
+                | `createdAt` | date range | `?createdAt[strictly_after]=2026-05-18T10:00:00Z` |
+                | `order[dateTime]` | sort | `?order[dateTime]=desc` |
+                | `order[createdAt]` | sort | `?order[createdAt]=asc` |
+
+                ### Profiles
+
+                | Filter | Type | Example |
+                |---|---|---|
+                | `network` | exact | `?network=/api/networks/3` |
+                | `network.identifier` | exact | `?network.identifier=instagram_profile` |
+                | `identifier` | partial | `?identifier=mastodon.social` |
+                | `title` | partial | `?title=anna` |
+                | `autoFetch` | boolean | `?autoFetch=true` |
+                | `order[identifier]` | sort | `?order[identifier]=asc` |
+                | `order[title]` | sort | `?order[title]=asc` |
+                | `order[createdAt]` | sort | `?order[createdAt]=desc` |
+                | `order[lastFetchSuccessDateTime]` | sort | `?order[lastFetchSuccessDateTime]=desc` |
+
+                ## Pagination
+
+                Hydra-style pagination on collection endpoints. The response includes:
+
+                ```json
+                {
+                  "hydra:totalItems": 1234,
+                  "hydra:view": {
+                    "@id": "/api/items?page=1",
+                    "hydra:first": "/api/items?page=1",
+                    "hydra:last": "/api/items?page=25",
+                    "hydra:next": "/api/items?page=2"
+                  },
+                  "hydra:member": [ ... ]
+                }
+                ```
+
+                Query params:
+
+                - `page` — page number (default `1`)
+                - `itemsPerPage` — items per page (`/api/items`: default 50; `/api/timeline`:
+                  default 50, max 200)
+
+                ## Incremental sync (recommended for WordPress polling)
+
+                For periodic polling, **always use `createdAt`** rather than `dateTime`:
+
+                - `dateTime` = publication time at the social network (immutable but may
+                  appear in the past if an old post is re-discovered)
+                - `createdAt` = import timestamp in this DB (monotonically increasing,
+                  perfect for "give me everything new")
+
+                ```
+                # First call (initial backfill):
+                GET /api/items?itemsPerPage=200&order[createdAt]=asc
+
+                # Store the largest createdAt you received, e.g. 2026-05-18T10:00:00+00:00
+
+                # Subsequent calls:
+                GET /api/items?createdAt[strictly_after]=2026-05-18T10:00:00%2B00:00&order[createdAt]=asc&itemsPerPage=200
+
+                # Update the cursor and repeat.
+                ```
+
+                ## RSS feeds
+
+                For WordPress plugins like **Feedzy**, **WP RSS Aggregator**, generic RSS
+                readers, IFTTT, Zapier and similar feed-consumer tooling, two RSS 2.0
+                endpoints are available **under the same Bearer-auth firewall** as the JSON API:
+
+                | Endpoint | Use case |
+                |---|---|
+                | `GET /api/feeds/timeline.rss` | Aggregated feed across all linked profiles |
+                | `GET /api/feeds/profiles/{id}.rss` | Single-profile feed |
+
+                Both feeds:
+
+                - exclude soft-deleted profiles, hidden items, soft-deleted items
+                - carry `<title>`, `<link>`, `<description>` (with inline `<img>` tags for any
+                  downloaded photos via absolute URLs), `<pubDate>` (RFC 2822), `<guid>`,
+                  `<category>` (network name), `<dc:creator>` (profile display name) and an
+                  `<enclosure>` for the first photo
+
+                Query params:
+
+                - `since` (ISO 8601, default -7 days for timeline)
+                - `until` (ISO 8601, optional)
+                - `limit` (default 100, max 200)
+                - `network` (timeline only — filter to one network identifier)
+
+                Most WordPress feed plugins support a custom `Authorization` header — set it
+                to `Bearer <your-token>` and you're done. Refresh intervals are typically
+                configured in the plugin itself (5 min, 1 h, etc.).
+
+                ## Error responses
 
                 | Status | Meaning |
-                |--------|---------|
-                | 400 | Invalid request body or parameters |
-                | 401 | Missing or invalid Bearer token |
-                | 404 | Resource not found or not linked to the authenticated client |
-                | 422 | Validation error |
+                |---|---|
+                | **400** Bad Request | Invalid request body, parameters, or filter syntax |
+                | **401** Unauthorized | Missing, invalid, or disabled-client Bearer token |
+                | **404** Not Found | Resource doesn't exist **or** isn't linked to your client |
+                | **422** Unprocessable Entity | Validation error on POST/PUT body |
+                | **500** Internal Server Error | Server-side bug — please report |
+
+                Error bodies follow RFC 7807 (`application/problem+json`):
+
+                ```json
+                {
+                  "type": "https://tools.ietf.org/html/rfc2616#section-10",
+                  "title": "An error occurred",
+                  "detail": "Profile not found.",
+                  "status": 404
+                }
+                ```
+
+                ## Response formats
+
+                Negotiate via the `Accept` header:
+
+                - `application/ld+json` — JSON-LD with Hydra pagination metadata (recommended)
+                - `application/json` — plain JSON
+                - `application/rss+xml` — only on `/api/feeds/…`
+
+                ## Conventions
+
+                - All timestamps are **ISO 8601** with timezone (e.g. `2026-05-18T10:00:00+00:00`).
+                - IRIs (e.g. `/api/profiles/42`) are accepted on POST/PUT wherever a relationship is expected.
+                - Network identifiers (machine-readable strings) are stable: `mastodon`,
+                  `bluesky_profile`, `instagram_profile`, `facebook_profile`, `facebook_page`,
+                  `thread`, `homepage`, … List all via `GET /api/networks`.
 
             contact:
                 name: criticalmass.in
@@ -71,6 +239,17 @@ nelmio_api_doc:
                     description: "API token issued via `bin/console app:client:create <name>`"
         security:
             - Bearer: []
+        tags:
+            - name: Profile
+              description: Social-network profiles. Scoped to the authenticated client.
+            - name: Item
+              description: Feed items (posts, tweets, photos) fetched from profiles.
+            - name: Timeline
+              description: Chronological feed across all linked profiles.
+            - name: Feed
+              description: RSS 2.0 feeds for WordPress / RSS-reader / feed-aggregator consumption.
+            - name: Network
+              description: Catalogue of supported social networks.
 
     areas:
         path_patterns:

--- a/src/Controller/Api/FeedController.php
+++ b/src/Controller/Api/FeedController.php
@@ -7,6 +7,7 @@ use App\Entity\Item;
 use App\Entity\Profile;
 use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +32,36 @@ class FeedController
     }
 
     #[Route('/api/feeds/timeline.rss', name: 'app_api_feed_timeline', methods: ['GET'])]
+    #[OA\Get(
+        summary: 'Client-scoped chronological RSS feed across all linked profiles.',
+        description: <<<'DESC'
+        RSS 2.0 feed aggregating recent items across every profile linked to the
+        authenticated client. Excludes soft-deleted profiles, hidden items and
+        soft-deleted items.
+
+        Each `<item>` carries title, link (permalink), description (item text
+        with inline `<img>` tags for downloaded photos using absolute URLs),
+        pubDate (RFC 2822), guid (item id, isPermaLink="false"), category
+        (network name), dc:creator (profile display name), and an `<enclosure>`
+        for the first photo with a guessed image MIME type.
+
+        Typical WordPress use: point Feedzy / WP RSS Aggregator at this URL
+        with a custom `Authorization: Bearer <token>` header. Configure the
+        plugin's refresh interval (5 min, 1 h, …) and the aggregator pulls
+        new items automatically.
+        DESC,
+        tags: ['Feed'],
+        parameters: [
+            new OA\Parameter(name: 'since', in: 'query', description: 'Only return items published after this timestamp. ISO 8601. Default: 7 days ago.', schema: new OA\Schema(type: 'string', format: 'date-time'), example: '2026-05-11T00:00:00Z'),
+            new OA\Parameter(name: 'until', in: 'query', description: 'Only return items published before this timestamp. ISO 8601.', schema: new OA\Schema(type: 'string', format: 'date-time')),
+            new OA\Parameter(name: 'limit', in: 'query', description: 'Maximum number of items in the feed (default 100, max 200).', schema: new OA\Schema(type: 'integer', default: 100, minimum: 1, maximum: 200)),
+            new OA\Parameter(name: 'network', in: 'query', description: 'Filter to a single network by identifier (e.g. mastodon, instagram_profile).', schema: new OA\Schema(type: 'string'), example: 'mastodon'),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'RSS 2.0 XML feed.', content: new OA\MediaType(mediaType: 'application/rss+xml')),
+            new OA\Response(response: 401, description: 'Missing or invalid Bearer token.'),
+        ],
+    )]
     public function timeline(Request $request): Response
     {
         $client = $this->requireClient();
@@ -83,6 +114,29 @@ class FeedController
     }
 
     #[Route('/api/feeds/profiles/{id}.rss', name: 'app_api_feed_profile', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[OA\Get(
+        summary: 'Per-profile RSS feed.',
+        description: <<<'DESC'
+        RSS 2.0 feed for a single profile linked to the authenticated client.
+        Returns 404 if the profile is not linked to the client (or is
+        soft-deleted). Hidden / soft-deleted items are excluded.
+
+        Item structure matches `/api/feeds/timeline.rss`.
+
+        Use this for embedding a single Mastodon / Instagram / Bluesky
+        account into a WordPress sidebar widget via a feed plugin.
+        DESC,
+        tags: ['Feed'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Profile ID.', schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'limit', in: 'query', description: 'Maximum number of items in the feed (default 100, max 200).', schema: new OA\Schema(type: 'integer', default: 100, minimum: 1, maximum: 200)),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'RSS 2.0 XML feed.', content: new OA\MediaType(mediaType: 'application/rss+xml')),
+            new OA\Response(response: 401, description: 'Missing or invalid Bearer token.'),
+            new OA\Response(response: 404, description: 'Profile not found or not linked to the authenticated client.'),
+        ],
+    )]
     public function profileFeed(int $id, Request $request): Response
     {
         $client = $this->requireClient();

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -101,7 +101,10 @@ class Item
 
     #[ORM\Column(type: 'text', nullable: true)]
     #[Groups(['item:read', 'item:write'])]
-    #[ApiProperty(description: 'Direct URL to the original post on the social network.')]
+    #[ApiProperty(
+        description: 'Direct URL to the original post on the social network. Used as `<link>` in the RSS feeds and is what a WordPress consumer would link to.',
+        example: 'https://mastodon.social/@example/110928301234567890',
+    )]
     private ?string $permalink = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
@@ -116,7 +119,10 @@ class Item
 
     #[ORM\Column(name: 'date_time', type: 'datetime_immutable', nullable: false)]
     #[Groups(['item:read', 'item:write'])]
-    #[ApiProperty(description: 'Publication date and time of the feed item on the social network.')]
+    #[ApiProperty(
+        description: 'Publication date and time of the post on the social network itself (ISO 8601 with timezone). Stable per post — does not change after import. Use this for ordering "what was published when". For incremental polling against a moving cursor, prefer createdAt because re-discovered old posts can land at any dateTime.',
+        example: '2026-05-18T08:30:00+00:00',
+    )]
     private ?\DateTimeImmutable $dateTime = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
@@ -131,7 +137,12 @@ class Item
 
     #[ORM\Column(name: 'created_at', type: 'datetime_immutable', nullable: false)]
     #[Groups(['item:read'])]
-    #[ApiProperty(description: 'Timestamp when this item was first imported into the system.', readable: true, writable: false)]
+    #[ApiProperty(
+        description: 'Timestamp when this item was first imported into the local DB (ISO 8601 with timezone). Monotonically increasing per insert, never modified. **This is the recommended cursor for incremental sync**: store the largest createdAt you have seen, then poll with `?createdAt[strictly_after]={cursor}&order[createdAt]=asc`.',
+        readable: true,
+        writable: false,
+        example: '2026-05-18T10:00:00+00:00',
+    )]
     private \DateTimeImmutable $createdAt;
 
     #[ORM\Column(type: 'text', nullable: true)]

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -65,7 +65,23 @@ class Profile
 
     #[ORM\Column(type: 'string', length: 255)]
     #[Groups(['profile:read', 'profile:write', 'item:read'])]
-    #[ApiProperty(description: 'Network-specific identifier, typically a URL. Example: "https://mastodon.social/@username" for Mastodon or "username.bsky.social" for Bluesky.')]
+    #[ApiProperty(
+        description: <<<'DESC'
+        Network-specific identifier, typically a URL. The exact format depends on the
+        network this profile belongs to. Examples:
+
+        - **mastodon**: `https://mastodon.social/@username`
+        - **bluesky_profile**: `username.bsky.social`
+        - **instagram_profile**: `https://www.instagram.com/username/`
+        - **facebook_page**: `https://www.facebook.com/PageName`
+        - **thread**: `https://www.threads.net/@username`
+        - **homepage**: any `https://…` URL
+
+        Each network validates the format via a regex on `Network.profileUrlPattern`;
+        a mismatching URL is rejected at POST time.
+        DESC,
+        example: 'https://mastodon.social/@example',
+    )]
     private ?string $identifier = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -86,17 +102,17 @@ class Profile
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['profile:read'])]
-    #[ApiProperty(description: 'Timestamp of the last successful feed fetch for this profile.', readable: true, writable: false)]
+    #[ApiProperty(description: 'Timestamp of the last successful feed fetch for this profile (ISO 8601). Useful to detect stale profiles or for sorting (`?order[lastFetchSuccessDateTime]=desc`).', readable: true, writable: false)]
     private ?\DateTimeImmutable $lastFetchSuccessDateTime = null;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['profile:read'])]
-    #[ApiProperty(description: 'Timestamp of the last failed feed fetch attempt.', readable: true, writable: false)]
+    #[ApiProperty(description: 'Timestamp of the last failed feed fetch attempt. Paired with lastFetchFailureError to surface profiles that need attention.', readable: true, writable: false)]
     private ?\DateTimeImmutable $lastFetchFailureDateTime = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
     #[Groups(['profile:read'])]
-    #[ApiProperty(description: 'Error message from the last failed fetch attempt, if any.', readable: true, writable: false)]
+    #[ApiProperty(description: 'Free-text reason for the last failed fetch attempt. May contain HTTP status codes, network errors, or upstream API messages.', readable: true, writable: false)]
     private ?string $lastFetchFailureError = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => true])]


### PR DESCRIPTION
The API doc landing pages still reflected the pre-PR-50 state of the API. After the four-PR series (#50–#53) the filter set, the slim-vs-detail split, Timeline pagination, the incremental-sync pattern and the RSS feeds were all undocumented — anyone landing on \`/api/doc\` had to guess.

This PR rewrites both landing pages and enriches the most-hit property descriptions.

## What's documented now

### Top-level description (both \`/api/doc\` and \`/api/docs\`)
- **Quick start**: 4-step curl recipe from \`bin/console app:client:create\` to \`?itemsPerPage=20\`
- **Authentication**: token issuance, header, 401 conditions (missing / invalid / disabled client)
- **Multi-tenancy**: shared profiles, last-client soft-delete, no physical deletes
- **Response visibility defaults**: hidden / soft-deleted exclusion, opt-in via query
- **Slim vs. detail responses**: \`item:read\` / \`profile:read\` group split
- **Media URLs**: \`photoPaths\` vs \`photoUrls\` (absolute via \`UrlHelper\`)
- **Filter tables**: full set of filters for Items and Profiles, with example query strings
- **Pagination**: Hydra response shape with example
- **Incremental sync**: explicit \`createdAt\` cursor recipe for WordPress polling
- **RSS feeds**: both endpoints, parameters, what's in each \`<item>\`
- **Error responses**: RFC 7807 shape and status-code table
- **Conventions**: ISO 8601 timestamps, IRI vs identifier, list of network identifiers

### Feed endpoints in \`/api/doc\` (Nelmio)
Both \`FeedController\` routes now carry \`#[OA\Get(...)]\` attributes (via \`zircote/swagger-php\`) with summary, description, parameter docs (\`since\`, \`until\`, \`limit\`, \`network\`, path \`id\`), and example responses for 200 / 401 / 404. They appear under a new **Feed** tag.

Note: API Platform's native \`/api/docs\` (Swagger UI) only documents its own resources, so the feeds remain discoverable through \`/api/doc\` (Nelmio). Both pages link the same info text.

### Tag groupings (Nelmio)
\`Profile\` · \`Item\` · \`Timeline\` · \`Feed\` · \`Network\` — each with a one-line description.

### Richer property descriptions
- \`Item.dateTime\` — clarified vs \`createdAt\`, ISO 8601 example
- \`Item.createdAt\` — explicit call-out as the recommended cursor for incremental sync
- \`Item.permalink\` — what it's for + example
- \`Profile.identifier\` — per-network format list with examples
- \`Profile.lastFetchSuccessDateTime\`, \`lastFetchFailureDateTime\`, \`lastFetchFailureError\` — what each is good for

## Test plan
- [x] \`bin/phpunit\` — 181/504, no regression vs main
- [x] \`php bin/console lint:container\` — OK
- [x] \`curl /api/docs.json | jq '.info.description'\` — full markdown landing text
- [x] \`curl /api/doc.json | jq '.paths | keys'\` — feeds now listed
- [x] \`curl /api/doc.json | jq '.tags'\` — Feed / Profile / Item / Network tags present
- [ ] Manual: load \`https://your-host/api/doc\` in a browser and walk through the rendered Swagger UI; verify the markdown rendering and the Feed section with its parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)