### PR TITLE
Groups PR C: REST API CRUD + convenience membership routes

### DIFF
--- a/src/Controller/Api/GroupMembershipController.php
+++ b/src/Controller/Api/GroupMembershipController.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Repository\GroupRepository;
+use App\Repository\ProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+class GroupMembershipController
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly GroupRepository $groupRepository,
+        private readonly ProfileRepository $profileRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route('/api/groups/{id}/profiles', name: 'app_api_group_membership_add', requirements: ['id' => '\d+'], methods: ['POST'])]
+    #[OA\Post(
+        summary: 'Add one or more profiles to a group (idempotent).',
+        description: 'Body: `{"profileIds": [42, 43]}` *or* `{"profiles": ["/api/profiles/42", "/api/profiles/43"]}`. Each profile must already be linked to the authenticated client. Already-member profiles are silently kept.',
+        tags: ['Group'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'profileIds', type: 'array', items: new OA\Items(type: 'integer'), example: [42, 43]),
+                    new OA\Property(property: 'profiles', type: 'array', items: new OA\Items(type: 'string', format: 'iri'), example: ['/api/profiles/42', '/api/profiles/43']),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Profiles added. Returns the resulting profile id list.'),
+            new OA\Response(response: 400, description: 'Body missing profile ids or referenced profile not linked to client.'),
+            new OA\Response(response: 404, description: 'Group not found or not owned by client.'),
+        ],
+    )]
+    public function add(int $id, Request $request): JsonResponse
+    {
+        $client = $this->requireClient();
+        $group = $this->requireOwnedGroup($id, $client);
+
+        $payload = $this->decodeJson($request);
+        $profileIds = $this->extractProfileIds($payload);
+
+        if ($profileIds === []) {
+            throw new BadRequestHttpException('Request must include profileIds or profiles.');
+        }
+
+        foreach ($profileIds as $profileId) {
+            $profile = $this->profileRepository->find($profileId);
+            if ($profile === null) {
+                throw new BadRequestHttpException(sprintf('Profile %d not found.', $profileId));
+            }
+            if (!$profile->getClients()->contains($client)) {
+                throw new BadRequestHttpException(sprintf('Profile %d is not linked to your client.', $profileId));
+            }
+            $group->addProfile($profile);
+        }
+
+        $this->em->flush();
+
+        return new JsonResponse([
+            'id' => $group->getId(),
+            'profileIds' => array_values(array_map(fn($p) => $p->getId(), $group->getProfiles()->toArray())),
+        ]);
+    }
+
+    #[Route('/api/groups/{id}/profiles/{profileId}', name: 'app_api_group_membership_remove', requirements: ['id' => '\d+', 'profileId' => '\d+'], methods: ['DELETE'])]
+    #[OA\Delete(
+        summary: 'Remove a profile from a group.',
+        description: 'Removes a single profile membership. The profile itself stays untouched; only the link to this group is removed.',
+        tags: ['Group'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'profileId', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Removed (or was not a member to begin with).'),
+            new OA\Response(response: 404, description: 'Group not found or not owned by client.'),
+        ],
+    )]
+    public function remove(int $id, int $profileId): Response
+    {
+        $client = $this->requireClient();
+        $group = $this->requireOwnedGroup($id, $client);
+
+        $profile = $this->profileRepository->find($profileId);
+        if ($profile !== null) {
+            $group->removeProfile($profile);
+            $this->em->flush();
+        }
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function requireClient(): Client
+    {
+        $client = $this->security->getUser();
+        if (!$client instanceof Client) {
+            throw new AccessDeniedHttpException();
+        }
+        return $client;
+    }
+
+    private function requireOwnedGroup(int $id, Client $client): Group
+    {
+        $group = $this->groupRepository->find($id);
+        if ($group === null || $group->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
+        return $group;
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJson(Request $request): array
+    {
+        $raw = $request->getContent();
+        if ($raw === '') {
+            return [];
+        }
+        try {
+            $decoded = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new BadRequestHttpException('Body must be valid JSON: ' . $e->getMessage());
+        }
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return list<int>
+     */
+    private function extractProfileIds(array $payload): array
+    {
+        $ids = [];
+
+        if (isset($payload['profileIds']) && is_array($payload['profileIds'])) {
+            foreach ($payload['profileIds'] as $value) {
+                $id = (int) $value;
+                if ($id > 0) {
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        if (isset($payload['profiles']) && is_array($payload['profiles'])) {
+            foreach ($payload['profiles'] as $value) {
+                if (!is_string($value)) {
+                    continue;
+                }
+                if (preg_match('#/api/profiles/(\d+)$#', $value, $m)) {
+                    $ids[] = (int) $m[1];
+                }
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/src/Doctrine/Extension/ClientScopedGroupExtension.php
+++ b/src/Doctrine/Extension/ClientScopedGroupExtension.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Doctrine\Extension;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Client;
+use App\Entity\Group;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class ClientScopedGroupExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        if ($resourceClass !== Group::class) {
+            return;
+        }
+
+        $this->scope($queryBuilder);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        if ($resourceClass !== Group::class) {
+            return;
+        }
+
+        $this->scope($queryBuilder);
+    }
+
+    private function scope(QueryBuilder $queryBuilder): void
+    {
+        $client = $this->security->getUser();
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
+        if (!$client instanceof Client) {
+            $queryBuilder->andWhere('1 = 0');
+            return;
+        }
+
+        $queryBuilder
+            ->andWhere(sprintf('%s.client = :clientScopeId', $rootAlias))
+            ->setParameter('clientScopeId', $client->getId());
+    }
+}

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -2,35 +2,97 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
 use App\Repository\GroupRepository;
+use App\State\ClientScopedGroupProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Table(name: 'profile_group')]
 #[ORM\UniqueConstraint(name: 'uniq_group_client_name', columns: ['client_id', 'name'])]
 #[ORM\Entity(repositoryClass: GroupRepository::class)]
+#[ApiResource(
+    shortName: 'Group',
+    operations: [
+        new GetCollection(
+            description: 'Returns all groups owned by the authenticated client, ordered by name. Slim group:read group — pass through the single GET for embedded member profiles.',
+        ),
+        new Get(
+            description: 'Returns a single group with its member profiles embedded.',
+            normalizationContext: ['groups' => ['group:read', 'group:detail']],
+        ),
+        new Post(
+            description: 'Creates a new group owned by the authenticated client. Pass profiles as a list of profile IRIs; they must already be linked to the client.',
+            processor: ClientScopedGroupProcessor::class,
+        ),
+        new Put(
+            description: 'Replaces an existing group (full replacement, including the profiles list).',
+            processor: ClientScopedGroupProcessor::class,
+        ),
+        new Patch(
+            description: 'Partial update of an existing group.',
+            processor: ClientScopedGroupProcessor::class,
+        ),
+        new Delete(
+            description: 'Deletes the group (hard delete). Member profiles are untouched.',
+            processor: ClientScopedGroupProcessor::class,
+        ),
+    ],
+    description: 'A named bundle of profiles, scoped to one API client. Profiles can be in multiple groups. Use /api/groups/{id}/items for the aggregated chronological timeline and /api/feeds/groups/{id}.rss for an RSS feed.',
+    normalizationContext: ['groups' => ['group:read']],
+    denormalizationContext: ['groups' => ['group:write']],
+    order: ['name' => 'ASC'],
+    paginationItemsPerPage: 50,
+)]
+#[ApiFilter(SearchFilter::class, properties: [
+    'name' => 'partial',
+    'profiles' => 'exact',
+])]
+#[ApiFilter(OrderFilter::class, properties: ['name', 'createdAt'])]
 class Group
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Unique identifier of the group.', readable: true, writable: false)]
     private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 64)]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Human-readable name of the group. Must be unique within the client.', example: 'Klima')]
     private ?string $name = null;
 
     #[ORM\ManyToOne(targetEntity: Client::class)]
     #[ORM\JoinColumn(name: 'client_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[ApiProperty(description: 'The owning client. Set automatically from the Bearer token; not writable via the API.', readable: false, writable: false)]
     private ?Client $client = null;
 
     #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Optional free-text description.')]
     private ?string $description = null;
 
     #[ORM\Column(type: 'string', length: 7, nullable: true)]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Optional badge color (#rrggbb).', example: '#6366f1')]
     private ?string $color = null;
 
     #[ORM\Column(name: 'created_at', type: 'datetime_immutable', nullable: false)]
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Timestamp when this group was created.', readable: true, writable: false)]
     private \DateTimeImmutable $createdAt;
 
     /** @var Collection<int, Profile> */
@@ -38,6 +100,8 @@ class Group
     #[ORM\JoinTable(name: 'profile_group_profile')]
     #[ORM\JoinColumn(name: 'group_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[ORM\InverseJoinColumn(name: 'profile_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['group:detail', 'group:write'])]
+    #[ApiProperty(description: 'Profiles that belong to this group. Pass as a list of profile IRIs, e.g. ["/api/profiles/42", "/api/profiles/43"]. Only included on the single-resource GET.')]
     private Collection $profiles;
 
     public function __construct()
@@ -133,6 +197,8 @@ class Group
         return $this;
     }
 
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Number of profiles in this group. Computed; readable in collection responses where the full profile list is omitted.', readable: true, writable: false)]
     public function getProfileCount(): int
     {
         return $this->profiles->count();

--- a/src/State/ClientScopedGroupProcessor.php
+++ b/src/State/ClientScopedGroupProcessor.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Profile;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/** @implements ProcessorInterface<Group, Group|null> */
+class ClientScopedGroupProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly Security $security,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?Group
+    {
+        $client = $this->security->getUser();
+        if (!$client instanceof Client) {
+            throw new AccessDeniedHttpException('Authentication required.');
+        }
+
+        if ($operation instanceof Delete) {
+            return $this->handleDelete($client, (int) $uriVariables['id']);
+        }
+
+        return $this->handleUpsert($client, $data);
+    }
+
+    private function handleUpsert(Client $client, Group $group): Group
+    {
+        $existingClient = $group->getClient();
+
+        if ($existingClient !== null && $existingClient->getId() !== $client->getId()) {
+            // Someone tried to PUT/PATCH a foreign client's group; the extension
+            // should have prevented loading it, but double-check defensively.
+            throw new NotFoundHttpException('Group not found.');
+        }
+
+        // POSTed groups arrive without a client. Always set / override to the
+        // authenticated client — clients can never create groups for others.
+        $group->setClient($client);
+
+        $this->ensureProfilesBelongToClient($client, $group);
+
+        $this->em->persist($group);
+        $this->em->flush();
+
+        return $group;
+    }
+
+    private function handleDelete(Client $client, int $groupId): null
+    {
+        $group = $this->em->getRepository(Group::class)->find($groupId);
+        if ($group === null || $group->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
+
+        $this->em->remove($group);
+        $this->em->flush();
+
+        return null;
+    }
+
+    private function ensureProfilesBelongToClient(Client $client, Group $group): void
+    {
+        foreach ($group->getProfiles() as $profile) {
+            assert($profile instanceof Profile);
+            if (!$profile->getClients()->contains($client)) {
+                throw new BadRequestHttpException(sprintf(
+                    'Profile "%s" (id=%d) is not linked to your client. Link it via POST /api/profiles first.',
+                    $profile->getDisplayName(),
+                    $profile->getId() ?? 0,
+                ));
+            }
+        }
+    }
+}

--- a/tests/Functional/Api/GroupApiTest.php
+++ b/tests/Functional/Api/GroupApiTest.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Api;
+
+use App\Tests\Functional\AbstractApiTestCase;
+
+class GroupApiTest extends AbstractApiTestCase
+{
+    public function testGetCollectionEmptyInitially(): void
+    {
+        $response = $this->requestAsClientA('GET', '/api/groups');
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $members = $data['hydra:member'] ?? $data['member'] ?? [];
+        $this->assertSame([], $members);
+    }
+
+    public function testPostCreateGroup(): void
+    {
+        $sharedProfileIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+
+        $response = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => [
+                'name' => 'My Mix',
+                'description' => 'Test group',
+                'color' => '#ff8800',
+                'profiles' => [$sharedProfileIri],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+        $this->assertSame('My Mix', $data['name']);
+        $this->assertSame(1, $data['profileCount']);
+    }
+
+    public function testPostRefusesProfileNotLinkedToClient(): void
+    {
+        // ClientA tries to add profileOnlyB (linked to clientB)
+        $onlyBProfileId = $this->lookupProfileIdAsClientB('https://mastodon.social/@onlyb');
+
+        $this->requestAsClientA('POST', '/api/groups', [
+            'json' => [
+                'name' => 'Bad Group',
+                'profiles' => ['/api/profiles/' . $onlyBProfileId],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testGetSingleGroupEmbedsProfiles(): void
+    {
+        $groupId = $this->createGroup('Detail Test', [
+            $this->ownedProfileIri('https://mastodon.social/@shared'),
+        ]);
+
+        $response = $this->requestAsClientA('GET', '/api/groups/' . $groupId);
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $this->assertSame('Detail Test', $data['name']);
+        $this->assertArrayHasKey('profiles', $data);
+        $this->assertCount(1, $data['profiles']);
+    }
+
+    public function testGetCollectionDoesNotEmbedProfiles(): void
+    {
+        $this->createGroup('Slim Test', [
+            $this->ownedProfileIri('https://mastodon.social/@shared'),
+        ]);
+
+        $response = $this->requestAsClientA('GET', '/api/groups');
+        $data = $response->toArray();
+        $members = $data['hydra:member'] ?? $data['member'] ?? [];
+
+        $this->assertNotEmpty($members);
+        foreach ($members as $group) {
+            $this->assertArrayNotHasKey('profiles', $group);
+            $this->assertArrayHasKey('profileCount', $group);
+        }
+    }
+
+    public function testClientAndClientBSeeSeparateGroups(): void
+    {
+        $this->createGroup('Group A', [], 'A');
+        $this->createGroup('Group B', [], 'B');
+
+        $aMembers = $this->extractMembers($this->requestAsClientA('GET', '/api/groups'));
+        $bMembers = $this->extractMembers($this->requestAsClientB('GET', '/api/groups'));
+
+        $aNames = array_map(fn($g) => $g['name'], $aMembers);
+        $bNames = array_map(fn($g) => $g['name'], $bMembers);
+
+        $this->assertContains('Group A', $aNames);
+        $this->assertNotContains('Group B', $aNames);
+        $this->assertContains('Group B', $bNames);
+        $this->assertNotContains('Group A', $bNames);
+    }
+
+    public function testGetForeignGroupReturns404(): void
+    {
+        $groupId = $this->createGroup('Other client group', [], 'B');
+
+        $this->requestAsClientA('GET', '/api/groups/' . $groupId);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testDeleteGroup(): void
+    {
+        $groupId = $this->createGroup('To delete', []);
+
+        $this->requestAsClientA('DELETE', '/api/groups/' . $groupId);
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->requestAsClientA('GET', '/api/groups/' . $groupId);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testAddProfilesConvenienceRoute(): void
+    {
+        $groupId = $this->createGroup('Membership Test', []);
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+
+        $response = $this->requestAsClientA('POST', '/api/groups/' . $groupId . '/profiles', [
+            'json' => ['profiles' => [$sharedIri]],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $check = $this->requestAsClientA('GET', '/api/groups/' . $groupId)->toArray();
+        $this->assertCount(1, $check['profiles']);
+    }
+
+    public function testAddProfilesRefusesForeignProfile(): void
+    {
+        $groupId = $this->createGroup('Membership Test', []);
+        $onlyBProfileId = $this->lookupProfileIdAsClientB('https://mastodon.social/@onlyb');
+
+        $this->requestAsClientA('POST', '/api/groups/' . $groupId . '/profiles', [
+            'json' => ['profileIds' => [$onlyBProfileId]],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testRemoveProfileConvenienceRoute(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Membership Test', [$sharedIri]);
+
+        $sharedId = (int) substr($sharedIri, strrpos($sharedIri, '/') + 1);
+
+        $this->requestAsClientA('DELETE', sprintf('/api/groups/%d/profiles/%d', $groupId, $sharedId));
+        $this->assertResponseStatusCodeSame(204);
+
+        $check = $this->requestAsClientA('GET', '/api/groups/' . $groupId)->toArray();
+        $this->assertSame([], $check['profiles']);
+    }
+
+    public function testForeignGroupCannotBeModified(): void
+    {
+        $groupId = $this->createGroup('Other client group', [], 'B');
+
+        $this->requestAsClientA('DELETE', '/api/groups/' . $groupId);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function extractMembers(\Symfony\Contracts\HttpClient\ResponseInterface $response): array
+    {
+        $data = $response->toArray();
+        return $data['hydra:member'] ?? $data['member'] ?? [];
+    }
+
+    private function ownedProfileIri(string $identifier, string $client = 'A'): string
+    {
+        $response = $client === 'A'
+            ? $this->requestAsClientA('GET', '/api/profiles')
+            : $this->requestAsClientB('GET', '/api/profiles');
+
+        foreach ($this->extractMembers($response) as $profile) {
+            if (($profile['identifier'] ?? null) === $identifier) {
+                return '/api/profiles/' . $profile['id'];
+            }
+        }
+        throw new \RuntimeException(sprintf('Profile %s not found for client %s', $identifier, $client));
+    }
+
+    private function lookupProfileIdAsClientB(string $identifier): int
+    {
+        $response = $this->requestAsClientB('GET', '/api/profiles');
+        $members = $this->extractMembers($response);
+
+        foreach ($members as $profile) {
+            if ($profile['identifier'] === $identifier) {
+                return (int) $profile['id'];
+            }
+        }
+        throw new \RuntimeException('Profile not found: ' . $identifier);
+    }
+
+    /** @param list<string> $profileIris */
+    private function createGroup(string $name, array $profileIris = [], string $client = 'A'): int
+    {
+        $response = $client === 'A'
+            ? $this->requestAsClientA('POST', '/api/groups', ['json' => ['name' => $name, 'profiles' => $profileIris]])
+            : $this->requestAsClientB('POST', '/api/groups', ['json' => ['name' => $name, 'profiles' => $profileIris]]);
+
+        $this->assertResponseStatusCodeSame(201);
+        return (int) $response->toArray()['id'];
+    }
+}


### PR DESCRIPTION
Third of five PRs for the Groups feature. Wires `Group` into the REST API end-to-end.

## Summary

### ApiResource (Group)
- `GET /api/groups` — paginated collection, slim `group:read` (id, name, color, description, createdAt, `profileCount`); no embedded profile list.
- `GET /api/groups/{id}` — adds `group:detail` so the embedded `profiles` array shows up.
- `POST /api/groups`, `PUT /api/groups/{id}`, `PATCH /api/groups/{id}`, `DELETE /api/groups/{id}` — all routed through `App\State\ClientScopedGroupProcessor`.
- Filters: `name` (partial), `profiles` (exact). `OrderFilter` on `name`, `createdAt`. Default: `?order[name]=asc`, 50 per page.

### Client scoping
- `App\Doctrine\Extension\ClientScopedGroupExtension` (`QueryCollectionExtension` + `QueryItemExtension`) scopes the default Doctrine providers to `g.client = currentClient`. Same pattern as Profile / Item.
- `App\State\ClientScopedGroupProcessor`:
  - Forces `Group.client` to the authenticated client on POST / PUT / PATCH (can't be spoofed).
  - Verifies every profile in the relationship is linked to that client (Profile↔Client M:N) → 400 otherwise.
  - DELETE 404s when the client doesn't own the group.
- `client` field is `readable: false, writable: false` — never in any payload.

### Convenience membership routes
- `POST /api/groups/{id}/profiles` — body accepts `{"profileIds": [42, 43]}` *or* `{"profiles": ["/api/profiles/42", ...]}`. Idempotent. Each profile must be linked to the client (400 otherwise).
- `DELETE /api/groups/{id}/profiles/{profileId}` — single removal, 204.
- Both routes carry `OpenApi` attributes so they appear in `/api/doc` under the Group tag with parameter docs and response codes.

## Test plan
- [x] `bin/phpunit` — 201/563, no new regressions; same one pre-existing failure as on `main`
- [x] `php bin/console lint:container` — OK
- [x] `php bin/console debug:router` — 6 API Platform Group routes + 2 convenience routes registered
- [ ] Manual via curl:
  ```bash
  # list (empty after fresh deploy)
  curl -H 'Authorization: Bearer <token>' https://your-host/api/groups
  # create
  curl -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
    -d '{"name":"Demo","profiles":["/api/profiles/42"]}' \
    https://your-host/api/groups
  # single
  curl -H 'Authorization: Bearer <token>' https://your-host/api/groups/1
  # add via convenience
  curl -X POST -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' \
    -d '{"profileIds":[43]}' \
    https://your-host/api/groups/1/profiles
  ```

## Next planned PRs
- **D**: `GET /api/groups/{id}/items` + `GET /api/feeds/groups/{id}.rss`
- **E**: Client-token login for the Web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)