### PR TITLE
Make FeedFetcher resilient to Error, not just Exception

### DIFF
--- a/src/FeedFetcher/FeedFetcher.php
+++ b/src/FeedFetcher/FeedFetcher.php
@@ -86,7 +86,7 @@ class FeedFetcher extends AbstractFeedFetcher
                     }
 
                     $callback($fetchResult);
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $profile->setLastFetchFailureDateTime(new \DateTimeImmutable());
                     $profile->setLastFetchFailureError($e->getMessage());
                     $this->profilePersister->persistProfile($profile);


### PR DESCRIPTION
## Summary

The per-profile try/catch in `FeedFetcher::fetch()` only caught `\Exception`. PHP `\Error` (typed-property uninitialized, type errors, etc.) escaped the loop and aborted the entire `app:fetch-scheduled` / `fetch-feed` run, leaving the remaining profiles unfetched.

Concrete trigger today: profile 2172 had URL `https://www.tiktok.com/@anna_bauseneick_mdl` registered against the `mastodon` network (Mastodon's URL pattern accidentally matched `tiktok.com/@…` and won by length sort before the `tiktok` network existed). The Mastodon fetcher called `https://www.tiktok.com/api/v1/accounts/lookup?acct=…`, got garbage back, the deserializer produced an empty `AccountInfo`, and `$accountInfo->getId()` threw `Typed property … must not be accessed before initialization` — a `TypeError`, not an `Exception`.

Net effect: every batch fetch silently aborted around the same profile.

The profile itself has been moved to the new `tiktok` network in the DB; this patch just widens the catch so future surprises are recorded as per-profile failures instead of run-wide crashes.

## Test plan

- [x] `bin/phpunit tests/NetworkFeedFetcher` — green
- [ ] After deploy: `bin/console fetch-feed -c 100` runs end-to-end without abort even when an individual profile throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)