### PR TITLE
Catch RSS.app delete errors instead of bubbling to 500

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -312,7 +312,13 @@ class ProfileController extends AbstractController
             return;
         }
 
-        $rssApp->deleteFeed($additionalData['rss_feed_id']);
+        try {
+            $rssApp->deleteFeed($additionalData['rss_feed_id']);
+        } catch (\Throwable $e) {
+            $this->addFlash('danger', sprintf('Löschen bei RSS.app fehlgeschlagen: %s', $e->getMessage()));
+
+            return;
+        }
 
         unset($additionalData['rss_feed_id']);
         $profile->setAdditionalData($additionalData);


### PR DESCRIPTION
## Summary

`ProfileController::unlinkRssAppFeed` (`src/Controller/ProfileController.php:303`) called `$rssApp->deleteFeed(...)` without exception handling. When RSS.app rate-limited the request (HTTP 429), the resulting `ClientException` bubbled up and Symfony rendered a 500 page on the user's "Feed entfernen" click.

Mirror the existing `rssappRegister` pattern: wrap the call in try/catch, flash a German danger message (`Löschen bei RSS.app fehlgeschlagen: …`), and skip the local `additional_data` cleanup so the user can retry once the rate limit lifts.

## Reproduction

In the Apache error log: `Uncaught PHP Exception Symfony\Component\HttpClient\Exception\ClientException: "HTTP/2 429 returned for "https://api.rss.app/v1/feeds/…"` while a parallel `bin/console fetch-feed` was hammering RSS.app.

## Test plan

- [x] `bin/phpunit tests/NetworkFeedFetcher` — green
- [ ] After deploy: with RSS.app under load, click "Feed entfernen" on a profile detail page → see red flash instead of 500; profile's `rss_feed_id` stays intact, retry works once load drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)