### PR TITLE
Groups PR E: Client-token login for the Web UI

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,6 +9,10 @@ security:
         web_user_provider:
             id: App\Security\WebUserProvider
 
+        web_combined_provider:
+            chain:
+                providers: ['web_user_provider', 'client_token_provider']
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
@@ -23,13 +27,15 @@ security:
 
         main:
             pattern: ^/
-            provider: web_user_provider
+            provider: web_combined_provider
             lazy: true
             form_login:
                 login_path: app_login
                 check_path: app_login
                 default_target_path: app_dashboard
                 enable_csrf: true
+            custom_authenticators:
+                - App\Security\WebTokenAuthenticator
             logout:
                 path: app_logout
                 target: app_login
@@ -38,5 +44,7 @@ security:
         - { path: ^/api/doc, roles: PUBLIC_ACCESS }
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: ROLE_API_CLIENT }
-        - { path: ^/login$, roles: PUBLIC_ACCESS }
+        - { path: ^/login, roles: PUBLIC_ACCESS }
+        # Group management is available to both admins and client-token users.
+        - { path: ^/groups, roles: [ROLE_ADMIN, ROLE_API_CLIENT] }
         - { path: ^/, roles: ROLE_ADMIN }

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Client;
 use App\Entity\Group;
 use App\Entity\Profile;
 use App\Form\GroupType;
@@ -14,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/groups')]
@@ -27,9 +29,17 @@ class GroupController extends AbstractController
     {
         $page = max(1, $request->query->getInt('page', 1));
         $search = trim($request->query->getString('search', ''));
-        $clientId = $request->query->getInt('client', 0) ?: null;
 
-        $client = $clientId ? $clientRepository->find($clientId) : null;
+        $clientUser = $this->loggedInClient();
+        if ($clientUser !== null) {
+            // Client users always see only their own groups; ignore ?client= overrides.
+            $client = $clientUser;
+            $clientPickerEnabled = false;
+        } else {
+            $clientId = $request->query->getInt('client', 0) ?: null;
+            $client = $clientId ? $clientRepository->find($clientId) : null;
+            $clientPickerEnabled = true;
+        }
 
         $total = $groupRepository->countFiltered($client, $search);
         $pages = max(1, (int) ceil($total / self::GROUPS_PER_PAGE));
@@ -39,12 +49,13 @@ class GroupController extends AbstractController
 
         return $this->render('group/index.html.twig', [
             'groups' => $groups,
-            'clients' => $clientRepository->findBy([], ['name' => 'ASC']),
+            'clients' => $clientPickerEnabled ? $clientRepository->findBy([], ['name' => 'ASC']) : [],
             'page' => $page,
             'pages' => $pages,
             'total' => $total,
             'search' => $search,
             'selectedClient' => $client,
+            'clientPickerEnabled' => $clientPickerEnabled,
         ]);
     }
 
@@ -53,10 +64,21 @@ class GroupController extends AbstractController
     {
         $group = new Group();
 
-        $form = $this->createForm(GroupType::class, $group);
+        $clientUser = $this->loggedInClient();
+        if ($clientUser !== null) {
+            $group->setClient($clientUser);
+        }
+
+        $form = $this->createForm(GroupType::class, $group, [
+            'lock_client_to' => $clientUser,
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            if ($clientUser !== null) {
+                // Force-set again in case form data was tampered with.
+                $group->setClient($clientUser);
+            }
             if ($error = $this->ensureProfilesBelongToClient($group)) {
                 $form->addError(new \Symfony\Component\Form\FormError($error));
             } else {
@@ -81,6 +103,7 @@ class GroupController extends AbstractController
         ItemRepository $itemRepository,
         NetworkRepository $networkRepository,
     ): Response {
+        $this->denyForeignClient($group);
         $page = max(1, $request->query->getInt('page', 1));
         $networkId = $request->query->getInt('network', 0) ?: null;
 
@@ -115,7 +138,11 @@ class GroupController extends AbstractController
     #[Route('/{id}/edit', name: 'app_group_edit', requirements: ['id' => '\d+'], methods: ['GET', 'POST'])]
     public function edit(Request $request, Group $group, EntityManagerInterface $em): Response
     {
-        $form = $this->createForm(GroupType::class, $group);
+        $this->denyForeignClient($group);
+
+        $form = $this->createForm(GroupType::class, $group, [
+            'lock_client_to' => $this->loggedInClient(),
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -139,6 +166,8 @@ class GroupController extends AbstractController
     #[Route('/{id}/delete', name: 'app_group_delete', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function delete(Request $request, Group $group, EntityManagerInterface $em): Response
     {
+        $this->denyForeignClient($group);
+
         if ($this->isCsrfTokenValid('delete-group-' . $group->getId(), $request->request->getString('_token'))) {
             $em->remove($group);
             $em->flush();
@@ -151,6 +180,8 @@ class GroupController extends AbstractController
     #[Route('/{id}/profiles/add', name: 'app_group_profile_add', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function addProfile(Request $request, Group $group, ProfileRepository $profileRepository, EntityManagerInterface $em): Response
     {
+        $this->denyForeignClient($group);
+
         if ($this->isCsrfTokenValid('group-add-profile-' . $group->getId(), $request->request->getString('_token'))) {
             $profileIds = array_map('intval', (array) $request->request->all('profileIds'));
 
@@ -179,6 +210,8 @@ class GroupController extends AbstractController
     #[Route('/{id}/profiles/{profileId}/remove', name: 'app_group_profile_remove', requirements: ['id' => '\d+', 'profileId' => '\d+'], methods: ['POST'])]
     public function removeProfile(Request $request, Group $group, int $profileId, ProfileRepository $profileRepository, EntityManagerInterface $em): Response
     {
+        $this->denyForeignClient($group);
+
         if ($this->isCsrfTokenValid('group-remove-profile-' . $group->getId() . '-' . $profileId, $request->request->getString('_token'))) {
             $profile = $profileRepository->find($profileId);
             if ($profile !== null) {
@@ -189,6 +222,20 @@ class GroupController extends AbstractController
         }
 
         return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
+    }
+
+    private function loggedInClient(): ?Client
+    {
+        $user = $this->getUser();
+        return $user instanceof Client ? $user : null;
+    }
+
+    private function denyForeignClient(Group $group): void
+    {
+        $client = $this->loggedInClient();
+        if ($client !== null && $group->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
     }
 
     /** @return string|null  Error message if invalid, null if OK */

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -12,6 +12,9 @@ class LoginController extends AbstractController
     #[Route('/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
+        if ($this->getUser() instanceof \App\Entity\Client) {
+            return $this->redirectToRoute('app_group_index');
+        }
         if ($this->getUser()) {
             return $this->redirectToRoute('app_dashboard');
         }
@@ -20,6 +23,15 @@ class LoginController extends AbstractController
             'last_username' => $authenticationUtils->getLastUsername(),
             'error' => $authenticationUtils->getLastAuthenticationError(),
         ]);
+    }
+
+    #[Route('/login/client-token', name: 'app_login_client_token', methods: ['POST'])]
+    public function clientTokenLogin(): never
+    {
+        // Intercepted by WebTokenAuthenticator. This action is unreachable in
+        // practice and only exists so the route shows up in debug:router and
+        // returns 405-on-GET instead of a stray 404.
+        throw new \LogicException('This method is intercepted by WebTokenAuthenticator.');
     }
 
     #[Route('/logout', name: 'app_logout')]

--- a/src/Form/GroupType.php
+++ b/src/Form/GroupType.php
@@ -18,18 +18,23 @@ class GroupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('name', TextType::class, [
-                'label' => 'Name',
-                'help' => 'Eindeutig pro Client.',
-            ])
-            ->add('client', EntityType::class, [
+        $builder->add('name', TextType::class, [
+            'label' => 'Name',
+            'help' => 'Eindeutig pro Client.',
+        ]);
+
+        // Client-token users always own their own groups; hide and lock the client field.
+        if ($options['lock_client_to'] === null) {
+            $builder->add('client', EntityType::class, [
                 'class' => Client::class,
                 'choice_label' => 'name',
                 'label' => 'Client',
                 'placeholder' => 'Client wählen...',
                 'help' => 'Eigentümer-Client der Gruppe. Bestimmt, wer sie über die API sieht.',
-            ])
+            ]);
+        }
+
+        $builder
             ->add('description', TextareaType::class, [
                 'label' => 'Beschreibung',
                 'required' => false,
@@ -62,6 +67,8 @@ class GroupType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Group::class,
+            'lock_client_to' => null,
         ]);
+        $resolver->setAllowedTypes('lock_client_to', ['null', Client::class]);
     }
 }

--- a/src/Security/WebTokenAuthenticator.php
+++ b/src/Security/WebTokenAuthenticator.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+/**
+ * Logs a Client into the Web UI via a 64-char hex token submitted from the
+ * second form on /login. Successful logins land on /groups (Client UX scope);
+ * failures bounce back to /login with a flash error.
+ */
+class WebTokenAuthenticator extends AbstractAuthenticator
+{
+    use TargetPathTrait;
+
+    private const LOGIN_PATH = '/login/client-token';
+    private const FAILURE_PATH = '/login';
+    private const SUCCESS_PATH = '/groups';
+
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ClientTokenUserProvider $clientTokenUserProvider,
+    ) {
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $request->isMethod('POST') && $request->getPathInfo() === self::LOGIN_PATH;
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $token = trim((string) $request->request->get('client_token', ''));
+        if ($token === '') {
+            throw new CustomUserMessageAuthenticationException('Bitte Token angeben.');
+        }
+        if (strlen($token) !== 64 || !ctype_xdigit($token)) {
+            throw new CustomUserMessageAuthenticationException('Ungültiges Token-Format (64 Hex-Zeichen erwartet).');
+        }
+
+        return new SelfValidatingPassport(
+            new UserBadge($token, fn(string $identifier) => $this->clientTokenUserProvider->loadUserByIdentifier($identifier)),
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token, string $firewallName): ?Response
+    {
+        $targetUrl = self::SUCCESS_PATH;
+
+        if ($request->hasSession()) {
+            $session = $request->getSession();
+            $session->getFlashBag()->add('success', sprintf(
+                'Eingeloggt als Client „%s".',
+                $token->getUser()?->getUserIdentifier() ?? 'unbekannt',
+            ));
+            $targetUrl = $this->getTargetPath($session, $firewallName) ?? $targetUrl;
+        }
+
+        return new RedirectResponse($targetUrl);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        if ($request->hasSession()) {
+            $request->getSession()->getFlashBag()->add('danger', sprintf(
+                'Login mit Token fehlgeschlagen: %s',
+                $exception instanceof CustomUserMessageAuthenticationException
+                    ? $exception->getMessageKey()
+                    : 'Token nicht gefunden oder Client deaktiviert.',
+            ));
+        }
+
+        return new RedirectResponse($this->urlGenerator->generate('app_login'));
+    }
+}

--- a/templates/_partials/_sidebar.html.twig
+++ b/templates/_partials/_sidebar.html.twig
@@ -11,50 +11,54 @@
 
     <div class="sidebar-section">Navigation</div>
     <ul class="sidebar-nav">
-        <li><a href="{{ path('app_dashboard') }}" class="{% if app.request.attributes.get('_route') == 'app_dashboard' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-th-large"></i></span>
-            Dashboard
-        </a></li>
-        <li><a href="{{ path('app_network_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_network' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-network-wired"></i></span>
-            Networks
-        </a></li>
-        <li><a href="{{ path('app_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_profile' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-users"></i></span>
-            Profiles
-        </a></li>
+        {% if is_granted('ROLE_ADMIN') %}
+            <li><a href="{{ path('app_dashboard') }}" class="{% if app.request.attributes.get('_route') == 'app_dashboard' %}active{% endif %}">
+                <span class="nav-icon"><i class="fas fa-th-large"></i></span>
+                Dashboard
+            </a></li>
+            <li><a href="{{ path('app_network_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_network' %}active{% endif %}">
+                <span class="nav-icon"><i class="fas fa-network-wired"></i></span>
+                Networks
+            </a></li>
+            <li><a href="{{ path('app_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_profile' %}active{% endif %}">
+                <span class="nav-icon"><i class="fas fa-users"></i></span>
+                Profiles
+            </a></li>
+        {% endif %}
         <li><a href="{{ path('app_group_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_group' %}active{% endif %}">
             <span class="nav-icon"><i class="fas fa-layer-group"></i></span>
             Gruppen
         </a></li>
-        {% set rssappRoute = app.request.attributes.get('_route') starts with 'app_rssapp_' %}
-        <li class="nav-group">
-            <details{% if rssappRoute %} open{% endif %}>
-                <summary class="{% if rssappRoute %}active-group{% endif %}">
-                    <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
-                    RSS.app
-                    <span class="nav-chevron"><i class="fas fa-chevron-right"></i></span>
-                </summary>
-                <ul class="sidebar-subnav">
-                    <li><a href="{{ path('app_rssapp_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_profile' %}active{% endif %}">
-                        <span class="nav-icon"><i class="fas fa-list"></i></span>
-                        Übersicht
-                    </a></li>
-                    <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
-                        <span class="nav-icon"><i class="fas fa-unlink"></i></span>
-                        Verwaiste Feeds
-                    </a></li>
-                </ul>
-            </details>
-        </li>
-        <li><a href="{{ path('app_item_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_item' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-stream"></i></span>
-            Items
-        </a></li>
-        <li><a href="{{ path('app_client_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_client' %}active{% endif %}">
-            <span class="nav-icon"><i class="fas fa-id-badge"></i></span>
-            Clients
-        </a></li>
+        {% if is_granted('ROLE_ADMIN') %}
+            {% set rssappRoute = app.request.attributes.get('_route') starts with 'app_rssapp_' %}
+            <li class="nav-group">
+                <details{% if rssappRoute %} open{% endif %}>
+                    <summary class="{% if rssappRoute %}active-group{% endif %}">
+                        <span class="nav-icon"><i class="fas fa-rss-square"></i></span>
+                        RSS.app
+                        <span class="nav-chevron"><i class="fas fa-chevron-right"></i></span>
+                    </summary>
+                    <ul class="sidebar-subnav">
+                        <li><a href="{{ path('app_rssapp_profile_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_profile' %}active{% endif %}">
+                            <span class="nav-icon"><i class="fas fa-list"></i></span>
+                            Übersicht
+                        </a></li>
+                        <li><a href="{{ path('app_rssapp_orphan_feed_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_rssapp_orphan_feed' %}active{% endif %}">
+                            <span class="nav-icon"><i class="fas fa-unlink"></i></span>
+                            Verwaiste Feeds
+                        </a></li>
+                    </ul>
+                </details>
+            </li>
+            <li><a href="{{ path('app_item_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_item' %}active{% endif %}">
+                <span class="nav-icon"><i class="fas fa-stream"></i></span>
+                Items
+            </a></li>
+            <li><a href="{{ path('app_client_index') }}" class="{% if app.request.attributes.get('_route') starts with 'app_client' %}active{% endif %}">
+                <span class="nav-icon"><i class="fas fa-id-badge"></i></span>
+                Clients
+            </a></li>
+        {% endif %}
     </ul>
 
     <div class="sidebar-footer">
@@ -63,7 +67,13 @@
                 <i class="fas fa-user"></i>
             </div>
             <div>
-                <div style="color: white; font-weight: 500;">{{ app.user.userIdentifier }}</div>
+                <div style="color: white; font-weight: 500;">
+                    {% if is_granted('ROLE_API_CLIENT') %}
+                        <i class="fas fa-key me-1" title="Client-Token"></i>{{ app.user.name }}
+                    {% else %}
+                        <i class="fas fa-user-shield me-1" title="Admin"></i>{{ app.user.userIdentifier }}
+                    {% endif %}
+                </div>
                 <a href="{{ path('app_logout') }}">Abmelden</a>
             </div>
         </div>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,7 +12,7 @@
         {% endblock %}
     </head>
     <body class="{% block body_class %}{% endblock %}">
-        {% if is_granted('ROLE_ADMIN') %}
+        {% if app.user %}
             {% include '_partials/_sidebar.html.twig' %}
             <div class="main">
                 <div class="topbar">

--- a/templates/group/edit.html.twig
+++ b/templates/group/edit.html.twig
@@ -9,7 +9,9 @@
         <div class="data-card-body">
             {{ form_start(form) }}
                 {{ form_row(form.name) }}
-                {{ form_row(form.client) }}
+                {% if form.client is defined %}
+                    {{ form_row(form.client) }}
+                {% endif %}
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
                 {{ form_row(form.profiles) }}

--- a/templates/group/index.html.twig
+++ b/templates/group/index.html.twig
@@ -13,12 +13,14 @@
 {% block body %}
     <form method="get" class="mb-3 d-flex gap-2">
         <input type="text" name="search" value="{{ search }}" class="form-control" placeholder="Nach Name filtern…">
-        <select name="client" class="form-select" style="max-width: 250px;">
-            <option value="">— Alle Clients —</option>
-            {% for c in clients %}
-                <option value="{{ c.id }}"{% if selectedClient and c.id == selectedClient.id %} selected{% endif %}>{{ c.name }}</option>
-            {% endfor %}
-        </select>
+        {% if clientPickerEnabled %}
+            <select name="client" class="form-select" style="max-width: 250px;">
+                <option value="">— Alle Clients —</option>
+                {% for c in clients %}
+                    <option value="{{ c.id }}"{% if selectedClient and c.id == selectedClient.id %} selected{% endif %}>{{ c.name }}</option>
+                {% endfor %}
+            </select>
+        {% endif %}
         <button type="submit" class="btn btn-outline-secondary">Filtern</button>
     </form>
 

--- a/templates/group/new.html.twig
+++ b/templates/group/new.html.twig
@@ -9,7 +9,9 @@
         <div class="data-card-body">
             {{ form_start(form) }}
                 {{ form_row(form.name) }}
-                {{ form_row(form.client) }}
+                {% if form.client is defined %}
+                    {{ form_row(form.client) }}
+                {% endif %}
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
                 {{ form_row(form.profiles) }}

--- a/templates/login/login.html.twig
+++ b/templates/login/login.html.twig
@@ -7,37 +7,76 @@
 {% block body %}
 <div class="mt-5">
     <div class="data-card">
-            <div class="data-card-header">
-                <h4 class="mb-0"><i class="fas fa-sign-in-alt me-2"></i>Login</h4>
-            </div>
-            <div class="data-card-body">
-                {% if error %}
-                    <div class="alert alert-danger">
-                        {{ error.messageKey|trans(error.messageData, 'security') }}
-                    </div>
-                {% endif %}
+        <div class="data-card-header">
+            <h4 class="mb-0"><i class="fas fa-sign-in-alt me-2"></i>Login</h4>
+        </div>
+        <div class="data-card-body">
+            {% if error %}
+                <div class="alert alert-danger">
+                    {{ error.messageKey|trans(error.messageData, 'security') }}
+                </div>
+            {% endif %}
 
-                <form action="{{ path('app_login') }}" method="post">
-                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-
-                    <div class="mb-3">
-                        <label for="username" class="form-label">Username</label>
-                        <input type="text" id="username" name="_username"
-                               class="form-control" value="{{ last_username }}"
-                               required autofocus>
-                    </div>
-
-                    <div class="mb-3">
-                        <label for="password" class="form-label">Password</label>
-                        <input type="password" id="password" name="_password"
-                               class="form-control" required>
-                    </div>
-
-                    <button type="submit" class="btn-primary-custom w-100">
-                        <i class="fas fa-sign-in-alt me-1"></i>Sign in
+            <ul class="nav nav-tabs mb-3" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tab-admin" data-bs-toggle="tab" data-bs-target="#pane-admin" type="button" role="tab">
+                        <i class="fas fa-user-shield me-1"></i>Admin
                     </button>
-                </form>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-client-token" data-bs-toggle="tab" data-bs-target="#pane-client-token" type="button" role="tab">
+                        <i class="fas fa-key me-1"></i>Client-Token
+                    </button>
+                </li>
+            </ul>
+
+            <div class="tab-content">
+                <div class="tab-pane fade show active" id="pane-admin" role="tabpanel">
+                    <p class="text-muted small">Login mit den Web-Admin-Zugangsdaten aus den Environment-Variablen.</p>
+                    <form action="{{ path('app_login') }}" method="post">
+                        <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+
+                        <div class="mb-3">
+                            <label for="username" class="form-label">Username</label>
+                            <input type="text" id="username" name="_username"
+                                   class="form-control" value="{{ last_username }}"
+                                   required autocomplete="username">
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="password" class="form-label">Password</label>
+                            <input type="password" id="password" name="_password"
+                                   class="form-control" required autocomplete="current-password">
+                        </div>
+
+                        <button type="submit" class="btn-primary-custom w-100">
+                            <i class="fas fa-sign-in-alt me-1"></i>Sign in
+                        </button>
+                    </form>
+                </div>
+
+                <div class="tab-pane fade" id="pane-client-token" role="tabpanel">
+                    <p class="text-muted small">
+                        Login mit einem API-Client-Token (64 Hex-Zeichen). Client-User können nach dem Login die eigenen Gruppen verwalten.
+                        Token erzeugst du mit <code>bin/console app:client:create &lt;name&gt;</code>.
+                    </p>
+                    <form action="/login/client-token" method="post">
+                        <div class="mb-3">
+                            <label for="client_token" class="form-label">Client-Token</label>
+                            <input type="text" id="client_token" name="client_token"
+                                   class="form-control font-monospace" required
+                                   minlength="64" maxlength="64"
+                                   pattern="[0-9a-fA-F]{64}"
+                                   placeholder="aaaaaaaaaaaaaaaa…">
+                        </div>
+
+                        <button type="submit" class="btn-primary-custom w-100">
+                            <i class="fas fa-key me-1"></i>Mit Token einloggen
+                        </button>
+                    </form>
+                </div>
             </div>
         </div>
+    </div>
 </div>
 {% endblock %}

--- a/tests/Functional/Group/ClientWebLoginTest.php
+++ b/tests/Functional/Group/ClientWebLoginTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Group;
+
+use App\Tests\Functional\AbstractApiTestCase;
+
+class ClientWebLoginTest extends AbstractApiTestCase
+{
+    public function testValidClientTokenLogsInAndRedirectsToGroups(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/login/client-token', $this->formBody(['client_token' => self::TOKEN_A]));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringContainsString('/groups', $this->location($response));
+    }
+
+    public function testInvalidClientTokenRedirectsBackToLogin(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/login/client-token', $this->formBody(['client_token' => str_repeat('z', 64)]));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringContainsString('/login', $this->location($response));
+    }
+
+    public function testMalformedTokenRedirectsBackToLogin(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/login/client-token', $this->formBody(['client_token' => 'too-short']));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringContainsString('/login', $this->location($response));
+    }
+
+    public function testDisabledClientTokenIsRejected(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/login/client-token', $this->formBody(['client_token' => self::TOKEN_DISABLED]));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertStringContainsString('/login', $this->location($response));
+    }
+
+    private function location(\Symfony\Contracts\HttpClient\ResponseInterface $response): string
+    {
+        $headers = $response->getHeaders(throw: false);
+        return $headers['location'][0] ?? '';
+    }
+
+    /** @param array<string, string> $fields */
+    private function formBody(array $fields): array
+    {
+        return [
+            'extra' => ['parameters' => $fields],
+        ];
+    }
+}


### PR DESCRIPTION
Fifth and final PR of the Groups feature. Lets a non-admin holder of an API client token sign into the Web UI to manage their own groups — without expanding their access to anything else.

## Summary

### Authentication
- New `App\Security\WebTokenAuthenticator`. Triggers on `POST /login/client-token` with a `client_token` body field, validates the 64-char hex format, then delegates to the existing `ClientTokenUserProvider` (which already filters disabled clients).
- `security.yaml`: the `main` firewall gains a chain provider combining `web_user_provider` and `client_token_provider`, plus the new custom authenticator. Access control opens `/groups/*` to **both** `ROLE_ADMIN` and `ROLE_API_CLIENT`; everything else stays admin-only.

### UX
- `/login` now offers two tabs: **Admin** (existing form) and **Client-Token** (new, posts to `/login/client-token`). Success redirects to `/groups`, failure bounces back to `/login` with a flash. A no-op controller action documents the `/login/client-token` route so it shows up in `debug:router`.
- `LoginController::login` redirects client users (with a pre-existing session) to `/groups` instead of `/dashboard`.
- Sidebar identifies the logged-in user: admin badge + name for ROLE_ADMIN, key badge + `client.name` for ROLE_API_CLIENT. Admin-only nav items (Dashboard, Networks, Profiles, Items, Clients, RSS.app) are hidden for client users; only **Gruppen** remains.
- `base.html.twig`: the sidebar now renders for any authenticated user (not just ROLE_ADMIN).

### Web-UI Group scoping
- `GroupController` introduces `loggedInClient()` and `denyForeignClient()`. Every show / edit / delete / profile-add / profile-remove route 404s when a client user touches a group they don't own.
- The list view is pre-filtered to the client's own groups; the client-picker dropdown vanishes.
- `GroupType` gets a `lock_client_to` option. When set, the `client` form field is suppressed entirely, and the controller force-sets `group.client` to the authenticated client on persist — clients cannot leak groups to other tenants via crafted form data.
- `new.html.twig` / `edit.html.twig` render the client field conditionally.

## Test plan
- [x] `bin/phpunit` — 210/590, no new regressions; same one pre-existing failure as on `main`
- [x] 4 new functional tests (`ClientWebLoginTest`): valid token → 302 to /groups, invalid 64-char → 302 to /login, malformed → 302 to /login, disabled-client → 302 to /login.
- [x] `php bin/console lint:container` — OK
- [x] `php bin/console lint:twig templates/` — OK (32 files)
- [ ] Manual on prod after deploy:
  1. `bin/console app:client:create demo` → grab the token
  2. Visit `/login`, switch to the Client-Token tab, paste the token, submit
  3. Verify landing on `/groups`, sidebar shows only Gruppen + the client's name
  4. Create a group, add some of the client's profiles, browse the timeline
  5. Manually visit `/dashboard` → 403
  6. Logout and login with the admin credentials → all sidebar entries reappear, the client's group still visible (admin sees all)

## Series done

Groups feature is now complete across the five planned PRs:

- A (#59): Entity, Web-UI CRUD, sidebar
- B (#60): Web-UI group timeline
- C (#61): REST API CRUD + convenience routes
- D (#62): `/api/groups/{id}/items` + RSS feed
- E (this): Client-token login for the Web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)