### PR TITLE
Pick groups for a profile from the profile show page

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -2,6 +2,8 @@
 
 namespace App\Controller;
 
+use App\Entity\Client;
+use App\Entity\Group;
 use App\Entity\Profile;
 use App\Form\ProfileType;
 use App\FeedFetcher\FeedFetcher;
@@ -9,6 +11,7 @@ use App\FeedFetcher\FetchInfo;
 use App\FeedFetcher\FetchResult;
 use App\FeedItemPersister\FeedItemPersisterInterface;
 use App\Model\Profile as ModelProfile;
+use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
@@ -122,14 +125,108 @@ class ProfileController extends AbstractController
     }
 
     #[Route('/{id}', name: 'app_profile_show', requirements: ['id' => '\d+'])]
-    public function show(Profile $profile, ItemRepository $itemRepository): Response
+    public function show(Profile $profile, ItemRepository $itemRepository, GroupRepository $groupRepository): Response
     {
+        $clientScope = $this->clientScope();
+        $currentGroups = $groupRepository->findByProfile($profile, $clientScope);
+        $availableGroups = $groupRepository->findAvailableForProfile($profile, $clientScope);
+
         $itemCount = $itemRepository->count(['profile' => $profile]);
 
         return $this->render('profile/show.html.twig', [
             'profile' => $profile,
             'itemCount' => $itemCount,
+            'currentGroups' => $currentGroups,
+            'availableGroups' => $availableGroups,
         ]);
+    }
+
+    #[Route('/{id}/groups/add', name: 'app_profile_groups_add', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function addToGroups(
+        Request $request,
+        Profile $profile,
+        GroupRepository $groupRepository,
+        EntityManagerInterface $em,
+    ): Response {
+        if (!$this->isCsrfTokenValid('profile-groups-add-' . $profile->getId(), $request->request->getString('_token'))) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $groupIds = array_map('intval', (array) $request->request->all('groupIds'));
+        if ($groupIds === []) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $clientScope = $this->clientScope();
+        $added = 0;
+
+        foreach ($groupIds as $groupId) {
+            if ($groupId <= 0) {
+                continue;
+            }
+            $group = $groupRepository->find($groupId);
+            if ($group === null) {
+                continue;
+            }
+            // Refuse cross-tenant: the group's client must be one of the
+            // profile's clients (and, for client-token users, the scope).
+            if (!$profile->getClients()->contains($group->getClient())) {
+                $this->addFlash('warning', sprintf(
+                    'Gruppe „%s" gehört nicht zu einem Client dieses Profils und wurde übersprungen.',
+                    $group->getName() ?? '?',
+                ));
+                continue;
+            }
+            if ($clientScope !== null && $group->getClient()?->getId() !== $clientScope->getId()) {
+                continue;
+            }
+            $group->addProfile($profile);
+            $added++;
+        }
+
+        $em->flush();
+
+        if ($added > 0) {
+            $this->addFlash('success', sprintf('Profil wurde zu %d Gruppe%s hinzugefügt.', $added, $added === 1 ? '' : 'n'));
+        }
+
+        return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
+    #[Route('/{id}/groups/{groupId}/remove', name: 'app_profile_group_remove', requirements: ['id' => '\d+', 'groupId' => '\d+'], methods: ['POST'])]
+    public function removeFromGroup(
+        Request $request,
+        Profile $profile,
+        int $groupId,
+        GroupRepository $groupRepository,
+        EntityManagerInterface $em,
+    ): Response {
+        if (!$this->isCsrfTokenValid('profile-group-remove-' . $profile->getId() . '-' . $groupId, $request->request->getString('_token'))) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $group = $groupRepository->find($groupId);
+        if ($group === null) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $clientScope = $this->clientScope();
+        if ($clientScope !== null && $group->getClient()?->getId() !== $clientScope->getId()) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $group->removeProfile($profile);
+        $em->flush();
+
+        $this->addFlash('success', sprintf('Profil wurde aus Gruppe „%s" entfernt.', $group->getName() ?? '?'));
+
+        return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
+    private function clientScope(): ?Client
+    {
+        $user = $this->getUser();
+        return $user instanceof Client ? $user : null;
     }
 
     #[Route('/{id}/edit', name: 'app_profile_edit', requirements: ['id' => '\d+'])]

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -21,6 +21,59 @@ class GroupRepository extends ServiceEntityRepository
     }
 
     /**
+     * Groups that already contain $profile. Optionally restricted to a single
+     * client (used to hide foreign-client groups from a client-token user).
+     *
+     * @return list<Group>
+     */
+    public function findByProfile(\App\Entity\Profile $profile, ?Client $client = null): array
+    {
+        $qb = $this->createQueryBuilder('g')
+            ->innerJoin('g.profiles', 'p')
+            ->andWhere('p.id = :profileId')
+            ->setParameter('profileId', $profile->getId())
+            ->orderBy('g.name', 'ASC');
+
+        if ($client !== null) {
+            $qb->andWhere('g.client = :clientScope')->setParameter('clientScope', $client);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Groups the profile is *not* in yet, restricted to clients the profile
+     * is linked to (so we never offer a foreign-tenant group as a target).
+     *
+     * @return list<Group>
+     */
+    public function findAvailableForProfile(\App\Entity\Profile $profile, ?Client $client = null): array
+    {
+        $allowedClients = $client !== null
+            ? [$client]
+            : iterator_to_array($profile->getClients());
+
+        if ($allowedClients === []) {
+            return [];
+        }
+
+        $allowedClientIds = array_map(fn($c) => $c->getId(), $allowedClients);
+
+        $qb = $this->createQueryBuilder('g')
+            ->andWhere('g.client IN (:clientIds)')
+            ->setParameter('clientIds', $allowedClientIds)
+            ->andWhere('g.id NOT IN (
+                SELECT g2.id FROM App\Entity\Group g2
+                JOIN g2.profiles p2
+                WHERE p2.id = :profileId
+            )')
+            ->setParameter('profileId', $profile->getId())
+            ->orderBy('g.name', 'ASC');
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
      * @return list<Group>
      */
     public function findPaginated(int $page, int $limit, ?Client $client = null, string $search = ''): array

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -116,6 +116,60 @@
                 </div>
             </div>
 
+            <div class="data-card mb-4">
+                <div class="data-card-header">Gruppen ({{ currentGroups|length }})</div>
+                <div class="data-card-body">
+                    {% if currentGroups is empty %}
+                        <p class="text-muted mb-2">Profil ist in keiner Gruppe.</p>
+                    {% else %}
+                        <ul class="list-unstyled mb-3">
+                            {% for group in currentGroups %}
+                                <li class="d-flex align-items-center justify-content-between mb-1">
+                                    <a href="{{ path('app_group_show', {id: group.id}) }}">
+                                        {% if group.color %}
+                                            <span class="net-badge me-1" style="background-color: {{ group.color }}; color: #fff;">{{ group.name }}</span>
+                                        {% else %}
+                                            <i class="fas fa-layer-group me-1"></i>{{ group.name }}
+                                        {% endif %}
+                                        <span class="text-muted small">({{ group.client.name }})</span>
+                                    </a>
+                                    <form method="post" action="{{ path('app_profile_group_remove', {id: profile.id, groupId: group.id}) }}"
+                                          class="d-inline"
+                                          data-controller="confirm"
+                                          data-confirm-message-value="Profil aus Gruppe &quot;{{ group.name }}&quot; entfernen?">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('profile-group-remove-' ~ profile.id ~ '-' ~ group.id) }}">
+                                        <button type="submit" class="action-btn" title="Aus Gruppe entfernen"><i class="fas fa-times"></i></button>
+                                    </form>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+
+                    {% if availableGroups is not empty %}
+                        <form method="post" action="{{ path('app_profile_groups_add', {id: profile.id}) }}">
+                            <input type="hidden" name="_token" value="{{ csrf_token('profile-groups-add-' ~ profile.id) }}">
+                            <label for="profile-group-add" class="form-label small">Zu Gruppen hinzufügen</label>
+                            <select id="profile-group-add" name="groupIds[]" class="form-select form-select-sm mb-2" multiple size="{{ min(6, availableGroups|length + 1) }}">
+                                {% for group in availableGroups %}
+                                    <option value="{{ group.id }}">{{ group.name }} ({{ group.client.name }})</option>
+                                {% endfor %}
+                            </select>
+                            <button type="submit" class="btn btn-outline-primary btn-sm w-100">
+                                <i class="fas fa-plus me-1"></i>Hinzufügen
+                            </button>
+                        </form>
+                    {% else %}
+                        <p class="text-muted small mb-0">
+                            {% if profile.clients|length == 0 %}
+                                Profil ist mit keinem Client verknüpft — keine Gruppen verfügbar.
+                            {% else %}
+                                Keine weiteren Gruppen verfügbar. Lege bei Bedarf eine neue Gruppe an: <a href="{{ path('app_group_new') }}">Neue Gruppe</a>.
+                            {% endif %}
+                        </p>
+                    {% endif %}
+                </div>
+            </div>
+
             <div class="data-card mb-4"
                  data-controller="item-list"
                  data-item-list-url-value="{{ path('app_item_index') }}"


### PR DESCRIPTION
On \`/profiles/{id}\` you can now manage the profile's group memberships directly instead of having to go to each group's edit page. A new **Gruppen** card lists the current memberships and offers a multi-select of the available groups.

## Summary

### Repository
- \`GroupRepository::findByProfile(Profile, ?Client)\` — groups that already contain the profile, optionally scoped to one client.
- \`GroupRepository::findAvailableForProfile(Profile, ?Client)\` — groups the profile is *not* in yet, restricted to clients the profile is linked to. The \`NOT IN\` subquery joins back through \`profile_group_profile\` so we never offer a group whose client doesn't share the profile.

### Controller
- \`ProfileController::show\` now fetches \`currentGroups\` + \`availableGroups\` and hands both to the template.
- New \`POST /profiles/{id}/groups/add\` — body \`groupIds[]\`. Refuses any group whose client isn't one of the profile's clients (warning flash, skipped). Client-token users (when the Profile UI eventually opens up to them) are additionally restricted to groups owned by their own client.
- New \`POST /profiles/{id}/groups/{groupId}/remove\` — single removal.

### Template
- Right column gains a **Gruppen** card with:
  - current memberships listed as badges (using \`group.color\` when set), with a per-row CSRF-protected remove button
  - a multi-select dropdown of available groups + an "Hinzufügen" button
  - friendly empty states (no clients → no groups; all groups already joined → link to \`/groups/new\`)

## Test plan
- [x] \`bin/phpunit\` — 210/590, no regressions; same one pre-existing failure as on \`main\`
- [x] \`php bin/console lint:container\` — OK
- [x] \`php bin/console lint:twig templates/profile/show.html.twig\` — OK
- [x] \`debug:router\` — both new routes registered (\`app_profile_groups_add\`, \`app_profile_group_remove\`)
- [ ] Manual on prod after deploy: open \`/profiles/2179\`, verify the new Gruppen card; pick 2-3 groups, hit Hinzufügen, then remove one via the × button; verify the change is reflected on the corresponding \`/groups/{id}\` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)