### PR TITLE
Promote RSS.app feed ID to its own profile column

### DIFF
--- a/migrations/Version20260520120000.php
+++ b/migrations/Version20260520120000.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Promote RSS.app feed ID from additional_data JSON to its own column on profile';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $profile = $schema->getTable('profile');
+        $profile->addColumn('rss_app_feed_id', 'string', ['length' => 64, 'notnull' => false]);
+        $profile->addIndex(['rss_app_feed_id'], 'IDX_PROFILE_RSS_APP_FEED_ID');
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, additional_data FROM profile WHERE additional_data IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $data = json_decode((string) $row['additional_data'], true);
+
+            if (!is_array($data) || !isset($data['rss_feed_id'])) {
+                continue;
+            }
+
+            $feedId = (string) $data['rss_feed_id'];
+            unset($data['rss_feed_id']);
+
+            $remaining = $data === []
+                ? null
+                : json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+            $this->connection->update('profile', [
+                'rss_app_feed_id' => $feedId,
+                'additional_data' => $remaining,
+            ], ['id' => $row['id']]);
+        }
+    }
+
+    public function preDown(Schema $schema): void
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, additional_data, rss_app_feed_id FROM profile WHERE rss_app_feed_id IS NOT NULL'
+        );
+
+        foreach ($rows as $row) {
+            $data = $row['additional_data'] !== null
+                ? (array) json_decode((string) $row['additional_data'], true)
+                : [];
+
+            $data['rss_feed_id'] = (string) $row['rss_app_feed_id'];
+
+            $this->connection->update('profile', [
+                'additional_data' => json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ], ['id' => $row['id']]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $profile = $schema->getTable('profile');
+        $profile->dropIndex('IDX_PROFILE_RSS_APP_FEED_ID');
+        $profile->dropColumn('rss_app_feed_id');
+    }
+}

--- a/src/Command/ImportRssAppProfilesCommand.php
+++ b/src/Command/ImportRssAppProfilesCommand.php
@@ -74,17 +74,14 @@ class ImportRssAppProfilesCommand extends Command
 
             if (isset($profileMap[$normalized])) {
                 $profile = $profileMap[$normalized];
-                $additionalData = $profile->getAdditionalData() ?? [];
 
-                if (($additionalData['rss_feed_id'] ?? null) === $feedId) {
+                if ($profile->getRssAppFeedId() === $feedId) {
                     $alreadyLinked++;
                     continue;
                 }
 
-                $additionalData['rss_feed_id'] = $feedId;
-
                 if (!$dryRun) {
-                    $profile->setAdditionalData($additionalData);
+                    $profile->setRssAppFeedId($feedId);
                 }
 
                 $linked++;
@@ -107,7 +104,7 @@ class ImportRssAppProfilesCommand extends Command
             $profile->setIdentifier($sourceUrl);
             $profile->setNetwork($network);
             $profile->setCreatedAt(new \DateTimeImmutable());
-            $profile->setAdditionalData(['rss_feed_id' => $feedId]);
+            $profile->setRssAppFeedId($feedId);
 
             if (!$dryRun) {
                 $this->entityManager->persist($profile);

--- a/src/Command/SyncRssAppFeedIdsCommand.php
+++ b/src/Command/SyncRssAppFeedIdsCommand.php
@@ -82,8 +82,7 @@ class SyncRssAppFeedIdsCommand extends Command
                 continue;
             }
 
-            $additionalData = $profile->getAdditionalData() ?? [];
-            $existingFeedId = $additionalData['rss_feed_id'] ?? null;
+            $existingFeedId = $profile->getRssAppFeedId();
 
             if ($existingFeedId !== null && !$force) {
                 $alreadyLinked++;
@@ -115,10 +114,8 @@ class SyncRssAppFeedIdsCommand extends Command
                 continue;
             }
 
-            $additionalData['rss_feed_id'] = $feedId;
-
             if (!$dryRun) {
-                $profile->setAdditionalData($additionalData);
+                $profile->setRssAppFeedId($feedId);
             }
 
             $updated++;

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -269,9 +269,7 @@ class ProfileController extends AbstractController
             try {
                 $feedData = $rssApp->createFeed($profile->getIdentifier());
 
-                $additionalData = $profile->getAdditionalData() ?? [];
-                $additionalData['rss_feed_id'] = $feedData['id'];
-                $profile->setAdditionalData($additionalData);
+                $profile->setRssAppFeedId($feedData['id']);
 
                 $em->flush();
 
@@ -306,22 +304,21 @@ class ProfileController extends AbstractController
             return;
         }
 
-        $additionalData = $profile->getAdditionalData() ?? [];
+        $feedId = $profile->getRssAppFeedId();
 
-        if (!isset($additionalData['rss_feed_id'])) {
+        if ($feedId === null) {
             return;
         }
 
         try {
-            $rssApp->deleteFeed($additionalData['rss_feed_id']);
+            $rssApp->deleteFeed($feedId);
         } catch (\Throwable $e) {
             $this->addFlash('danger', sprintf('Löschen bei RSS.app fehlgeschlagen: %s', $e->getMessage()));
 
             return;
         }
 
-        unset($additionalData['rss_feed_id']);
-        $profile->setAdditionalData($additionalData);
+        $profile->setRssAppFeedId(null);
 
         $em->flush();
 

--- a/src/Controller/RssAppOrphanFeedController.php
+++ b/src/Controller/RssAppOrphanFeedController.php
@@ -33,8 +33,7 @@ class RssAppOrphanFeedController extends AbstractController
         $knownSourceUrls = [];
 
         foreach ($profiles as $profile) {
-            $additionalData = $profile->getAdditionalData() ?? [];
-            $feedId = $additionalData['rss_feed_id'] ?? null;
+            $feedId = $profile->getRssAppFeedId();
             if ($feedId !== null) {
                 $knownFeedIds[$feedId] = true;
             }

--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -50,6 +50,7 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
         $profileShared->setNetwork($networkMastodon);
         $profileShared->setCreatedAt(new \DateTimeImmutable());
         $profileShared->setRssAppFeedId('fixture-feed-shared');
+        $profileShared->setAdditionalData(['fixture_note' => 'shared']);
         $manager->persist($profileShared);
         $clientA->addProfile($profileShared);
         $clientB->addProfile($profileShared);

--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -49,7 +49,7 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
         $profileShared->setIdentifier('https://mastodon.social/@shared');
         $profileShared->setNetwork($networkMastodon);
         $profileShared->setCreatedAt(new \DateTimeImmutable());
-        $profileShared->setAdditionalData(['rss_feed_id' => 'fixture-feed-shared']);
+        $profileShared->setRssAppFeedId('fixture-feed-shared');
         $manager->persist($profileShared);
         $clientA->addProfile($profileShared);
         $clientB->addProfile($profileShared);

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -20,6 +20,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Table(name: 'profile')]
 #[ORM\UniqueConstraint(name: 'uniq_profile_network_identifier', columns: ['network_id', 'identifier'])]
+#[ORM\Index(name: 'IDX_PROFILE_RSS_APP_FEED_ID', columns: ['rss_app_feed_id'])]
 #[ORM\Entity(repositoryClass: \App\Repository\ProfileRepository::class)]
 #[ApiResource(
     operations: [
@@ -127,8 +128,13 @@ class Profile
 
     #[ORM\Column(type: 'text', nullable: true)]
     #[Groups(['profile:detail', 'profile:write'])]
-    #[ApiProperty(description: 'Arbitrary JSON data for network-specific configuration (e.g. RSS.app feed ID). Only included on the single-profile endpoint, not in collections.')]
+    #[ApiProperty(description: 'Arbitrary JSON data for network-specific configuration. Only included on the single-profile endpoint, not in collections.')]
     private ?string $additionalData = null;
+
+    #[ORM\Column(type: 'string', length: 64, nullable: true)]
+    #[Groups(['profile:detail', 'profile:write'])]
+    #[ApiProperty(description: 'RSS.app feed ID linked to this profile (only set for RSS.app-based networks). Only included on the single-profile endpoint, not in collections.')]
+    private ?string $rssAppFeedId = null;
 
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     #[Groups(['profile:read', 'profile:write'])]
@@ -292,6 +298,18 @@ class Profile
     public function setAdditionalData(?array $additionalData): self
     {
         $this->additionalData = $additionalData !== null ? json_encode($additionalData) : null;
+
+        return $this;
+    }
+
+    public function getRssAppFeedId(): ?string
+    {
+        return $this->rssAppFeedId;
+    }
+
+    public function setRssAppFeedId(?string $rssAppFeedId): self
+    {
+        $this->rssAppFeedId = $rssAppFeedId;
 
         return $this;
     }

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -16,6 +16,7 @@ class Profile
     protected bool $savePhotos = false;
     protected bool $saveVideos = false;
     protected ?string $additionalData = null;
+    protected ?string $rssAppFeedId = null;
 
     public function getId(): ?int
     {
@@ -172,4 +173,15 @@ class Profile
         return $this;
     }
 
+    public function getRssAppFeedId(): ?string
+    {
+        return $this->rssAppFeedId;
+    }
+
+    public function setRssAppFeedId(?string $rssAppFeedId): self
+    {
+        $this->rssAppFeedId = $rssAppFeedId;
+
+        return $this;
+    }
 }

--- a/src/ProfileFetcher/DoctrineProfileFetcher.php
+++ b/src/ProfileFetcher/DoctrineProfileFetcher.php
@@ -72,6 +72,8 @@ class DoctrineProfileFetcher implements ProfileFetcherInterface
             $model->setAdditionalData(json_encode($additionalData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
         }
 
+        $model->setRssAppFeedId($entity->getRssAppFeedId());
+
         return $model;
     }
 }

--- a/src/ProfilePersister/DoctrineProfilePersister.php
+++ b/src/ProfilePersister/DoctrineProfilePersister.php
@@ -58,7 +58,8 @@ class DoctrineProfilePersister implements ProfilePersisterInterface
             ->setLastFetchSuccessDateTime($profile->getLastFetchSuccessDateTime() ? \DateTimeImmutable::createFromInterface($profile->getLastFetchSuccessDateTime()) : null)
             ->setLastFetchFailureDateTime($profile->getLastFetchFailureDateTime() ? \DateTimeImmutable::createFromInterface($profile->getLastFetchFailureDateTime()) : null)
             ->setLastFetchFailureError($profile->getLastFetchFailureError())
-            ->setAdditionalData($additionalData ? (array) json_decode($additionalData, true) : null);
+            ->setAdditionalData($additionalData ? (array) json_decode($additionalData, true) : null)
+            ->setRssAppFeedId($profile->getRssAppFeedId());
 
         $this->entityManager->persist($entity);
         $this->entityManager->flush();

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -38,9 +38,8 @@ class ProfileRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('p')
             ->leftJoin('p.network', 'n')
             ->addSelect('n')
-            ->where('p.additionalData LIKE :key')
+            ->where('p.rssAppFeedId IS NOT NULL')
             ->andWhere('p.deleted = false')
-            ->setParameter('key', '%"rss_feed_id"%')
             ->orderBy('p.identifier', 'ASC')
             ->getQuery()
             ->getResult();

--- a/src/RssApp/FeedRegistrar.php
+++ b/src/RssApp/FeedRegistrar.php
@@ -31,9 +31,7 @@ class FeedRegistrar
             return RegistrationResult::notApplicable();
         }
 
-        $additionalData = $profile->getAdditionalData() ?? [];
-
-        if (isset($additionalData['rss_feed_id'])) {
+        if ($profile->getRssAppFeedId() !== null) {
             return RegistrationResult::notApplicable();
         }
 
@@ -47,8 +45,7 @@ class FeedRegistrar
             $existingFeedId = $this->rssApp->findRssAppFeedIdBySourceUrl($sourceUrl);
 
             if ($existingFeedId !== null) {
-                $additionalData['rss_feed_id'] = $existingFeedId;
-                $profile->setAdditionalData($additionalData);
+                $profile->setRssAppFeedId($existingFeedId);
 
                 $importedCount = $this->importInitialItems($profile);
 
@@ -56,8 +53,7 @@ class FeedRegistrar
             }
 
             $feedData = $this->rssApp->createFeed($sourceUrl);
-            $additionalData['rss_feed_id'] = $feedData['id'];
-            $profile->setAdditionalData($additionalData);
+            $profile->setRssAppFeedId($feedData['id']);
 
             return RegistrationResult::newlyCreated();
         } catch (\Throwable $e) {
@@ -72,9 +68,7 @@ class FeedRegistrar
 
     public function linkExistingFeedAndImport(Profile $profile, string $feedId): int
     {
-        $additionalData = $profile->getAdditionalData() ?? [];
-        $additionalData['rss_feed_id'] = $feedId;
-        $profile->setAdditionalData($additionalData);
+        $profile->setRssAppFeedId($feedId);
 
         return $this->importInitialItems($profile);
     }
@@ -94,6 +88,7 @@ class FeedRegistrar
         $modelProfile->setIdentifier($profile->getIdentifier());
         $modelProfile->setNetwork($profile->getNetwork()->getIdentifier());
         $modelProfile->setAdditionalData($profile->getAdditionalData());
+        $modelProfile->setRssAppFeedId($profile->getRssAppFeedId());
 
         $fetcher = null;
         foreach ($this->feedFetcher->getNetworkFetcherList() as $networkFetcher) {

--- a/src/RssApp/Fetcher.php
+++ b/src/RssApp/Fetcher.php
@@ -24,21 +24,18 @@ abstract class Fetcher extends AbstractNetworkFeedFetcher
             return [];
         }
 
-        $additionalData = json_decode($profile->getAdditionalData() ?? '{}', true);
-
-        $feedId = $additionalData['rss_feed_id'] ?? null;
+        $feedId = $profile->getRssAppFeedId();
 
         if ($feedId && !$this->rssApp->feedExists($feedId)) {
             $this->logger->notice(sprintf('RSS.app Feed %s existiert nicht mehr für %s, suche neu.', $feedId, $sourceUrl));
             $feedId = null;
-            unset($additionalData['rss_feed_id']);
+            $profile->setRssAppFeedId(null);
         }
 
         if (!$feedId) {
             $feedId = $this->rssApp->findRssAppFeedIdBySourceUrl($sourceUrl);
             if ($feedId) {
-                $additionalData['rss_feed_id'] = $feedId;
-                $profile->setAdditionalData(json_encode($additionalData, JSON_UNESCAPED_SLASHES));
+                $profile->setRssAppFeedId($feedId);
             } else {
                 $this->markAsFailed($profile, 'Kein Feed bei RSS.app gefunden für ' . $sourceUrl);
                 return [];

--- a/src/State/ClientScopedProfileProcessor.php
+++ b/src/State/ClientScopedProfileProcessor.php
@@ -123,16 +123,15 @@ class ClientScopedProfileProcessor implements ProcessorInterface
 
     private function deleteRssAppFeedIfNeeded(Profile $profile): void
     {
-        $additionalData = $profile->getAdditionalData() ?? [];
+        $feedId = $profile->getRssAppFeedId();
 
-        if (!isset($additionalData['rss_feed_id'])) {
+        if ($feedId === null) {
             return;
         }
 
         try {
-            $this->rssApp->deleteFeed($additionalData['rss_feed_id']);
-            unset($additionalData['rss_feed_id']);
-            $profile->setAdditionalData($additionalData ?: null);
+            $this->rssApp->deleteFeed($feedId);
+            $profile->setRssAppFeedId(null);
         } catch (\Throwable) {
             // RSS.app deletion failure should not block profile soft-delete
         }

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -349,7 +349,7 @@
                             data-action="profile-fetch#fetch">
                         <i class="fas fa-download me-1"></i>Items importieren
                     </button>
-                    {% set rssAppFeedId = profile.additionalData.rss_feed_id|default(null) %}
+                    {% set rssAppFeedId = profile.rssAppFeedId %}
                     {% if rssAppFeedId %}
                         <form method="post" action="{{ path('app_profile_rssapp_delete', {id: profile.id}) }}"
                               data-controller="confirm"

--- a/templates/rssapp_profile/index.html.twig
+++ b/templates/rssapp_profile/index.html.twig
@@ -20,7 +20,7 @@
                 </thead>
                 <tbody>
                     {% for profile in profiles %}
-                        {% set feedId = profile.additionalData.rss_feed_id|default('') %}
+                        {% set feedId = profile.rssAppFeedId|default('') %}
                         {% set lastDate = lastItemDates[profile.id]|default(null) %}
                         <tr>
                             <td>

--- a/tests/Command/SyncRssAppFeedIdsCommandTest.php
+++ b/tests/Command/SyncRssAppFeedIdsCommandTest.php
@@ -30,7 +30,7 @@ class SyncRssAppFeedIdsCommandTest extends TestCase
         $profile->setNetwork($network);
 
         if ($feedId !== null) {
-            $profile->setAdditionalData(['rss_feed_id' => $feedId]);
+            $profile->setRssAppFeedId($feedId);
         }
 
         return $profile;
@@ -58,7 +58,7 @@ class SyncRssAppFeedIdsCommandTest extends TestCase
 
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertStringContainsString('1 aktualisiert', $tester->getDisplay());
-        $this->assertSame('feed-abc', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('feed-abc', $profile->getRssAppFeedId());
     }
 
     public function testSkipsProfileWithExistingFeedId(): void
@@ -107,7 +107,7 @@ class SyncRssAppFeedIdsCommandTest extends TestCase
         $tester->execute(['--force' => true]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertSame('new-feed', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('new-feed', $profile->getRssAppFeedId());
     }
 
     public function testDryRunDoesNotPersist(): void
@@ -194,7 +194,7 @@ class SyncRssAppFeedIdsCommandTest extends TestCase
         $tester->execute(['--network' => 'instagram_profile']);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertSame('ig-feed', $instagram->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('ig-feed', $instagram->getRssAppFeedId());
         $this->assertNull($facebook->getAdditionalData());
     }
 

--- a/tests/Unit/Entity/ProfileTest.php
+++ b/tests/Unit/Entity/ProfileTest.php
@@ -17,7 +17,7 @@ class ProfileTest extends TestCase
     public function testGetAdditionalDataDecodesJson(): void
     {
         $profile = new Profile();
-        $data = ['rss_feed_id' => 'abc123', 'key' => 'value'];
+        $data = ['foo' => 'abc123', 'key' => 'value'];
         $profile->setAdditionalData($data);
 
         $this->assertSame($data, $profile->getAdditionalData());

--- a/tests/Unit/RssApp/FeedRegistrarTest.php
+++ b/tests/Unit/RssApp/FeedRegistrarTest.php
@@ -52,7 +52,7 @@ class FeedRegistrarTest extends TestCase
     public function testNotApplicableWhenFeedIdAlreadySet(): void
     {
         $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/foo');
-        $profile->setAdditionalData(['rss_feed_id' => 'preset-id']);
+        $profile->setRssAppFeedId('preset-id');
 
         $this->rssApp->expects($this->never())->method('findRssAppFeedIdBySourceUrl');
         $this->rssApp->expects($this->never())->method('createFeed');
@@ -60,7 +60,7 @@ class FeedRegistrarTest extends TestCase
         $result = $this->registrar->registerIfNeeded($profile);
 
         $this->assertFalse($result->registered);
-        $this->assertSame('preset-id', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('preset-id', $profile->getRssAppFeedId());
     }
 
     public function testCreatesNewFeedWhenNoneFoundAtRssApp(): void
@@ -84,7 +84,7 @@ class FeedRegistrarTest extends TestCase
         $this->assertTrue($result->registered);
         $this->assertFalse($result->linkedToExistingFeed);
         $this->assertSame(0, $result->importedItems);
-        $this->assertSame('new-feed-123', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('new-feed-123', $profile->getRssAppFeedId());
     }
 
     public function testLinksToExistingFeedAndImportsInitialItems(): void
@@ -124,7 +124,7 @@ class FeedRegistrarTest extends TestCase
         $this->assertTrue($result->registered);
         $this->assertTrue($result->linkedToExistingFeed);
         $this->assertSame(3, $result->importedItems);
-        $this->assertSame('existing-feed-99', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('existing-feed-99', $profile->getRssAppFeedId());
     }
 
     public function testReturnsNotApplicableWhenRssAppLookupThrows(): void
@@ -137,7 +137,7 @@ class FeedRegistrarTest extends TestCase
         $result = $this->registrar->registerIfNeeded($profile);
 
         $this->assertFalse($result->registered);
-        $this->assertArrayNotHasKey('rss_feed_id', $profile->getAdditionalData() ?? []);
+        $this->assertNull($profile->getRssAppFeedId());
     }
 
     public function testNotApplicableWhenIdentifierIsNull(): void
@@ -185,7 +185,7 @@ class FeedRegistrarTest extends TestCase
         $imported = $this->registrar->linkExistingFeedAndImport($profile, 'adopted-feed-42');
 
         $this->assertSame(2, $imported);
-        $this->assertSame('adopted-feed-42', $profile->getAdditionalData()['rss_feed_id']);
+        $this->assertSame('adopted-feed-42', $profile->getRssAppFeedId());
     }
 
     private function makeProfile(string $networkIdentifier, string $url, ?int $id = null): Profile


### PR DESCRIPTION
## Summary
- Replaces the `additional_data['rss_feed_id']` JSON-key pattern with a dedicated `rss_app_feed_id` column on `profile` (VARCHAR 64, non-unique index).
- Schema-API + PHP-based backfill in `Version20260520120000` keeps the migration portable between MySQL (prod) and PostgreSQL (local). Existing rows are backfilled in `postUp()` and the JSON key is stripped (`additional_data` becomes `NULL` if it ends up empty). `preDown()` reverses the data move before `down()` drops the schema.
- All readers/writers go through the new `rssAppFeedId` property on `Profile` (Entity + Model). Touched: `RssApp\Fetcher`, `RssApp\FeedRegistrar` (both `registerIfNeeded` and the newer `linkExistingFeedAndImport`), `ProfileRepository::findWithRssAppFeedId` (now a clean `WHERE p.rssAppFeedId IS NOT NULL` instead of `LIKE '%"rss_feed_id"%'` over JSON), `ClientScopedProfileProcessor`, `ProfileController`, `RssAppOrphanFeedController`, `SyncRssAppFeedIdsCommand`, `ImportRssAppProfilesCommand`, `TestFixtures`, two Twig templates.
- API exposure: `rssAppFeedId` is in the `profile:detail` + `profile:write` groups, matching `additionalData` — only on the single-profile endpoint, not in collections.

## Why
The previous `LIKE '%"rss_feed_id"%'` lookup is fragile (no index, JSON shape coupling). Splitting the field out gives us an indexed column and removes the dual-write juggling around the JSON in 8+ call sites.

## Test plan
- [x] `bin/phpunit` — 205 tests pass (same pre-existing risky/deprecation noise as on main)
- [x] Migration up/down verified on local PostgreSQL with seed rows (JSON-only, JSON with extra keys, no JSON) — backfill correct in both directions
- [x] `doctrine:schema:validate` clean
- [ ] Verify on prod after deploy: `app:rssapp:sync-feed-ids` still works, `/rssapp-profiles` page renders feed IDs, RSS.app registration via `/profiles/new` writes to the new column

## Notes
- Migration timestamp `20260520120000` slots in after the most recent migration on main (`Version20260519153030`, Group entity).
- Drops the JSON key on backfill (single source of truth). The down migration restores it from the column, so rollback is non-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)