### PR TITLE
Filter yt-dlp output to real media files only

### DIFF
--- a/src/MediaDownloader/VideoDownloader.php
+++ b/src/MediaDownloader/VideoDownloader.php
@@ -6,6 +6,8 @@ use Symfony\Component\Process\Process;
 
 class VideoDownloader
 {
+    private const VIDEO_EXTENSIONS = ['mp4', 'webm', 'mov', 'mkv', 'm4v', 'avi'];
+
     public function __construct(
         private readonly string $mediaDirectory,
     ) {
@@ -36,17 +38,33 @@ class VideoDownloader
             throw new \RuntimeException(sprintf('yt-dlp failed: %s', $process->getErrorOutput() ?: $process->getOutput()));
         }
 
-        // Find the output file
-        $files = glob(sprintf('%s/video.*', $outputDir));
+        // Find the actual video file — yt-dlp also writes sidecars (.info.json,
+        // .description, .live_chat.json, .vtt, …) which would otherwise match.
+        $absolutePath = $this->findVideoFile($outputDir);
 
-        if (empty($files)) {
-            throw new \RuntimeException('yt-dlp produced no output file');
+        if ($absolutePath === null) {
+            throw new \RuntimeException('yt-dlp produced no video output file');
         }
 
-        // Return relative path
-        $absolutePath = $files[0];
-
         return ltrim(str_replace($this->mediaDirectory, '', $absolutePath), '/');
+    }
+
+    private function findVideoFile(string $outputDir): ?string
+    {
+        $found = glob(sprintf('%s/video.*', $outputDir)) ?: [];
+
+        foreach ($found as $path) {
+            $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+            if (!in_array($extension, self::VIDEO_EXTENSIONS, true)) {
+                continue;
+            }
+            if (!is_file($path) || filesize($path) === 0) {
+                continue;
+            }
+            return $path;
+        }
+
+        return null;
     }
 
     public function isAvailable(): bool

--- a/src/MediaDownloader/YtDlpPhotoDownloader.php
+++ b/src/MediaDownloader/YtDlpPhotoDownloader.php
@@ -6,6 +6,8 @@ use Symfony\Component\Process\Process;
 
 class YtDlpPhotoDownloader
 {
+    private const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif'];
+
     public function __construct(
         private readonly string $mediaDirectory,
     ) {
@@ -41,7 +43,7 @@ class YtDlpPhotoDownloader
             throw new \RuntimeException(sprintf('yt-dlp photo extraction failed: %s', $process->getErrorOutput() ?: $process->getOutput()));
         }
 
-        $files = glob(sprintf('%s/photo_*.*', $outputDir));
+        $files = $this->collectImageFiles($outputDir);
 
         if (empty($files)) {
             return [];
@@ -56,6 +58,29 @@ class YtDlpPhotoDownloader
         }
 
         return $paths;
+    }
+
+    /** @return list<string> */
+    private function collectImageFiles(string $outputDir): array
+    {
+        // yt-dlp may write sidecar files (.info.json, .description, .live_chat.json, …).
+        // Only return real image files, and skip zero-byte writes that occasionally
+        // happen when a thumbnail extraction partially fails.
+        $found = glob(sprintf('%s/photo_*.*', $outputDir)) ?: [];
+
+        $images = [];
+        foreach ($found as $path) {
+            $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+            if (!in_array($extension, self::IMAGE_EXTENSIONS, true)) {
+                continue;
+            }
+            if (!is_file($path) || filesize($path) === 0) {
+                continue;
+            }
+            $images[] = $path;
+        }
+
+        return $images;
     }
 
     public function isAvailable(): bool


### PR DESCRIPTION
## What you're seeing

Item 123308 finished with status \`completed\` but the photo renders as the small broken-image \`[?]\` placeholder and the video player is black with playback controls.

## Diagnosis

Both \`YtDlpPhotoDownloader\` and \`VideoDownloader\` used loose globs (\`photo_*.*\` / \`video.*\`) to find their outputs. yt-dlp also writes sidecar files into the same directory:

- \`*.info.json\` — metadata dump
- \`*.description\` — caption text
- \`*.live_chat.json\` — chat replay for streams
- \`*.vtt\` — subtitles
- \`*.webp\` original thumbnails (before \`--convert-thumbnails jpg\` runs)

Any of those match the globs. If a sidecar is what \`sort()\` returns first, that's what ends up in \`photoPaths\` / \`videoPath\`. The template then renders \`<img src=".../photo_1.info.json">\` (broken placeholder) and \`<video src=".../video.live_chat.json">\` (player loads, no playable source).

## Fix

Both downloaders now:

- Restrict the glob match to a hard-coded allow-list of media extensions
  (jpg/jpeg/png/gif/webp/avif for photos; mp4/webm/mov/mkv/m4v/avi for video).
- Skip zero-byte files — partial yt-dlp failures sometimes leave these.

Existing items in the DB still point at the bad paths from the previous run — re-running "Medien herunterladen" with this code overwrites them with the correct paths.

## Diagnostic step (please run on prod after deploy)

```bash
ls -la public/media/<profileId>/123308/
file public/media/<profileId>/123308/*
```

If you see anything ending in \`.info.json\` / \`.description\` / \`.live_chat.json\` next to your media, that confirms the diagnosis. You can clean those up manually:

```bash
find public/media -name '*.info.json' -delete
find public/media -name '*.description' -delete
find public/media -name '*.live_chat.json' -delete
find public/media -name '*.vtt' -delete
```

## Test plan
- [x] \`bin/phpunit tests/MediaDownloader/\` — 32 tests, 87 assertions, OK
- [ ] After deploy: re-click "Medien herunterladen" on item 123308 and verify the photo renders properly and the video plays. If it still doesn't, share the directory listing from \`ls -la public/media/<profileId>/123308/\` and the related lines from \`var/log/prod.log\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)