### PR TITLE
Surface RSS.app error body and avoid 500 on registration failure

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -169,15 +169,19 @@ class ProfileController extends AbstractController
     public function rssappRegister(Request $request, Profile $profile, RssAppInterface $rssApp, EntityManagerInterface $em): Response
     {
         if ($this->isCsrfTokenValid('rssapp-' . $profile->getId(), $request->request->getString('_token'))) {
-            $feedData = $rssApp->createFeed($profile->getIdentifier());
+            try {
+                $feedData = $rssApp->createFeed($profile->getIdentifier());
 
-            $additionalData = $profile->getAdditionalData() ?? [];
-            $additionalData['rss_feed_id'] = $feedData['id'];
-            $profile->setAdditionalData($additionalData);
+                $additionalData = $profile->getAdditionalData() ?? [];
+                $additionalData['rss_feed_id'] = $feedData['id'];
+                $profile->setAdditionalData($additionalData);
 
-            $em->flush();
+                $em->flush();
 
-            $this->addFlash('success', 'Feed wurde bei RSS.app registriert.');
+                $this->addFlash('success', 'Feed wurde bei RSS.app registriert.');
+            } catch (\Throwable $e) {
+                $this->addFlash('danger', sprintf('Registrierung bei RSS.app fehlgeschlagen: %s', $e->getMessage()));
+            }
         }
 
         return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);

--- a/src/RssApp/RssApp.php
+++ b/src/RssApp/RssApp.php
@@ -89,7 +89,41 @@ class RssApp implements RssAppInterface
             'json' => ['url' => $url],
         ]);
 
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            // Pull the body without triggering toArray's auto-throw, so we can surface
+            // RSS.app's actual error message (e.g. "Unsupported source URL") instead of
+            // a generic "HTTP 400 returned" from Symfony's HttpClient.
+            $body = $response->getContent(throw: false);
+            throw new RssAppException(sprintf(
+                'RSS.app rejected URL "%s" with HTTP %d: %s',
+                $url,
+                $statusCode,
+                $this->extractMessage($body) ?: 'no body',
+            ));
+        }
+
         return $response->toArray();
+    }
+
+    private function extractMessage(string $body): ?string
+    {
+        if ($body === '') {
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+        if (is_array($decoded)) {
+            foreach (['message', 'error', 'detail', 'description'] as $key) {
+                if (isset($decoded[$key]) && is_string($decoded[$key])) {
+                    return $decoded[$key];
+                }
+            }
+        }
+
+        // Fall back to the raw body, trimmed to keep flash messages readable.
+        return mb_substr(trim($body), 0, 200);
     }
 
     public function deleteFeed(string $feedId): void

--- a/src/RssApp/RssAppException.php
+++ b/src/RssApp/RssAppException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace App\RssApp;
+
+class RssAppException extends \RuntimeException
+{
+}


### PR DESCRIPTION
## What you saw

\`POST /profiles/{id}/rssapp-register\` for a Twitter profile → Symfony 500 page with

> HTTP/2 400 returned for "https://api.rss.app/v1/feeds".

No information about *why* RSS.app rejected the URL.

## Diagnosis

\`RssApp::createFeed\` called \`\$response->toArray()\`, which auto-throws \`ClientException\` on non-2xx responses. The Web-UI controller (\`ProfileController::rssappRegister\`) didn't wrap the call, so the exception bubbled up to Symfony's error handler and produced a raw 500 page. RSS.app's actual response body (the bit that says *what* is wrong, e.g. "Unsupported source URL") was discarded by \`toArray\`'s default error path.

## Fix

- **\`RssApp::createFeed\`** now inspects the status itself. On non-2xx it reads the body with \`getContent(throw: false)\`, looks for common error keys (\`message\`/\`error\`/\`detail\`/\`description\`) in JSON or falls back to the trimmed raw body, and throws a domain-specific \`App\RssApp\RssAppException\` with the URL, status code, and decoded message.
- **\`ProfileController::rssappRegister\`** wraps the call in \`try/catch\` and uses \`addFlash('danger', …)\` so failures land in the flash bar on the profile show page instead of a 500.
- Other call sites (\`FeedRegistrar\`, \`ClientScopedProfileProcessor\`, \`RssAppOrphanFeedController\`) already catch \`Throwable\`, so the new exception naturally produces a better message there too without further changes.

After this lands, when RSS.app returns 400 for a Twitter URL you'll see a flash like:

> Registrierung bei RSS.app fehlgeschlagen: RSS.app rejected URL "https://twitter.com/foo" with HTTP 400: <RSS.app's actual error text>

…which tells you whether Twitter is genuinely unsupported on your plan, the URL format isn't accepted, or something else.

## Test plan
- [x] \`bin/phpunit\` — 184 tests, 517 assertions; same 1 pre-existing failure as main
- [x] \`php bin/console lint:container\` — OK
- [ ] After deploy: retry the Twitter-profile registration and confirm the flash message shows RSS.app's actual rejection reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)