### PR TITLE
Skip yt-dlp for Mastodon/Bluesky posts without a video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 Profiles can opt into automatic photo/video downloads via `savePhotos` and `saveVideos` flags. Media is stored via Flysystem (local adapter at `public/media/`).
 
-- **`MediaUrlExtractor`** — extracts photo URLs from `raw` JSON (RSS.app `description_html` img tags, RSS.app `thumbnail` fallback, Bluesky `embed.images[]`, Mastodon `media_attachments[]`). Supports multiple photos per item. Video URL is the item's `permalink`.
+- **`MediaUrlExtractor`** — extracts photo URLs from `raw` JSON (RSS.app `description_html` img tags, RSS.app `thumbnail` fallback, Bluesky `post.embed` images, Mastodon `media_attachments[]`). Supports multiple photos per item. Video URL is the item's `permalink` — for Mastodon/Bluesky only when the raw payload actually contains a video attachment/embed (posts without video are skipped instead of failing in yt-dlp); all other networks are probed blindly.
 - **`PhotoDownloader`** — downloads images via HttpClient, stores as `{profileId}/{itemId}/photo_{index}.{ext}` in Flysystem
 - **`YtDlpPhotoDownloader`** — extracts photos (including carousel/album images) via `yt-dlp` in original quality. Used for Instagram, Threads, and Facebook where RSS.app only provides a single thumbnail. Falls back to `PhotoDownloader` if `yt-dlp` is unavailable or returns no results.
 - **`VideoDownloader`** — downloads videos via `yt-dlp` process, stores as `{profileId}/{itemId}/video.{ext}` on disk. Requires `yt-dlp` to be installed; gracefully skips if unavailable.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ php bin/console app:rssapp:sync-feed-ids --force      # re-check existing feed I
 
 ### Media download
 
-Download photos and videos for feed items. For Instagram, Threads, and Facebook, photos (including carousel/album images) are extracted in original quality via `yt-dlp`, with a fallback to the RSS.app thumbnail. Bluesky and Mastodon photos are downloaded directly from their API response (supports multiple photos per post natively). Videos are downloaded via `yt-dlp` from the item's permalink URL.
+Download photos and videos for feed items. For Instagram, Threads, and Facebook, photos (including carousel/album images) are extracted in original quality via `yt-dlp`, with a fallback to the RSS.app thumbnail. Bluesky and Mastodon photos are downloaded directly from their API response (supports multiple photos per post natively). Videos are downloaded via `yt-dlp` from the item's permalink URL. For Mastodon and Bluesky, yt-dlp is only invoked when the post's raw data actually contains a video — posts without a video are skipped instead of being recorded as failed downloads.
 
 ```bash
 php bin/console app:download-media                    # all profiles with savePhotos/saveVideos enabled

--- a/src/MediaDownloader/MediaUrlExtractor.php
+++ b/src/MediaDownloader/MediaUrlExtractor.php
@@ -7,6 +7,14 @@ use App\Entity\Item;
 class MediaUrlExtractor
 {
     /**
+     * Networks whose raw payload reliably reveals whether a post contains a
+     * video. For these we only hand the permalink to yt-dlp when the raw data
+     * actually shows a video attachment — for all other networks (RSS.app,
+     * homepage, …) the permalink is probed blindly as before.
+     */
+    private const VIDEO_DETECTABLE_NETWORKS = ['mastodon', 'bluesky_profile'];
+
+    /**
      * @return list<string>
      */
     public function extractPhotoUrls(Item $item): array
@@ -35,11 +43,15 @@ class MediaUrlExtractor
             return [$data['thumbnail']];
         }
 
-        // Bluesky format: embed.images array
-        if (isset($data['embed']['images']) && is_array($data['embed']['images'])) {
+        // Bluesky format: embed view images (nested under post.embed in fresh
+        // raw payloads, top-level embed kept for older payloads)
+        $embed = $this->resolveBlueskyEmbed($data);
+        $images = $embed['images'] ?? $embed['media']['images'] ?? null;
+
+        if (is_array($images)) {
             $urls = [];
 
-            foreach ($data['embed']['images'] as $image) {
+            foreach ($images as $image) {
                 if (isset($image['fullsize'])) {
                     $urls[] = $image['fullsize'];
                 } elseif (isset($image['thumb'])) {
@@ -72,7 +84,70 @@ class MediaUrlExtractor
 
     public function extractVideoUrl(Item $item): ?string
     {
-        return $item->getPermalink();
+        $permalink = $item->getPermalink();
+
+        if (!$permalink) {
+            return null;
+        }
+
+        $networkIdentifier = $item->getProfile()?->getNetwork()?->getIdentifier();
+
+        if (in_array($networkIdentifier, self::VIDEO_DETECTABLE_NETWORKS, true) && !$this->rawContainsVideo($item)) {
+            return null;
+        }
+
+        return $permalink;
+    }
+
+    private function rawContainsVideo(Item $item): bool
+    {
+        $raw = $item->getRaw();
+
+        if ($raw === null) {
+            return false;
+        }
+
+        $data = json_decode($raw, true);
+
+        if (!is_array($data)) {
+            return false;
+        }
+
+        // Mastodon format: media_attachments with type video/gifv
+        $attachments = $data['media_attachments'] ?? null;
+
+        if (is_array($attachments)) {
+            foreach ($attachments as $attachment) {
+                if (in_array($attachment['type'] ?? null, ['video', 'gifv'], true)) {
+                    return true;
+                }
+            }
+        }
+
+        // Bluesky format: embed view of type app.bsky.embed.video (playlist
+        // holds the HLS URL), also when wrapped in recordWithMedia
+        $embed = $this->resolveBlueskyEmbed($data);
+
+        if ($embed !== null) {
+            foreach ([$embed['$type'] ?? null, $embed['media']['$type'] ?? null] as $type) {
+                if (is_string($type) && str_contains($type, 'embed.video')) {
+                    return true;
+                }
+            }
+
+            if (isset($embed['playlist']) || isset($embed['media']['playlist'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function resolveBlueskyEmbed(array $data): ?array
+    {
+        $embed = $data['post']['embed'] ?? $data['embed'] ?? null;
+
+        return is_array($embed) ? $embed : null;
     }
 
     /**

--- a/src/MediaDownloader/VideoDownloader.php
+++ b/src/MediaDownloader/VideoDownloader.php
@@ -35,6 +35,8 @@ class VideoDownloader
         $process->run();
 
         if (!$process->isSuccessful()) {
+            $this->removeDirectoryIfEmpty($outputDir);
+
             throw new \RuntimeException(sprintf('yt-dlp failed: %s', $process->getErrorOutput() ?: $process->getOutput()));
         }
 
@@ -43,6 +45,8 @@ class VideoDownloader
         $absolutePath = $this->findVideoFile($outputDir);
 
         if ($absolutePath === null) {
+            $this->removeDirectoryIfEmpty($outputDir);
+
             throw new \RuntimeException('yt-dlp produced no video output file');
         }
 
@@ -65,6 +69,19 @@ class VideoDownloader
         }
 
         return null;
+    }
+
+    private function removeDirectoryIfEmpty(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $entries = scandir($dir);
+
+        if ($entries !== false && count($entries) === 2) {
+            @rmdir($dir);
+        }
     }
 
     public function isAvailable(): bool

--- a/src/NetworkFeedFetcher/Mastodon/EntryConverter.php
+++ b/src/NetworkFeedFetcher/Mastodon/EntryConverter.php
@@ -13,7 +13,7 @@ class EntryConverter
 
     }
 
-    public static function convert(Profile $profile, Status $status): ?Item
+    public static function convert(Profile $profile, Status $status, ?array $rawEntry = null): ?Item
     {
         $feedItem = new Item();
         $feedItem->setProfileId($profile->getId());
@@ -31,6 +31,10 @@ class EntryConverter
                     ->setText($text)
                     ->setDateTime($dateTime)
                 ;
+
+                if ($rawEntry !== null) {
+                    $feedItem->setRaw(json_encode($rawEntry, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+                }
 
                 return $feedItem;
             }

--- a/src/NetworkFeedFetcher/Mastodon/MastodonFeedFetcher.php
+++ b/src/NetworkFeedFetcher/Mastodon/MastodonFeedFetcher.php
@@ -28,9 +28,12 @@ class MastodonFeedFetcher extends AbstractNetworkFeedFetcher
             $account = IdentifierParser::parse($profile);
 
             $accountInfo = $this->getAccountInfo($account);
-            $timeline = $this->fetchTimeline($account, $accountInfo, $fetchInfo->getCount());
+            $response = $this->fetchTimeline($account, $accountInfo, $fetchInfo->getCount());
 
-            return $this->convertTimeline($profile, $timeline);
+            $timeline = $this->serializer->deserialize($response, sprintf('%s[]', Status::class), 'json');
+            $rawEntries = json_decode($response, true) ?: [];
+
+            return $this->convertTimeline($profile, $timeline, $rawEntries);
         } catch (\Exception $exception) {
             $this->markAsFailed($profile, sprintf('Failed to fetch social network profile %d: %s', $profile->getId(), $exception->getMessage()));
 
@@ -47,21 +50,20 @@ class MastodonFeedFetcher extends AbstractNetworkFeedFetcher
         return $this->serializer->deserialize($response, AccountInfo::class, 'json');
     }
 
-    private function fetchTimeline(Account $account, AccountInfo $accountInfo, int $count): array
+    private function fetchTimeline(Account $account, AccountInfo $accountInfo, int $count): string
     {
         $url = sprintf('https://%s/api/v1/accounts/%s/statuses?limit=%d', $account->getHostname(), $accountInfo->getId(), $count);
 
-        $response = $this->httpClient->request('GET', $url)->getContent();
-
-        return $this->serializer->deserialize($response, sprintf('%s[]', Status::class), 'json');
+        return $this->httpClient->request('GET', $url)->getContent();
     }
 
-    private function convertTimeline(Profile $profile, array $timeline): array
+    private function convertTimeline(Profile $profile, array $timeline, array $rawEntries): array
     {
         $feedItemList = [];
 
-        foreach ($timeline as $status) {
-            $feedItem = EntryConverter::convert($profile, $status);
+        foreach ($timeline as $index => $status) {
+            $rawEntry = $rawEntries[$index] ?? null;
+            $feedItem = EntryConverter::convert($profile, $status, is_array($rawEntry) ? $rawEntry : null);
 
             if ($feedItem) {
                 $feedItemList[] = $feedItem;

--- a/tests/MediaDownloader/MediaUrlExtractorTest.php
+++ b/tests/MediaDownloader/MediaUrlExtractorTest.php
@@ -3,6 +3,8 @@
 namespace App\Tests\MediaDownloader;
 
 use App\Entity\Item;
+use App\Entity\Network;
+use App\Entity\Profile;
 use App\MediaDownloader\MediaUrlExtractor;
 use PHPUnit\Framework\TestCase;
 
@@ -181,5 +183,163 @@ class MediaUrlExtractorTest extends TestCase
         $item = new Item();
 
         $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    private function createItemForNetwork(string $networkIdentifier): Item
+    {
+        $network = new Network();
+        $network->setIdentifier($networkIdentifier);
+
+        $profile = new Profile();
+        $profile->setNetwork($network);
+
+        $item = new Item();
+        $item->setProfile($profile);
+        $item->setPermalink('https://example.com/post/1');
+
+        return $item;
+    }
+
+    public function testExtractVideoUrlReturnsPermalinkForMastodonVideoPost(): void
+    {
+        $item = $this->createItemForNetwork('mastodon');
+        $item->setRaw(json_encode([
+            'media_attachments' => [
+                ['type' => 'image', 'url' => 'https://mastodon.example.com/media/photo.png'],
+                ['type' => 'video', 'url' => 'https://mastodon.example.com/media/video.mp4'],
+            ],
+        ]));
+
+        $this->assertSame('https://example.com/post/1', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsPermalinkForMastodonGifv(): void
+    {
+        $item = $this->createItemForNetwork('mastodon');
+        $item->setRaw(json_encode([
+            'media_attachments' => [
+                ['type' => 'gifv', 'url' => 'https://mastodon.example.com/media/animation.mp4'],
+            ],
+        ]));
+
+        $this->assertSame('https://example.com/post/1', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullForMastodonPhotoOnlyPost(): void
+    {
+        $item = $this->createItemForNetwork('mastodon');
+        $item->setRaw(json_encode([
+            'media_attachments' => [
+                ['type' => 'image', 'url' => 'https://mastodon.example.com/media/photo.png'],
+            ],
+        ]));
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullForMastodonTextPost(): void
+    {
+        $item = $this->createItemForNetwork('mastodon');
+        $item->setRaw(json_encode([
+            'media_attachments' => [],
+        ]));
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullForMastodonPostWithoutRaw(): void
+    {
+        $item = $this->createItemForNetwork('mastodon');
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsPermalinkForBlueskyVideoEmbed(): void
+    {
+        $item = $this->createItemForNetwork('bluesky_profile');
+        $item->setRaw(json_encode([
+            'post' => [
+                'embed' => [
+                    '$type' => 'app.bsky.embed.video#view',
+                    'playlist' => 'https://video.bsky.app/watch/abc/playlist.m3u8',
+                ],
+            ],
+        ]));
+
+        $this->assertSame('https://example.com/post/1', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsPermalinkForBlueskyRecordWithMediaVideo(): void
+    {
+        $item = $this->createItemForNetwork('bluesky_profile');
+        $item->setRaw(json_encode([
+            'post' => [
+                'embed' => [
+                    '$type' => 'app.bsky.embed.recordWithMedia#view',
+                    'media' => [
+                        '$type' => 'app.bsky.embed.video#view',
+                        'playlist' => 'https://video.bsky.app/watch/abc/playlist.m3u8',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertSame('https://example.com/post/1', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullForBlueskyImageEmbed(): void
+    {
+        $item = $this->createItemForNetwork('bluesky_profile');
+        $item->setRaw(json_encode([
+            'post' => [
+                'embed' => [
+                    '$type' => 'app.bsky.embed.images#view',
+                    'images' => [
+                        ['fullsize' => 'https://bsky.example.com/image.jpg'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsNullForBlueskyTextPost(): void
+    {
+        $item = $this->createItemForNetwork('bluesky_profile');
+        $item->setRaw(json_encode([
+            'post' => [
+                'record' => ['text' => 'Just text, no media'],
+            ],
+        ]));
+
+        $this->assertNull($this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractVideoUrlReturnsPermalinkForNonDetectableNetwork(): void
+    {
+        $item = $this->createItemForNetwork('instagram_profile');
+
+        $this->assertSame('https://example.com/post/1', $this->extractor->extractVideoUrl($item));
+    }
+
+    public function testExtractPhotoUrlsFromBlueskyPostNestedEmbed(): void
+    {
+        $item = new Item();
+        $item->setRaw(json_encode([
+            'post' => [
+                'embed' => [
+                    'images' => [
+                        ['fullsize' => 'https://bsky.example.com/image1.jpg'],
+                        ['thumb' => 'https://bsky.example.com/thumb2.jpg'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertSame([
+            'https://bsky.example.com/image1.jpg',
+            'https://bsky.example.com/thumb2.jpg',
+        ], $this->extractor->extractPhotoUrls($item));
     }
 }

--- a/tests/NetworkFeedFetcher/Mastodon/EntryConverterTest.php
+++ b/tests/NetworkFeedFetcher/Mastodon/EntryConverterTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\NetworkFeedFetcher\Mastodon;
+
+use App\Model\Profile;
+use App\NetworkFeedFetcher\Mastodon\EntryConverter;
+use App\NetworkFeedFetcher\Mastodon\Model\Status;
+use PHPUnit\Framework\TestCase;
+
+class EntryConverterTest extends TestCase
+{
+    private function createStatus(): Status
+    {
+        return (new Status())
+            ->setId('116296397062584045')
+            ->setCreatedAt(new \DateTime('2026-06-10 12:00:00'))
+            ->setUrl('https://mastodon.social/@Example/116296397062584045')
+            ->setContent('<p>Hello world</p>');
+    }
+
+    private function createProfile(): Profile
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+
+        return $profile;
+    }
+
+    public function testConvertSetsBasicFields(): void
+    {
+        $item = EntryConverter::convert($this->createProfile(), $this->createStatus());
+
+        $this->assertNotNull($item);
+        $this->assertSame('https://mastodon.social/@Example/116296397062584045', $item->getPermalink());
+        $this->assertSame('https://mastodon.social/@Example/116296397062584045', $item->getUniqueIdentifier());
+        $this->assertSame('<p>Hello world</p>', $item->getText());
+        $this->assertSame(42, $item->getProfileId());
+    }
+
+    public function testConvertStoresRawEntry(): void
+    {
+        $rawEntry = [
+            'id' => '116296397062584045',
+            'url' => 'https://mastodon.social/@Example/116296397062584045',
+            'media_attachments' => [
+                ['type' => 'video', 'url' => 'https://files.mastodon.social/media/video.mp4'],
+            ],
+        ];
+
+        $item = EntryConverter::convert($this->createProfile(), $this->createStatus(), $rawEntry);
+
+        $this->assertNotNull($item);
+        $this->assertJson($item->getRaw());
+
+        $decoded = json_decode($item->getRaw(), true);
+        $this->assertSame('video', $decoded['media_attachments'][0]['type']);
+    }
+
+    public function testConvertWithoutRawEntryLeavesRawNull(): void
+    {
+        $item = EntryConverter::convert($this->createProfile(), $this->createStatus());
+
+        $this->assertNotNull($item);
+        $this->assertNull($item->getRaw());
+    }
+}


### PR DESCRIPTION
## Problem

`MediaUrlExtractor::extractVideoUrl()` lieferte bedingungslos den Permalink — bei aktiviertem `saveVideos` lief yt-dlp damit für **jeden** Post, auch reine Text-/Foto-Posts. Ergebnis auf einem echten Mastodon-Profil: **31 von 32 Items als `failed`** mit `Unsupported URL`-Noise, dazu 31 leere Media-Verzeichnisse. Die Statusspalte wurde damit wertlos, `--retry-failed` hätte alles erneut durchprobiert.

Bei der Analyse kamen zwei tieferliegende Bugs zum Vorschein:

1. **Mastodon-Items hatten gar kein `raw`** — der `EntryConverter` rief `setRaw()` nie auf (100 % `raw IS NULL` in der DB). Der `media_attachments`-Foto-Zweig im `MediaUrlExtractor` war damit totes Code.
2. **Bluesky-Embeds liegen unter `post.embed`**, der Extractor suchte aber nur top-level `embed` — für frisch gefetchte Bluesky-Items ebenfalls wirkungslos.

## Fix (3 Commits)

1. **Mastodon-Fetcher speichert das Original-API-JSON als `raw`** (analog zum Bluesky-Fetcher) — macht Video-Erkennung möglich und reaktiviert nebenbei die Mastodon-Foto-Extraktion.
2. **Video-Erkennung vor dem yt-dlp-Aufruf**: Für Netzwerke mit verlässlichem Video-Marker im Raw (Mastodon `media_attachments` type `video`/`gifv`, Bluesky `embed.video`-Views inkl. `recordWithMedia`) wird der Permalink nur noch bei tatsächlichem Video an yt-dlp gereicht. RSS.app-Netzwerke behalten das blinde Probing (kein Marker verfügbar). Bluesky-Embeds werden jetzt unter `post.embed` aufgelöst (top-level bleibt als Fallback).
3. **`VideoDownloader` räumt leere Verzeichnisse** bei Fehlschlägen auf (Foto-Verzeichnisse desselben Items bleiben unberührt).

## Verifikation

End-to-End-Test mit echtem Profil (`@Mastodon@mastodon.social`, `saveVideos=true`, `fetch-feed mastodon -c 40`):

| | vorher | nachher |
|---|---|---|
| `completed` | 1 | **32** |
| `failed` | 31 | **0** |
| Video (999 KB MP4) heruntergeladen | ✅ | ✅ |
| `raw` befüllt | 0/32 | **32/32** |
| leere Verzeichnisse | 31 | **0** |

`bin/phpunit`: 223/224 grün — die eine Failure (`WahlkampfImporterTest`) stammt aus uncommitteten lokalen WIP-Dateien und besteht auch ohne diesen Branch (per `git stash` verifiziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)