### PR TITLE
Groups PR D: /api/groups/{id}/items + RSS feed

### DIFF
--- a/src/Controller/Api/FeedController.php
+++ b/src/Controller/Api/FeedController.php
@@ -3,8 +3,10 @@
 namespace App\Controller\Api;
 
 use App\Entity\Client;
+use App\Entity\Group;
 use App\Entity\Item;
 use App\Entity\Profile;
+use App\Repository\GroupRepository;
 use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,6 +28,7 @@ class FeedController
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly ProfileRepository $profileRepository,
+        private readonly GroupRepository $groupRepository,
         private readonly Security $security,
         private readonly UrlHelper $urlHelper,
     ) {
@@ -168,6 +171,100 @@ class FeedController
         return $this->buildRssResponse(
             title: $title,
             description: sprintf('Feed of items from %s on %s.', $profile->getDisplayName(), $networkName),
+            selfUrl: $this->urlHelper->getAbsoluteUrl($request->getRequestUri()),
+            items: $items,
+        );
+    }
+
+    #[Route('/api/feeds/groups/{id}.rss', name: 'app_api_feed_group', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[OA\Get(
+        summary: 'Per-group RSS feed.',
+        description: <<<'DESC'
+        RSS 2.0 feed for a single group: items across every (non-soft-deleted)
+        member profile, dateTime DESC. Returns 404 if the group is not owned by
+        the authenticated client. Hidden / soft-deleted items are excluded.
+
+        Item structure matches `/api/feeds/timeline.rss`. Each `<item>` carries
+        the originating profile's network as `<category>` and the profile's
+        display name as `<dc:creator>` so consumer-side templates can
+        differentiate items from different networks even though they all live
+        in the same feed.
+
+        Use this for embedding a topical bundle of accounts (e.g. "all the
+        Mastodon, Instagram, Bluesky and Twitter accounts on the topic of
+        climate") into a WordPress site as a single feed.
+        DESC,
+        tags: ['Feed', 'Group'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Group ID.', schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'limit', in: 'query', description: 'Maximum number of items in the feed (default 100, max 200).', schema: new OA\Schema(type: 'integer', default: 100, minimum: 1, maximum: 200)),
+            new OA\Parameter(name: 'network', in: 'query', description: 'Optional: filter to a single network identifier.', schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'RSS 2.0 XML feed.', content: new OA\MediaType(mediaType: 'application/rss+xml')),
+            new OA\Response(response: 401, description: 'Missing or invalid Bearer token.'),
+            new OA\Response(response: 404, description: 'Group not found or not owned by the authenticated client.'),
+        ],
+    )]
+    public function groupFeed(int $id, Request $request): Response
+    {
+        $client = $this->requireClient();
+
+        $group = $this->groupRepository->find($id);
+        if ($group === null || $group->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
+
+        $limit = min(
+            max(1, $request->query->getInt('limit', self::DEFAULT_LIMIT)),
+            self::MAX_LIMIT,
+        );
+
+        $profileIds = [];
+        foreach ($group->getProfiles() as $profile) {
+            if (!$profile->isDeleted() && $profile->getId() !== null) {
+                $profileIds[] = $profile->getId();
+            }
+        }
+
+        if ($profileIds === []) {
+            return $this->buildRssResponse(
+                title: sprintf('%s — Gruppe', $group->getName() ?? '?'),
+                description: 'Aggregated feed across the group\'s member profiles.',
+                selfUrl: $this->urlHelper->getAbsoluteUrl($request->getRequestUri()),
+                items: [],
+            );
+        }
+
+        $qb = $this->em->createQueryBuilder()
+            ->select('i')
+            ->from(Item::class, 'i')
+            ->innerJoin('i.profile', 'p')
+            ->where('p.id IN (:profileIds)')
+            ->andWhere('p.deleted = false')
+            ->andWhere('i.hidden = false')
+            ->andWhere('i.deleted = false')
+            ->setParameter('profileIds', $profileIds)
+            ->orderBy('i.dateTime', 'DESC')
+            ->setMaxResults($limit);
+
+        $network = $request->query->get('network');
+        if ($network !== null) {
+            $qb->innerJoin('p.network', 'n')
+                ->andWhere('n.identifier = :network')
+                ->setParameter('network', $network);
+        }
+
+        $items = $qb->getQuery()->getResult();
+
+        $title = sprintf('%s — Gruppe', $group->getName() ?? '?');
+        if ($network !== null) {
+            $title .= sprintf(' (%s)', $network);
+        }
+
+        return $this->buildRssResponse(
+            title: $title,
+            description: sprintf('Aggregated feed across the %d profiles in group "%s".', count($profileIds), $group->getName() ?? '?'),
             selfUrl: $this->urlHelper->getAbsoluteUrl($request->getRequestUri()),
             items: $items,
         );

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -15,6 +15,7 @@ use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use App\State\GroupItemsProvider;
 use App\State\TimelineProvider;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -33,6 +34,26 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
             See available filters below for full query options.
             TEXT,
+        ),
+        new GetCollection(
+            uriTemplate: '/groups/{groupId}/items',
+            uriVariables: ['groupId'],
+            provider: GroupItemsProvider::class,
+            description: 'Chronological items across every (non-soft-deleted) member profile of the group. Hidden / deleted items excluded, dateTime DESC, paginated 50 per page (max 200). Supports `?since=`, `?until=` and `?network=` (network identifier). 404 if the group does not belong to the authenticated client.',
+            openapi: new OpenApiOperation(
+                summary: 'Get all items for a group',
+                parameters: [
+                    new Parameter(name: 'groupId', in: 'path', required: true, schema: ['type' => 'integer']),
+                    new Parameter(name: 'page', in: 'query', description: 'Page number (default: 1).', schema: ['type' => 'integer', 'default' => 1, 'minimum' => 1]),
+                    new Parameter(name: 'itemsPerPage', in: 'query', description: 'Items per page (default: 50, max: 200).', schema: ['type' => 'integer', 'default' => 50, 'minimum' => 1, 'maximum' => 200]),
+                    new Parameter(name: 'since', in: 'query', description: 'Return items published after this timestamp (ISO 8601).', schema: ['type' => 'string', 'format' => 'date-time']),
+                    new Parameter(name: 'until', in: 'query', description: 'Return items published before this timestamp (ISO 8601).', schema: ['type' => 'string', 'format' => 'date-time']),
+                    new Parameter(name: 'network', in: 'query', description: 'Filter by network identifier (e.g. mastodon).', schema: ['type' => 'string']),
+                ],
+            ),
+            paginationEnabled: true,
+            paginationItemsPerPage: 50,
+            paginationMaximumItemsPerPage: 200,
         ),
         new GetCollection(
             uriTemplate: '/timeline',

--- a/src/State/GroupItemsProvider.php
+++ b/src/State/GroupItemsProvider.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Doctrine\Orm\Paginator;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Item;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Provides paginated items for a single group: /api/groups/{groupId}/items.
+ *
+ * @implements ProviderInterface<Item>
+ */
+class GroupItemsProvider implements ProviderInterface
+{
+    public const DEFAULT_ITEMS_PER_PAGE = 50;
+    public const MAX_ITEMS_PER_PAGE = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Paginator|array
+    {
+        $client = $this->security->getUser();
+        if (!$client instanceof Client) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $groupId = (int) ($uriVariables['groupId'] ?? 0);
+        $group = $this->em->getRepository(Group::class)->find($groupId);
+        if ($group === null || $group->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
+
+        $filters = $context['filters'] ?? [];
+
+        $page = max(1, (int) ($filters['page'] ?? 1));
+        $requestedPerPage = $filters['itemsPerPage'] ?? self::DEFAULT_ITEMS_PER_PAGE;
+        $itemsPerPage = min(max(1, (int) $requestedPerPage), self::MAX_ITEMS_PER_PAGE);
+
+        $profileIds = $this->liveProfileIds($group);
+        if ($profileIds === []) {
+            // Group has no non-soft-deleted members — return an empty page so the
+            // Hydra envelope still carries totalItems=0 for the client.
+            return new Paginator(new DoctrinePaginator(
+                $this->em->createQueryBuilder()
+                    ->select('i')->from(Item::class, 'i')->where('1 = 0')
+                    ->setMaxResults($itemsPerPage)
+                    ->setFirstResult(($page - 1) * $itemsPerPage)
+                    ->getQuery()
+            ));
+        }
+
+        $qb = $this->em->createQueryBuilder()
+            ->select('i')
+            ->from(Item::class, 'i')
+            ->innerJoin('i.profile', 'p')
+            ->andWhere('p.id IN (:profileIds)')
+            ->andWhere('p.deleted = false')
+            ->andWhere('i.hidden = false')
+            ->andWhere('i.deleted = false')
+            ->setParameter('profileIds', $profileIds)
+            ->orderBy('i.dateTime', 'DESC')
+            ->setFirstResult(($page - 1) * $itemsPerPage)
+            ->setMaxResults($itemsPerPage);
+
+        $this->applyOptionalFilters($qb, $filters);
+
+        return new Paginator(new DoctrinePaginator($qb->getQuery()));
+    }
+
+    /** @return list<int> */
+    private function liveProfileIds(Group $group): array
+    {
+        $ids = [];
+        foreach ($group->getProfiles() as $profile) {
+            if (!$profile->isDeleted() && $profile->getId() !== null) {
+                $ids[] = $profile->getId();
+            }
+        }
+        return $ids;
+    }
+
+    /** @param array<string, mixed> $filters */
+    private function applyOptionalFilters(\Doctrine\ORM\QueryBuilder $qb, array $filters): void
+    {
+        if (!empty($filters['network'])) {
+            $qb->innerJoin('p.network', 'n')
+                ->andWhere('n.identifier = :networkIdentifier')
+                ->setParameter('networkIdentifier', (string) $filters['network']);
+        }
+
+        if (!empty($filters['since'])) {
+            $qb->andWhere('i.dateTime >= :since')
+                ->setParameter('since', new \DateTimeImmutable((string) $filters['since']));
+        }
+
+        if (!empty($filters['until'])) {
+            $qb->andWhere('i.dateTime <= :until')
+                ->setParameter('until', new \DateTimeImmutable((string) $filters['until']));
+        }
+    }
+}

--- a/tests/Functional/Api/GroupApiTest.php
+++ b/tests/Functional/Api/GroupApiTest.php
@@ -167,6 +167,64 @@ class GroupApiTest extends AbstractApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testGroupItemsEndpoint(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Items Test', [$sharedIri]);
+
+        $response = $this->requestAsClientA('GET', '/api/groups/' . $groupId . '/items');
+        $this->assertResponseIsSuccessful();
+
+        $items = $this->extractMembers($response);
+        $this->assertNotEmpty($items, 'group items endpoint should return shared items');
+        foreach ($items as $item) {
+            $this->assertStringContainsString('Shared', $item['text']);
+        }
+    }
+
+    public function testGroupItemsEndpoint404ForForeignGroup(): void
+    {
+        $groupId = $this->createGroup('Foreign Items Test', [], 'B');
+
+        $this->requestAsClientA('GET', '/api/groups/' . $groupId . '/items');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testGroupItemsExcludesHiddenAndDeleted(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Hidden Test', [$sharedIri]);
+
+        $items = $this->extractMembers($this->requestAsClientA('GET', '/api/groups/' . $groupId . '/items'));
+        $texts = array_map(fn($i) => $i['text'], $items);
+
+        $this->assertNotContains('Shared hidden item', $texts);
+        $this->assertNotContains('Shared soft-deleted item', $texts);
+    }
+
+    public function testGroupRssFeed(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Rss Test', [$sharedIri]);
+
+        $response = $this->requestAsClientA('GET', '/api/feeds/groups/' . $groupId . '.rss', ['headers' => ['Accept' => '*/*']]);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('application/rss+xml', $response->getHeaders()['content-type'][0]);
+
+        $body = $response->getContent();
+        $this->assertStringStartsWith('<?xml', $body);
+        $this->assertStringContainsString('<rss ', $body);
+        $this->assertStringContainsString('Shared item 1', $body);
+    }
+
+    public function testGroupRssFeed404ForForeignGroup(): void
+    {
+        $groupId = $this->createGroup('Foreign Rss Test', [], 'B');
+
+        $this->requestAsClientA('GET', '/api/feeds/groups/' . $groupId . '.rss', ['headers' => ['Accept' => '*/*']]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     private function extractMembers(\Symfony\Contracts\HttpClient\ResponseInterface $response): array
     {
         $data = $response->toArray();


### PR DESCRIPTION
Fourth of five PRs for the Groups feature. Exposes a group's aggregated item timeline via two API surfaces — JSON-LD for programmatic consumers, RSS 2.0 for feed-aggregator tooling.

## Summary

### `GET /api/groups/{groupId}/items`
- Paginated JSON-LD collection across every (non-soft-deleted) member profile of the group.
- `dateTime` DESC, hidden / soft-deleted items excluded.
- Pagination identical to `/api/items` (`?page=`, `?itemsPerPage=`, default 50, max 200).
- Query filters: `?since=`, `?until=` (ISO 8601), `?network=<identifier>`.
- 404 if the group doesn't belong to the authenticated client.
- Implemented as an additional `GetCollection` on the Item `ApiResource` with `uriTemplate: /groups/{groupId}/items` and a custom `GroupItemsProvider` that returns an `ApiPlatform\Doctrine\Orm\Paginator`, so the Hydra envelope (`hydra:totalItems`, `hydra:view`) lands automatically.

### `GET /api/feeds/groups/{id}.rss`
- RSS 2.0 feed across the group's members.
- Item structure identical to `/api/feeds/timeline.rss`. Each `<item>` carries the originating profile's network as `<category>` and the profile's display name as `<dc:creator>` so consumer-side templates can differentiate items from different networks within the same feed.
- Query params: `?limit=` (max 200), optional `?network=<identifier>`.

### Internals
- `GroupItemsProvider` pulls profile IDs from the eagerly-loaded group collection (skipping soft-deleted profiles) and uses an `IN()` query on items. Same pattern as `ItemRepository::findPaginatedByGroup` from PR B.
- `FeedController::groupFeed` reuses the existing `buildRssResponse` helper, so the Atom self-link, generator name, dc:creator handling and enclosure logic come along for free.

## Test plan
- [x] `bin/phpunit` — 206/582, no new regressions; same 1 pre-existing failure on `main`
- [x] `php bin/console lint:container` — OK
- [x] 5 new in `GroupApiTest`: items endpoint returns items, items endpoint 404 for foreign group, items endpoint excludes hidden/deleted, RSS endpoint returns valid XML with right Content-Type, RSS endpoint 404 for foreign group
- [ ] Manual via curl:
  ```bash
  # JSON-LD timeline of group 1
  curl -H 'Authorization: Bearer <token>' \
    'https://your-host/api/groups/1/items?itemsPerPage=20'

  # Same as RSS (e.g. for a Feedzy widget)
  curl -H 'Authorization: Bearer <token>' \
    'https://your-host/api/feeds/groups/1.rss?limit=20&network=mastodon'
  ```

## Next planned PR
- **E**: Client-token login for the Web UI (so non-admin users can manage their own groups via the UI as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)