### PR TITLE
Fix DateTime/DateTimeImmutable mismatch in scheduled fetch

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -7,9 +7,9 @@ class Profile
     protected int $id;
     protected ?string $identifier = null;
     protected string $network;
-    private ?\DateTime $createdAt = null;
-    protected ?\DateTime $lastFetchSuccessDateTime = null;
-    protected ?\DateTime $lastFetchFailureDateTime = null;
+    private ?\DateTimeImmutable $createdAt = null;
+    protected ?\DateTimeImmutable $lastFetchSuccessDateTime = null;
+    protected ?\DateTimeImmutable $lastFetchFailureDateTime = null;
     protected ?string $lastFetchFailureError = null;
     protected bool $autoFetch = true;
     protected bool $fetchSource = false;
@@ -60,36 +60,36 @@ class Profile
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(?\DateTimeInterface $createdAt): self
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 
         return $this;
     }
 
-    public function getLastFetchSuccessDateTime(): ?\DateTimeInterface
+    public function getLastFetchSuccessDateTime(): ?\DateTimeImmutable
     {
         return $this->lastFetchSuccessDateTime;
     }
 
-    public function setLastFetchSuccessDateTime(?\DateTimeInterface $lastFetchSuccessDateTime): self
+    public function setLastFetchSuccessDateTime(?\DateTimeImmutable $lastFetchSuccessDateTime): self
     {
         $this->lastFetchSuccessDateTime = $lastFetchSuccessDateTime;
 
         return $this;
     }
 
-    public function getLastFetchFailureDateTime(): ?\DateTimeInterface
+    public function getLastFetchFailureDateTime(): ?\DateTimeImmutable
     {
         return $this->lastFetchFailureDateTime;
     }
 
-    public function setLastFetchFailureDateTime(?\DateTimeInterface $lastFetchFailureDateTime): self
+    public function setLastFetchFailureDateTime(?\DateTimeImmutable $lastFetchFailureDateTime): self
     {
         $this->lastFetchFailureDateTime = $lastFetchFailureDateTime;
 

--- a/src/NetworkFeedFetcher/AbstractNetworkFeedFetcher.php
+++ b/src/NetworkFeedFetcher/AbstractNetworkFeedFetcher.php
@@ -36,7 +36,7 @@ abstract class AbstractNetworkFeedFetcher implements NetworkFeedFetcherInterface
     protected function markAsFailed(Profile $profile, string $errorMessage): Profile
     {
         $profile
-            ->setLastFetchFailureDateTime(new \DateTime())
+            ->setLastFetchFailureDateTime(new \DateTimeImmutable())
             ->setLastFetchFailureError($errorMessage);
 
         $this

--- a/src/NetworkFeedFetcher/Homepage/HomepageFeedFetcher.php
+++ b/src/NetworkFeedFetcher/Homepage/HomepageFeedFetcher.php
@@ -62,7 +62,7 @@ class HomepageFeedFetcher extends AbstractNetworkFeedFetcher
     protected function markAsFailed(Profile $profile, string $errorMessage): Profile
     {
         $profile
-            ->setLastFetchFailureDateTime(new \DateTime())
+            ->setLastFetchFailureDateTime(new \DateTimeImmutable())
             ->setLastFetchFailureError($errorMessage);
 
         $this

--- a/src/ProfileFetcher/DoctrineProfileFetcher.php
+++ b/src/ProfileFetcher/DoctrineProfileFetcher.php
@@ -59,13 +59,8 @@ class DoctrineProfileFetcher implements ProfileFetcherInterface
         $model->setNetwork($entity->getNetwork()->getIdentifier());
         $model->setAutoFetch($entity->isAutoFetch());
 
-        if ($entity->getLastFetchSuccessDateTime()) {
-            $model->setLastFetchSuccessDateTime(\DateTime::createFromInterface($entity->getLastFetchSuccessDateTime()));
-        }
-
-        if ($entity->getLastFetchFailureDateTime()) {
-            $model->setLastFetchFailureDateTime(\DateTime::createFromInterface($entity->getLastFetchFailureDateTime()));
-        }
+        $model->setLastFetchSuccessDateTime($entity->getLastFetchSuccessDateTime());
+        $model->setLastFetchFailureDateTime($entity->getLastFetchFailureDateTime());
 
         $model->setLastFetchFailureError($entity->getLastFetchFailureError());
         $model->setFetchSource($entity->isFetchSource());


### PR DESCRIPTION
## Summary

- The cron-scheduled `app:fetch-scheduled` command has been silently no-op'ing since #d007956 (2026-03-25): every fetch threw `Cannot assign DateTimeImmutable to property App\Model\Profile::$lastFetchSuccessDateTime of type ?DateTime`, and the catch block then threw the same error trying to persist the failure — so neither success nor failure timestamps were ever written.
- Fix: align the `App\Model\Profile` DateTime properties (`createdAt`, `lastFetchSuccessDateTime`, `lastFetchFailureDateTime`) and their accessors with the Entity by switching from `?\DateTime` / `?\DateTimeInterface` to `?\DateTimeImmutable`.
- Update the two remaining `markAsFailed` call sites (`AbstractNetworkFeedFetcher`, `HomepageFeedFetcher`) plus `DoctrineProfileFetcher::convertToModel` so they stop downgrading entity timestamps to mutable `\DateTime`.

## How it was found

On prod, `MAX(last_fetch_success_date_time)` per scheduled network ranged between 2026-05-10 and 2026-05-23, all from manual "Jetzt fetchen" clicks in the Web UI (`ProfileController` writes directly to the Entity, whose setter is correctly typed). 24 h aggregated success/failure counters were `0` across all 7 scheduled networks. A manual `bin/console fetch-feed bluesky_profile -c 5` reproduced the typed-property error.

## Test plan

- [x] `bin/phpunit tests/NetworkFeedFetcher` — green (34 tests)
- [x] Smoke check: `App\Model\Profile::setLastFetchSuccessDateTime(new \DateTimeImmutable())` round-trips cleanly via the getter
- [ ] After merge: `git pull` on Prod, wait for next cron tick (next `:00`, `:15`, `:30`, `:45`, `:50` minute), confirm `last_fetch_success_date_time` advances for at least one profile per scheduled network

🤖 Generated with [Claude Code](https://claude.com/claude-code)