### PR TITLE
Let admins pick any group for a profile, regardless of client linkage

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -168,17 +168,17 @@ class ProfileController extends AbstractController
             if ($group === null) {
                 continue;
             }
-            // Refuse cross-tenant: the group's client must be one of the
-            // profile's clients (and, for client-token users, the scope).
-            if (!$profile->getClients()->contains($group->getClient())) {
-                $this->addFlash('warning', sprintf(
-                    'Gruppe „%s" gehört nicht zu einem Client dieses Profils und wurde übersprungen.',
-                    $group->getName() ?? '?',
-                ));
-                continue;
-            }
-            if ($clientScope !== null && $group->getClient()?->getId() !== $clientScope->getId()) {
-                continue;
+            // For client-token users: refuse cross-tenant. Admin can add a
+            // profile to any group; tenancy is enforced at the read side
+            // (API client scope only sees groups it owns).
+            if ($clientScope !== null) {
+                if ($group->getClient()?->getId() !== $clientScope->getId()) {
+                    continue;
+                }
+                if (!$profile->getClients()->contains($clientScope)) {
+                    $this->addFlash('warning', 'Profil ist nicht mit deinem Client verknüpft.');
+                    continue;
+                }
             }
             $group->addProfile($profile);
             $added++;

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -42,26 +42,20 @@ class GroupRepository extends ServiceEntityRepository
     }
 
     /**
-     * Groups the profile is *not* in yet, restricted to clients the profile
-     * is linked to (so we never offer a foreign-tenant group as a target).
+     * Groups the profile is *not* in yet.
+     *
+     * - When $client is given (client-token user), restrict to groups owned
+     *   by that client *and* the profile must be linked to that client too.
+     * - When $client is null (admin), return *all* groups the profile is not
+     *   in, regardless of whether the profile is linked to the group's
+     *   client. Admins are tenant-wide and we don't want to hide groups
+     *   behind a profile↔client link that may not exist for imported data.
      *
      * @return list<Group>
      */
     public function findAvailableForProfile(\App\Entity\Profile $profile, ?Client $client = null): array
     {
-        $allowedClients = $client !== null
-            ? [$client]
-            : iterator_to_array($profile->getClients());
-
-        if ($allowedClients === []) {
-            return [];
-        }
-
-        $allowedClientIds = array_map(fn($c) => $c->getId(), $allowedClients);
-
         $qb = $this->createQueryBuilder('g')
-            ->andWhere('g.client IN (:clientIds)')
-            ->setParameter('clientIds', $allowedClientIds)
             ->andWhere('g.id NOT IN (
                 SELECT g2.id FROM App\Entity\Group g2
                 JOIN g2.profiles p2
@@ -69,6 +63,15 @@ class GroupRepository extends ServiceEntityRepository
             )')
             ->setParameter('profileId', $profile->getId())
             ->orderBy('g.name', 'ASC');
+
+        if ($client !== null) {
+            // Client-token user: only their own groups, and only if the
+            // profile is actually linked to them.
+            if (!$profile->getClients()->contains($client)) {
+                return [];
+            }
+            $qb->andWhere('g.client = :clientScope')->setParameter('clientScope', $client);
+        }
 
         return $qb->getQuery()->getResult();
     }

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -160,11 +160,7 @@
                         </form>
                     {% else %}
                         <p class="text-muted small mb-0">
-                            {% if profile.clients|length == 0 %}
-                                Profil ist mit keinem Client verknüpft — keine Gruppen verfügbar.
-                            {% else %}
-                                Keine weiteren Gruppen verfügbar. Lege bei Bedarf eine neue Gruppe an: <a href="{{ path('app_group_new') }}">Neue Gruppe</a>.
-                            {% endif %}
+                            Keine weiteren Gruppen verfügbar. Lege bei Bedarf eine neue Gruppe an: <a href="{{ path('app_group_new') }}">Neue Gruppe</a>.
                         </p>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Reported

On \`/profiles/2179\` the Gruppen card shows

> Gruppen (0) — Profil ist in keiner Gruppe.
> Profil ist mit keinem Client verknüpft — keine Gruppen verfügbar.

Despite groups existing in the system.

## Cause

The previous \`findAvailableForProfile\` filtered groups by the intersection of the profile's clients and the group's owning client. Profile 2179 has no client_profile entries (likely imported via the Wahlkampf importer, which never links a Client), so the intersection was empty → no groups were offered.

The intent of that check was to keep a *client-token* user from leaking profiles across tenants. Applying it to admin users too made the feature useless in the typical single-admin setup.

## Fix

Split the behaviour by user type:

| User type | Available groups | When adding |
|---|---|---|
| Admin | Any group the profile isn't in yet | Any group |
| Client-token | Only groups owned by the user's own client | Group must be owned by user's client *and* profile must be linked to that client (warning otherwise) |

Tenant safety is preserved on the read side (client extension still scopes \`/api/groups\` and \`/groups\` to the user's own client) and on the write side for client-token users. The admin Web UI has full access by design.

The misleading "Profil ist mit keinem Client verknüpft" empty-state is removed from the template.

## Test plan
- [x] \`bin/phpunit\` — 210/590, no regressions; same one pre-existing failure on \`main\`
- [x] \`php bin/console lint:container\` — OK
- [x] \`php bin/console lint:twig templates/profile/show.html.twig\` — OK
- [ ] Manual on prod after deploy: open \`/profiles/2179\`, verify the Gruppen card now offers groups; pick one, hit Hinzufügen, confirm it lands; remove via the × button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)