### PR TITLE
Groups PR B: Group timeline on show page

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -7,6 +7,8 @@ use App\Entity\Profile;
 use App\Form\GroupType;
 use App\Repository\ClientRepository;
 use App\Repository\GroupRepository;
+use App\Repository\ItemRepository;
+use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,6 +20,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class GroupController extends AbstractController
 {
     private const GROUPS_PER_PAGE = 50;
+    private const TIMELINE_ITEMS_PER_PAGE = 50;
 
     #[Route('', name: 'app_group_index', methods: ['GET'])]
     public function index(Request $request, GroupRepository $groupRepository, ClientRepository $clientRepository): Response
@@ -72,10 +75,40 @@ class GroupController extends AbstractController
     }
 
     #[Route('/{id}', name: 'app_group_show', requirements: ['id' => '\d+'], methods: ['GET'])]
-    public function show(Group $group): Response
-    {
+    public function show(
+        Group $group,
+        Request $request,
+        ItemRepository $itemRepository,
+        NetworkRepository $networkRepository,
+    ): Response {
+        $page = max(1, $request->query->getInt('page', 1));
+        $networkId = $request->query->getInt('network', 0) ?: null;
+
+        $itemCount = $itemRepository->countByGroup($group, $networkId);
+        $pages = max(1, (int) ceil($itemCount / self::TIMELINE_ITEMS_PER_PAGE));
+        $page = min($page, $pages);
+
+        $items = $itemRepository->findPaginatedByGroup($group, $page, self::TIMELINE_ITEMS_PER_PAGE, $networkId);
+
+        // Collect the distinct networks present in the group's live members, so
+        // the network filter offers only what's actually relevant.
+        $networks = [];
+        foreach ($group->getProfiles() as $profile) {
+            if ($profile->isDeleted() || $profile->getNetwork() === null) {
+                continue;
+            }
+            $networks[$profile->getNetwork()->getId()] = $profile->getNetwork();
+        }
+        ksort($networks);
+
         return $this->render('group/show.html.twig', [
             'group' => $group,
+            'items' => $items,
+            'itemCount' => $itemCount,
+            'page' => $page,
+            'pages' => $pages,
+            'networks' => array_values($networks),
+            'selectedNetworkId' => $networkId,
         ]);
     }
 

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -25,6 +25,64 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * Paginated items across all profiles in a group, excluding hidden /
+     * soft-deleted items and items belonging to soft-deleted profiles.
+     *
+     * @return list<Item>
+     */
+    public function findPaginatedByGroup(\App\Entity\Group $group, int $page, int $limit, ?int $networkId = null): array
+    {
+        $qb = $this->groupQueryBuilder($group)
+            ->orderBy('i.dateTime', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        if ($networkId !== null) {
+            $qb->andWhere('n.id = :networkId')->setParameter('networkId', $networkId);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function countByGroup(\App\Entity\Group $group, ?int $networkId = null): int
+    {
+        $qb = $this->groupQueryBuilder($group)->select('COUNT(i.id)');
+
+        if ($networkId !== null) {
+            $qb->andWhere('n.id = :networkId')->setParameter('networkId', $networkId);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    private function groupQueryBuilder(\App\Entity\Group $group): QueryBuilder
+    {
+        $profileIds = [];
+        foreach ($group->getProfiles() as $profile) {
+            if (!$profile->isDeleted()) {
+                $profileIds[] = $profile->getId();
+            }
+        }
+
+        $qb = $this->createQueryBuilder('i')
+            ->leftJoin('i.profile', 'p')
+            ->addSelect('p')
+            ->leftJoin('p.network', 'n')
+            ->addSelect('n')
+            ->andWhere('i.hidden = false')
+            ->andWhere('i.deleted = false');
+
+        if ($profileIds === []) {
+            // Group has no live members → no items. Force-empty result.
+            $qb->andWhere('1 = 0');
+        } else {
+            $qb->andWhere('p.id IN (:profileIds)')->setParameter('profileIds', $profileIds);
+        }
+
+        return $qb;
+    }
+
+    /**
      * @param list<int> $networkIds
      * @return list<Item>
      */

--- a/templates/group/show.html.twig
+++ b/templates/group/show.html.twig
@@ -46,7 +46,7 @@
         </div>
 
         <div class="col-md-8">
-            <div class="data-card">
+            <div class="data-card mb-3">
                 <div class="data-card-header">
                     Mitglieder
                 </div>
@@ -90,6 +90,70 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="data-card">
+                <div class="data-card-header d-flex align-items-center justify-content-between">
+                    <span>Timeline <span class="text-muted small">({{ itemCount }} {{ itemCount == 1 ? 'Item' : 'Items' }})</span></span>
+                    {% if networks|length > 1 %}
+                        <form method="get" class="d-flex gap-2 m-0" action="{{ path('app_group_show', {id: group.id}) }}">
+                            <select name="network" class="form-select form-select-sm" onchange="this.form.submit()">
+                                <option value="">Alle Netzwerke</option>
+                                {% for n in networks %}
+                                    <option value="{{ n.id }}"{% if selectedNetworkId == n.id %} selected{% endif %}>{{ n.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </form>
+                    {% endif %}
+                </div>
+                <div class="data-card-body">
+                    {% if items is empty %}
+                        <p class="text-muted mb-0">Noch keine Items in dieser Gruppe{% if selectedNetworkId %} für das gewählte Netzwerk{% endif %}.</p>
+                    {% else %}
+                        <table class="data-table">
+                            <thead>
+                                <tr>
+                                    <th>Netzwerk</th>
+                                    <th>Profil</th>
+                                    <th>Text</th>
+                                    <th>Datum</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in items %}
+                                    <tr>
+                                        <td>
+                                            {% if item.profile and item.profile.network %}
+                                                <span class="net-badge" style="background-color: {{ item.profile.network.backgroundColor }}; color: {{ item.profile.network.textColor }};">
+                                                    <i class="{{ item.profile.network.icon }} me-1"></i>{{ item.profile.network.name }}
+                                                </span>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            {% if item.profile %}
+                                                <a href="{{ path('app_profile_show', {id: item.profile.id}) }}" class="link-subtle">
+                                                    {{ item.profile.displayName|length > 30 ? item.profile.displayName[:30] ~ '…' : item.profile.displayName }}
+                                                </a>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <a href="{{ path('app_item_show', {id: item.id}) }}" class="link-subtle">
+                                                {{ item.text|length > 80 ? item.text[:80] ~ '…' : item.text }}
+                                            </a>
+                                        </td>
+                                        <td><span class="time-ago" title="{{ item.dateTime|date('d.m.Y H:i:s') }}">{{ item.dateTime|date('d.m.Y H:i') }}</span></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+
+                        {% if pages > 1 %}
+                            <div class="mt-3">
+                                {% include '_partials/_pagination.html.twig' with {page: page, pages: pages} %}
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
Second of five PRs for the Groups feature. Adds a **paginated chronological item timeline** to the group show page.

## Summary

### Repository
- `ItemRepository::findPaginatedByGroup($group, $page, $limit, ?$networkId)` and `::countByGroup($group, ?$networkId)`. Implementation pulls profile IDs from the eagerly-loaded group collection and queries items with an `IN()` clause — keeps the DQL straightforward and side-steps the M:N join.
- Hidden / soft-deleted items and items belonging to soft-deleted profiles are excluded (matches existing defaults).

### Controller / template
- `GroupController::show` now reads `?page=` and `?network=<id>` from the request, computes the live network set from the group's members, and passes items + pagination data to the template.
- `group/show.html.twig` adds a **Timeline** card below the member list with:
  - item count in the header
  - a network filter dropdown (only rendered when the group spans more than one network)
  - a standard items table (network badge, profile link, truncated text, dateTime)
  - shared pagination partial
  - friendly empty states (with and without an active network filter)

## Test plan
- [x] `bin/phpunit` — 189/527, no new regressions; same one pre-existing failure on `main`
- [x] `php bin/console lint:container` — OK
- [x] `php bin/console lint:twig templates/group/` — OK
- [ ] Manual: open a group with multiple member profiles across networks, verify the timeline renders, the network dropdown narrows correctly, and pagination links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)