### PR TITLE
Sort network dropdowns alphabetically

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -122,7 +122,7 @@ class GroupController extends AbstractController
             }
             $networks[$profile->getNetwork()->getId()] = $profile->getNetwork();
         }
-        ksort($networks);
+        usort($networks, static fn ($a, $b): int => strcasecmp($a->getName() ?? '', $b->getName() ?? ''));
 
         return $this->render('group/show.html.twig', [
             'group' => $group,

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -31,6 +31,7 @@ class ProfileType extends AbstractType
                 'choice_label' => 'name',
                 'placeholder' => 'Netzwerk wählen...',
                 'label' => 'Netzwerk',
+                'query_builder' => fn (\Doctrine\ORM\EntityRepository $er) => $er->createQueryBuilder('n')->orderBy('n.name', 'ASC'),
             ])
             ->add('identifier', TextType::class, [
                 'label' => 'Identifier',


### PR DESCRIPTION
## Summary

- `ProfileType` network EntityType now sorts options by `name` ASC via `query_builder`. Previously it used Doctrine's natural (id) order.
- `GroupController::show` was calling `ksort()` on the network list — which sorts by the array's int keys (the network IDs), not by name. Now uses case-insensitive `usort()` on `name`.
- Other network pickers (item list filter, profile list filter, network admin) were already alphabetical via `findBy([], ['name' => 'ASC'])`.

## Test plan

- [ ] `/profiles/new` and `/profiles/{id}/edit` — network dropdown is alphabetical
- [ ] `/groups/{id}` — network filter dropdown is alphabetical

🤖 Generated with [Claude Code](https://claude.com/claude-code)