### PR TITLE
Add 'open in network' button next to profile identifier

### DIFF
--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -43,7 +43,14 @@
                         </tr>
                         <tr>
                             <th>Identifier</th>
-                            <td>{{ profile.identifier }}</td>
+                            <td>
+                                {{ profile.identifier }}
+                                {% if profile.identifier starts with 'http://' or profile.identifier starts with 'https://' %}
+                                    <a href="{{ profile.identifier }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary ms-2">
+                                        <i class="fas fa-external-link-alt me-1"></i>Im Netzwerk öffnen
+                                    </a>
+                                {% endif %}
+                            </td>
                         </tr>
                         <tr>
                             <th>Titel</th>


### PR DESCRIPTION
## Summary

- Renders a small outline button beside the identifier on `/profiles/{id}` when the identifier is an `http(s)` URL.
- Opens the live profile (Instagram/Facebook/Twitter/etc.) in a new tab — saves a copy/paste step.
- Mirrors the existing external-link pattern from `templates/item/show.html.twig` (`target=_blank`, `rel=noopener`, `fa-external-link-alt`).

## Test plan

- [ ] Visit `/profiles/40` — button "Im Netzwerk öffnen" appears next to identifier, clicking opens the URL in a new tab
- [ ] Visit a profile whose identifier is not an http URL (if any exist, e.g. legacy username-only) — button is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)