### PR TITLE
Cover facebook_page + threads_profile in FeedRegistrar

### DIFF
--- a/src/RssApp/FeedRegistrar.php
+++ b/src/RssApp/FeedRegistrar.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 
 class FeedRegistrar
 {
-    public const RSS_APP_NETWORKS = ['instagram_profile', 'facebook_profile', 'thread', 'twitter'];
+    public const RSS_APP_NETWORKS = ['instagram_profile', 'facebook_profile', 'facebook_page', 'threads_profile', 'thread', 'twitter'];
     public const INITIAL_IMPORT_COUNT = 100;
 
     public function __construct(


### PR DESCRIPTION
## Summary
- `FeedRegistrar::RSS_APP_NETWORKS` was missing `facebook_page` even though `FacebookFeedFetcher` returns that identifier and extends the RSS.app `Fetcher`. Profiles of that network were never registered at RSS.app via `registerIfNeeded()`.
- The constant also listed `thread` but the seeded network identifier is `threads_profile` (see NetworkFixtures / database). Added the correct one; kept `thread` for safety.

## Test plan
- [x] Existing tests still pass locally (where they were passing before).
- [ ] After deploy: POST a `facebook_page` profile via API → `additionalData.rss_feed_id` is set.
- [ ] Existing facebook_page profiles can be re-registered via DELETE + POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)