### PR TITLE
Add TikTok network (fetched via RSS.app)

### DIFF
--- a/migrations/Version20260524120000.php
+++ b/migrations/Version20260524120000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260524120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Seed TikTok network row (fetched via RSS.app)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->connection->insert('network', [
+            'identifier' => 'tiktok',
+            'name' => 'TikTok',
+            'icon' => 'fab fa-tiktok',
+            'background_color' => '#000000',
+            'text_color' => 'white',
+            'profile_url_pattern' => '#^https?://(www\.)?tiktok\.com/@[\w.\-]+/?$#i',
+            'cron_expression' => '35 * * * *',
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->connection->delete('network', ['identifier' => 'tiktok']);
+    }
+}

--- a/src/NetworkFeedFetcher/TikTok/TikTokFeedFetcher.php
+++ b/src/NetworkFeedFetcher/TikTok/TikTokFeedFetcher.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace App\NetworkFeedFetcher\TikTok;
+
+use App\RssApp\Fetcher;
+
+class TikTokFeedFetcher extends Fetcher
+{
+    public function getNetworkIdentifier(): string
+    {
+        return 'tiktok';
+    }
+}


### PR DESCRIPTION
## Summary

- New `TikTokFeedFetcher` extends `RssApp\Fetcher` with network identifier `tiktok`. Service auto-registers via `SocialNetworkFetcherPass`, no wiring needed.
- Migration `Version20260524120000` seeds the network row:
  - identifier: `tiktok`
  - name: `TikTok`
  - icon: `fab fa-tiktok`
  - background: `#000000`, text: white
  - profile URL pattern: `^https?://(www\.)?tiktok\.com/@handle/?$`
  - cron: `35 * * * *` (next free minute — :30 instagram, :45 threads, :50 twitter were taken)

## Test plan

- [x] `bin/phpunit tests/NetworkFeedFetcher` — green
- [ ] After deploy: `php bin/console doctrine:migrations:migrate` adds the network row
- [ ] `php bin/console network:list` shows `tiktok`
- [ ] Adding a TikTok profile via `/profiles/new` matches the URL pattern
- [ ] Cron at `:35` fetches the TikTok profiles via RSS.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)