### PR TITLE
Gruppen-Verwaltung: 500er-Bugs beheben, Regeln vereinheitlichen, durchsuchbarer Profil-Picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 ### Network Fetcher Types
 
-- **Direct API fetchers**: `MastodonFeedFetcher`, `BlueskyFeedFetcher`, `HomepageFeedFetcher` — each extends `AbstractNetworkFeedFetcher` and calls the network's API directly
-- **RSS.app-based fetchers**: `FacebookFeedFetcher`, `InstagramFeedFetcher`, `ThreadFeedFetcher` — extend `RssApp\Fetcher` (abstract), which proxies through RSS.app's API
+- **Direct API fetchers**: `MastodonFeedFetcher`, `BlueskyFeedFetcher`, `HomepageFeedFetcher` — each extends `AbstractNetworkFeedFetcher` and calls the network's API directly. The Mastodon fetcher stores the original API entry JSON as the item's `raw` (like Bluesky does).
+- **RSS.app-based fetchers**: `FacebookFeedFetcher`, `InstagramFeedFetcher`, `ThreadFeedFetcher`, `TikTokFeedFetcher`, `TwitterFeedFetcher` — extend `RssApp\Fetcher` (abstract), which proxies through RSS.app's API
 
 ### Each Network Fetcher Directory Contains
 
@@ -79,8 +79,11 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 - **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `savePhotos`, `saveVideos`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
 - **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`. Supports soft-delete, hide toggles, and media downloads.
-- **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
+- **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `profileUrlPattern`, `cronExpression`.
 - **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
+- **Group** — Client-scoped bundle of profiles (`profile_group` table): `id`, `name` (unique per client, validated via `UniqueEntity` + `NotBlank`), `client` (FK, required), `description`, `color`, `profiles` (ManyToMany via `profile_group_profile`). Deleting a group never touches profiles.
+
+**Gotcha:** The `profile` table has **no ID sequence** (IDs historically come from the criticalmass.in import). New profiles need an explicit ID — the API POST handler uses `ProfileRepository::findNextFreeId()` (MAX+1, race-prone workaround; proper identity column tracked in issue #86).
 
 ### Media Download System
 
@@ -111,22 +114,38 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - CLI commands and feed fetching run system-wide, no client context
 - Security: `ApiTokenAuthenticator` + `ClientTokenUserProvider`, stateless firewall for `/api/*`
 
+### Groups
+
+- A `Group` belongs to exactly one client; profiles can be members of any number of groups
+- **Membership rule (keep consistent everywhere):** admins may add *any* profile to *any* group; client-token users only profiles linked to their client. Enforced identically in `ProfileController::addToGroups()` and `GroupController::addProfile()`.
+- Members are managed via the searchable picker on the group show page (`app_group_profile_add` + JSON search endpoint `app_group_profile_search`, max 20 results, members and deleted profiles excluded) and via the profile show page. The `GroupType` form deliberately has **no** profiles field — editing a group never touches its member collection.
+- API: `/api/groups` CRUD is client-scoped via `ClientScopedGroupProcessor`, which assigns the client *after* validation — that's why the client requirement lives as a form constraint in `GroupType`, not as an entity-level `Assert\NotNull`. Group timeline at `/api/groups/{id}/items`, RSS feed at `/api/feeds/groups/{id}.rss`.
+
 ### Web UI
 
-- **Authentication**: Form login at `/login`, in-memory admin user via `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD_HASH` env vars, implemented in `WebUserProvider`
-- **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `LoginController`
+- **Authentication**: Form login at `/login`, in-memory admin user via `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD_HASH` env vars, implemented in `WebUserProvider`. Client-token users can log in via `/login/client-token` (`WebTokenAuthenticator`) and see only the group pages.
+- **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `GroupController`, `LoginController`
 - **Frontend stack**: Bootstrap 5.3, Stimulus controllers, Handlebars templates, Symfony Asset Mapper (no build step)
-- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`, `media_download_controller`
+- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`, `media_download_controller`, `group_profile_picker_controller`, `rssapp_table_controller`, `csrf_protection_controller`
 - **CSS**: Custom design system in `assets/styles/app.css` (dark sidebar, stat cards, network cards, data tables)
 - **AJAX patterns**: Profile and item lists use Stimulus + Handlebars for client-side rendering with AJAX pagination, search, and filtering. Controllers return JSON when `X-Requested-With: XMLHttpRequest` header is present.
+- **CSRF (two mechanisms!):** Symfony forms (login, GroupType, …) use *stateless* CSRF — `csrf_protection_controller.js` generates a random token on submit and double-submits it as field value + `csrf-token_<token>` cookie. **This controller is load-bearing; without JS every form submit fails.** Plain action forms (`csrf_token('…')` in Twig: toggles, delete, group add/remove) use classic session-based tokens. When driving the UI via HTTP (curl), generate a fresh double-submit pair per form POST (the cookie is consumed on validation) and parse session tokens from the rendered HTML.
 
 ### REST API (API Platform)
 
 - All endpoints under `/api/` require Bearer token (except `/api/docs`)
-- Profiles, items: client-scoped via custom State Providers/Processors
+- Profiles, items, groups: client-scoped via custom State Providers/Processors
 - Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
+- Group timeline: `GET /api/groups/{id}/items`; RSS feeds at `/api/feeds/groups/{id}.rss`
 - Networks: public read access
 - OpenAPI docs at `/api/docs`
+
+## Testing
+
+- Functional tests run against **SQLite** (`var/data_test.db`, see `.env.test`); production uses PostgreSQL. The schema is **not** rebuilt automatically — after entity/migration changes run `php bin/console doctrine:schema:drop --env=test --force && php bin/console doctrine:schema:create --env=test`, otherwise functional tests fail with `InvalidFieldNameException`.
+- Functional tests purge + load fixtures themselves (`NetworkFixtures`, `TestFixtures`) per test, see `tests/Functional/AbstractApiTestCase.php`.
+- **Web tests:** log in with `$client->loginUser(static::getContainer()->get(WebUserProvider::class)->loadUserByIdentifier('admin'), 'main')` — a hand-built `InMemoryUser` with a different password hash gets silently deauthenticated by the user-changed check on the next request (redirects to /login). Example: `tests/Functional/Web/GroupManagementTest.php`.
+- The ~90 risky-test warnings ("did not remove its own exception handlers") are a known pre-existing issue (#81); do **not** add `restore_exception_handler()` in `tearDown()` — PHPUnit 13 then complains about removed handlers instead.
 
 ## Adding a New Network Fetcher
 
@@ -172,3 +191,5 @@ docker compose up -d                                 # start PostgreSQL
 symfony serve -d                                     # start web server
 php bin/console doctrine:migrations:migrate          # run migrations
 ```
+
+**Port drift gotcha:** `compose.override.yaml` maps PostgreSQL port `"5432"` without a fixed host port — Docker assigns a random one whenever the container is recreated, silently invalidating `DATABASE_URL` in `.env.local` (symptom: "Connection refused" on a stale port). Check with `docker compose ps` and update `.env.local`, or use `symfony console` instead of `php bin/console` (the Symfony CLI injects the current Docker port automatically).

--- a/assets/controllers/group_profile_picker_controller.js
+++ b/assets/controllers/group_profile_picker_controller.js
@@ -1,0 +1,98 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Searchable profile picker on the group show page.
+ *
+ * Live-searches profiles via the JSON endpoint and renders them as
+ * checkboxes inside the surrounding form. Adding members is a regular
+ * form POST to app_group_profile_add — JS is only used for searching.
+ */
+export default class extends Controller {
+    static targets = ['input', 'results', 'submit'];
+    static values = {
+        searchUrl: String,
+    };
+
+    connect() {
+        this.timeout = null;
+        this.search();
+    }
+
+    disconnect() {
+        clearTimeout(this.timeout);
+    }
+
+    onInput() {
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(() => this.search(), 300);
+    }
+
+    async search() {
+        const term = this.inputTarget.value.trim();
+        this.resultsTarget.innerHTML = '<div class="text-muted small py-2">Suche…</div>';
+
+        try {
+            const url = new URL(this.searchUrlValue, window.location.origin);
+            if (term !== '') {
+                url.searchParams.set('q', term);
+            }
+
+            const response = await window.fetch(url, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+            this._renderResults(data.results, data.limit, term);
+        } catch (error) {
+            this.resultsTarget.innerHTML = `<div class="text-danger small py-2">Suche fehlgeschlagen: ${this._escape(error.message)}</div>`;
+        }
+
+        this._updateSubmitState();
+    }
+
+    onToggle() {
+        this._updateSubmitState();
+    }
+
+    _renderResults(results, limit, term) {
+        if (results.length === 0) {
+            this.resultsTarget.innerHTML = term === ''
+                ? '<div class="text-muted small py-2">Keine weiteren Profile verfügbar.</div>'
+                : '<div class="text-muted small py-2">Keine Treffer. Suche nach Identifier oder Titel.</div>';
+            return;
+        }
+
+        const rows = results.map((p) => `
+            <label class="d-flex align-items-center gap-2 py-1 border-bottom picker-row" style="cursor: pointer;">
+                <input type="checkbox" class="form-check-input mt-0 flex-shrink-0" name="profileIds[]" value="${p.id}"
+                       data-action="change->group-profile-picker#onToggle">
+                ${p.network ? `<span class="net-badge flex-shrink-0" style="background-color: ${this._escape(p.networkBackgroundColor || '#666')}; color: ${this._escape(p.networkTextColor || '#fff')};"><i class="${this._escape(p.networkIcon || '')} me-1"></i>${this._escape(p.network)}</span>` : ''}
+                <span class="text-truncate" title="${this._escape(p.identifier || '')}">${this._escape(p.label)}</span>
+            </label>
+        `).join('');
+
+        const hint = results.length >= limit
+            ? `<div class="text-muted small py-1">Es werden die ersten ${limit} Treffer angezeigt — Suche verfeinern für mehr.</div>`
+            : '';
+
+        this.resultsTarget.innerHTML = rows + hint;
+    }
+
+    _updateSubmitState() {
+        const checked = this.resultsTarget.querySelectorAll('input[name="profileIds[]"]:checked').length;
+        this.submitTarget.disabled = checked === 0;
+        this.submitTarget.textContent = checked > 0
+            ? `${checked} Profil${checked === 1 ? '' : 'e'} hinzufügen`
+            : 'Profile hinzufügen';
+    }
+
+    _escape(value) {
+        const div = document.createElement('div');
+        div.textContent = value ?? '';
+        return div.innerHTML;
+    }
+}

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -23,6 +23,7 @@ class GroupController extends AbstractController
 {
     private const GROUPS_PER_PAGE = 50;
     private const TIMELINE_ITEMS_PER_PAGE = 50;
+    private const PICKER_RESULTS = 20;
 
     #[Route('', name: 'app_group_index', methods: ['GET'])]
     public function index(Request $request, GroupRepository $groupRepository, ClientRepository $clientRepository): Response
@@ -79,16 +80,12 @@ class GroupController extends AbstractController
                 // Force-set again in case form data was tampered with.
                 $group->setClient($clientUser);
             }
-            if ($error = $this->ensureProfilesBelongToClient($group)) {
-                $form->addError(new \Symfony\Component\Form\FormError($error));
-            } else {
-                $em->persist($group);
-                $em->flush();
+            $em->persist($group);
+            $em->flush();
 
-                $this->addFlash('success', sprintf('Gruppe "%s" wurde angelegt.', $group->getName()));
+            $this->addFlash('success', sprintf('Gruppe "%s" wurde angelegt. Füge jetzt Profile hinzu.', $group->getName()));
 
-                return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
-            }
+            return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
         }
 
         return $this->render('group/new.html.twig', [
@@ -146,15 +143,11 @@ class GroupController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($error = $this->ensureProfilesBelongToClient($group)) {
-                $form->addError(new \Symfony\Component\Form\FormError($error));
-            } else {
-                $em->flush();
+            $em->flush();
 
-                $this->addFlash('success', 'Gruppe wurde aktualisiert.');
+            $this->addFlash('success', 'Gruppe wurde aktualisiert.');
 
-                return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
-            }
+            return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
         }
 
         return $this->render('group/edit.html.twig', [
@@ -168,11 +161,15 @@ class GroupController extends AbstractController
     {
         $this->denyForeignClient($group);
 
-        if ($this->isCsrfTokenValid('delete-group-' . $group->getId(), $request->request->getString('_token'))) {
-            $em->remove($group);
-            $em->flush();
-            $this->addFlash('success', 'Gruppe wurde gelöscht.');
+        if (!$this->isCsrfTokenValid('delete-group-' . $group->getId(), $request->request->getString('_token'))) {
+            $this->addFlash('danger', 'Die Aktion konnte nicht ausgeführt werden (ungültiges Sicherheitstoken). Bitte erneut versuchen.');
+
+            return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
         }
+
+        $em->remove($group);
+        $em->flush();
+        $this->addFlash('success', 'Gruppe wurde gelöscht.');
 
         return $this->redirectToRoute('app_group_index');
     }
@@ -182,26 +179,40 @@ class GroupController extends AbstractController
     {
         $this->denyForeignClient($group);
 
-        if ($this->isCsrfTokenValid('group-add-profile-' . $group->getId(), $request->request->getString('_token'))) {
-            $profileIds = array_map('intval', (array) $request->request->all('profileIds'));
+        if (!$this->isCsrfTokenValid('group-add-profile-' . $group->getId(), $request->request->getString('_token'))) {
+            $this->addFlash('danger', 'Die Aktion konnte nicht ausgeführt werden (ungültiges Sicherheitstoken). Bitte erneut versuchen.');
 
-            foreach ($profileIds as $profileId) {
-                if ($profileId <= 0) {
-                    continue;
-                }
-                $profile = $profileRepository->find($profileId);
-                if ($profile === null) {
-                    continue;
-                }
-                if (!$profile->getClients()->contains($group->getClient())) {
-                    $this->addFlash('warning', sprintf('Profil "%s" ist nicht mit dem Client der Gruppe verknüpft und wurde übersprungen.', $profile->getDisplayName()));
-                    continue;
-                }
-                $group->addProfile($profile);
+            return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
+        }
+
+        $profileIds = array_map('intval', (array) $request->request->all('profileIds'));
+        $clientUser = $this->loggedInClient();
+        $added = 0;
+
+        foreach ($profileIds as $profileId) {
+            if ($profileId <= 0) {
+                continue;
             }
+            $profile = $profileRepository->find($profileId);
+            if ($profile === null || $profile->isDeleted()) {
+                continue;
+            }
+            // Same rule as on the profile show page: admins may group any
+            // profile; client-token users only profiles linked to them.
+            if ($clientUser !== null && !$profile->getClients()->contains($clientUser)) {
+                $this->addFlash('warning', sprintf('Profil "%s" ist nicht mit deinem Client verknüpft und wurde übersprungen.', $profile->getDisplayName()));
+                continue;
+            }
+            $group->addProfile($profile);
+            $added++;
+        }
 
-            $em->flush();
-            $this->addFlash('success', 'Profile wurden zur Gruppe hinzugefügt.');
+        $em->flush();
+
+        if ($added > 0) {
+            $this->addFlash('success', sprintf('%d Profil%s zur Gruppe hinzugefügt.', $added, $added === 1 ? '' : 'e'));
+        } else {
+            $this->addFlash('info', 'Keine Profile ausgewählt.');
         }
 
         return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
@@ -212,13 +223,17 @@ class GroupController extends AbstractController
     {
         $this->denyForeignClient($group);
 
-        if ($this->isCsrfTokenValid('group-remove-profile-' . $group->getId() . '-' . $profileId, $request->request->getString('_token'))) {
-            $profile = $profileRepository->find($profileId);
-            if ($profile !== null) {
-                $group->removeProfile($profile);
-                $em->flush();
-                $this->addFlash('success', sprintf('Profil "%s" wurde aus der Gruppe entfernt.', $profile->getDisplayName()));
-            }
+        if (!$this->isCsrfTokenValid('group-remove-profile-' . $group->getId() . '-' . $profileId, $request->request->getString('_token'))) {
+            $this->addFlash('danger', 'Die Aktion konnte nicht ausgeführt werden (ungültiges Sicherheitstoken). Bitte erneut versuchen.');
+
+            return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
+        }
+
+        $profile = $profileRepository->find($profileId);
+        if ($profile !== null) {
+            $group->removeProfile($profile);
+            $em->flush();
+            $this->addFlash('success', sprintf('Profil "%s" wurde aus der Gruppe entfernt.', $profile->getDisplayName()));
         }
 
         return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
@@ -230,30 +245,35 @@ class GroupController extends AbstractController
         return $user instanceof Client ? $user : null;
     }
 
+    #[Route('/{id}/profiles/search', name: 'app_group_profile_search', requirements: ['id' => '\d+'], methods: ['GET'])]
+    public function searchProfiles(Request $request, Group $group, ProfileRepository $profileRepository): Response
+    {
+        $this->denyForeignClient($group);
+
+        $term = trim($request->query->getString('q', ''));
+        $memberIds = array_map(static fn (Profile $p) => $p->getId(), $group->getProfiles()->toArray());
+
+        $profiles = $profileRepository->searchForPicker($term, $memberIds, self::PICKER_RESULTS);
+
+        return $this->json([
+            'results' => array_map(static fn (Profile $p) => [
+                'id' => $p->getId(),
+                'label' => $p->getDisplayName(),
+                'identifier' => $p->getIdentifier(),
+                'network' => $p->getNetwork()?->getName(),
+                'networkIcon' => $p->getNetwork()?->getIcon(),
+                'networkBackgroundColor' => $p->getNetwork()?->getBackgroundColor(),
+                'networkTextColor' => $p->getNetwork()?->getTextColor(),
+            ], $profiles),
+            'limit' => self::PICKER_RESULTS,
+        ]);
+    }
+
     private function denyForeignClient(Group $group): void
     {
         $client = $this->loggedInClient();
         if ($client !== null && $group->getClient()?->getId() !== $client->getId()) {
             throw new NotFoundHttpException('Group not found.');
         }
-    }
-
-    /** @return string|null  Error message if invalid, null if OK */
-    private function ensureProfilesBelongToClient(Group $group): ?string
-    {
-        $client = $group->getClient();
-        if ($client === null) {
-            return null;
-        }
-        foreach ($group->getProfiles() as $profile) {
-            if (!$profile->getClients()->contains($client)) {
-                return sprintf(
-                    'Profil "%s" ist nicht mit dem Client "%s" verknüpft. Verknüpfe es zuerst auf der Profil-Detailseite oder über die API.',
-                    $profile->getDisplayName(),
-                    $client->getName(),
-                );
-            }
-        }
-        return null;
     }
 }

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -18,7 +18,9 @@ use App\State\ClientScopedGroupProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: 'profile_group')]
 #[ORM\UniqueConstraint(name: 'uniq_group_client_name', columns: ['client_id', 'name'])]
@@ -61,6 +63,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
     'profiles' => 'exact',
 ])]
 #[ApiFilter(OrderFilter::class, properties: ['name', 'createdAt'])]
+#[UniqueEntity(fields: ['client', 'name'], message: 'Eine Gruppe mit diesem Namen existiert für diesen Client bereits.')]
 class Group
 {
     #[ORM\Id]
@@ -72,9 +75,14 @@ class Group
 
     #[ORM\Column(type: 'string', length: 64)]
     #[Groups(['group:read', 'group:write'])]
+    #[Assert\NotBlank(message: 'Bitte einen Namen für die Gruppe angeben.')]
+    #[Assert\Length(max: 64)]
     #[ApiProperty(description: 'Human-readable name of the group. Must be unique within the client.', example: 'Klima')]
     private ?string $name = null;
 
+    // Kein Assert\NotNull hier: Beim API-POST setzt der ClientScopedGroupProcessor
+    // den Client erst nach der Validierung. Das Web-Formular erzwingt die
+    // Auswahl über einen Feld-Constraint im GroupType.
     #[ORM\ManyToOne(targetEntity: Client::class)]
     #[ORM\JoinColumn(name: 'client_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     #[ApiProperty(description: 'The owning client. Set automatically from the Bearer token; not writable via the API.', readable: false, writable: false)]

--- a/src/Form/GroupType.php
+++ b/src/Form/GroupType.php
@@ -4,8 +4,6 @@ namespace App\Form;
 
 use App\Entity\Client;
 use App\Entity\Group;
-use App\Entity\Profile;
-use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
@@ -13,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotNull;
 
 class GroupType extends AbstractType
 {
@@ -31,6 +30,7 @@ class GroupType extends AbstractType
                 'label' => 'Client',
                 'placeholder' => 'Client wählen...',
                 'help' => 'Eigentümer-Client der Gruppe. Bestimmt, wer sie über die API sieht.',
+                'constraints' => [new NotNull(message: 'Bitte einen Client wählen.')],
             ]);
         }
 
@@ -44,23 +44,12 @@ class GroupType extends AbstractType
                 'label' => 'Farbe',
                 'required' => false,
                 'help' => 'Optional, für die Badge-Darstellung im UI.',
-            ])
-            ->add('profiles', EntityType::class, [
-                'class' => Profile::class,
-                'multiple' => true,
-                'expanded' => false,
-                'label' => 'Profile',
-                'required' => false,
-                'attr' => ['size' => 15],
-                'choice_label' => fn(Profile $p) => sprintf('%s — %s', $p->getNetwork()?->getName() ?? '?', $p->getDisplayName()),
-                'query_builder' => fn(EntityRepository $repository) => $repository->createQueryBuilder('p')
-                    ->leftJoin('p.network', 'n')
-                    ->addSelect('n')
-                    ->andWhere('p.deleted = false')
-                    ->orderBy('n.name', 'ASC')
-                    ->addOrderBy('p.identifier', 'ASC'),
-                'help' => 'Profile, die zur Gruppe gehören. Profile, die nicht zum gewählten Client verknüpft sind, werden beim Speichern abgewiesen.',
             ]);
+        // Mitglieder werden nicht mehr über dieses Formular gepflegt, sondern
+        // über den durchsuchbaren Picker auf der Gruppen-Detailseite (und die
+        // Profil-Detailseite). Das frühere Multi-Select über alle Profile war
+        // bei ~2000 Einträgen unbenutzbar und hat beim Bearbeiten die
+        // Mitgliederliste ersetzt.
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -82,6 +82,36 @@ class ProfileRepository extends ServiceEntityRepository
     /**
      * @param list<int> $networkIds
      */
+    /**
+     * Search non-deleted profiles for the group member picker, excluding
+     * profiles that are already members.
+     *
+     * @param list<int> $excludeIds
+     * @return list<Profile>
+     */
+    public function searchForPicker(string $term, array $excludeIds = [], int $limit = 20): array
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->leftJoin('p.network', 'n')
+            ->addSelect('n')
+            ->andWhere('p.deleted = false')
+            ->orderBy('n.name', 'ASC')
+            ->addOrderBy('p.identifier', 'ASC')
+            ->setMaxResults($limit);
+
+        if ($term !== '') {
+            $qb->andWhere('LOWER(p.identifier) LIKE :term OR LOWER(p.title) LIKE :term')
+                ->setParameter('term', '%' . mb_strtolower($term) . '%');
+        }
+
+        if ($excludeIds !== []) {
+            $qb->andWhere('p.id NOT IN (:excludeIds)')
+                ->setParameter('excludeIds', $excludeIds);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     private function applyFilters(\Doctrine\ORM\QueryBuilder $qb, array $networkIds, string $search, string $status): void
     {
         if ($networkIds !== []) {

--- a/templates/group/edit.html.twig
+++ b/templates/group/edit.html.twig
@@ -14,7 +14,7 @@
                 {% endif %}
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
-                {{ form_row(form.profiles) }}
+                <p class="text-muted small">Mitglieder verwaltest du auf der <a href="{{ path('app_group_show', {id: group.id}) }}">Gruppen-Seite</a> über die durchsuchbare Profil-Auswahl.</p>
                 <div class="mt-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary">Speichern</button>
                     <a href="{{ path('app_group_show', {id: group.id}) }}" class="btn btn-outline-secondary">Abbrechen</a>

--- a/templates/group/new.html.twig
+++ b/templates/group/new.html.twig
@@ -14,7 +14,7 @@
                 {% endif %}
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
-                {{ form_row(form.profiles) }}
+                <p class="text-muted small">Profile fügst du nach dem Anlegen auf der Gruppen-Seite hinzu — dort gibt es eine durchsuchbare Auswahl.</p>
                 <div class="mt-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary">Anlegen</button>
                     <a href="{{ path('app_group_index') }}" class="btn btn-outline-secondary">Abbrechen</a>

--- a/templates/group/show.html.twig
+++ b/templates/group/show.html.twig
@@ -52,7 +52,7 @@
                 </div>
                 <div class="data-card-body">
                     {% if group.profiles is empty %}
-                        <p class="text-muted mb-0">Diese Gruppe enthält noch keine Profile. Über „Bearbeiten" lassen sich welche hinzufügen.</p>
+                        <p class="text-muted mb-3">Diese Gruppe enthält noch keine Profile — unten welche suchen und hinzufügen.</p>
                     {% else %}
                         <table class="data-table">
                             <thead>
@@ -91,6 +91,27 @@
                             </tbody>
                         </table>
                     {% endif %}
+                </div>
+            </div>
+
+            <div class="data-card mb-3">
+                <div class="data-card-header">Profile hinzufügen</div>
+                <div class="data-card-body">
+                    <form method="post" action="{{ path('app_group_profile_add', {id: group.id}) }}"
+                          data-controller="group-profile-picker"
+                          data-group-profile-picker-search-url-value="{{ path('app_group_profile_search', {id: group.id}) }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('group-add-profile-' ~ group.id) }}">
+                        <input type="search" class="form-control form-control-sm mb-2"
+                               placeholder="Profil suchen (Identifier oder Titel)…"
+                               data-group-profile-picker-target="input"
+                               data-action="input->group-profile-picker#onInput">
+                        <div class="mb-2" style="max-height: 280px; overflow-y: auto;"
+                             data-group-profile-picker-target="results"></div>
+                        <button type="submit" class="btn btn-primary btn-sm" disabled
+                                data-group-profile-picker-target="submit">
+                            Profile hinzufügen
+                        </button>
+                    </form>
                 </div>
             </div>
 

--- a/tests/Functional/Web/GroupManagementTest.php
+++ b/tests/Functional/Web/GroupManagementTest.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\DataFixtures\NetworkFixtures;
+use App\DataFixtures\TestFixtures;
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Profile;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
+use App\Security\WebUserProvider;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class GroupManagementTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        $loader = new Loader();
+        $loader->addFixture(new NetworkFixtures());
+        $loader->addFixture(new TestFixtures());
+
+        $executor = new ORMExecutor($this->em, new ORMPurger($this->em));
+        $executor->execute($loader->getFixtures());
+
+        // Use the provider's own user so the refreshed user matches exactly —
+        // a hand-built InMemoryUser with a different password hash would be
+        // deauthenticated by the usersChanged check on the next request.
+        $admin = static::getContainer()->get(WebUserProvider::class)->loadUserByIdentifier('admin');
+        $this->client->loginUser($admin, 'main');
+    }
+
+    private function findClient(string $name): Client
+    {
+        return $this->em->getRepository(Client::class)->findOneBy(['name' => $name]);
+    }
+
+    private function findProfile(string $identifier): Profile
+    {
+        return $this->em->getRepository(Profile::class)->findOneBy(['identifier' => $identifier]);
+    }
+
+    private function createGroup(string $name, Client $client): Group
+    {
+        $group = new Group();
+        $group->setName($name);
+        $group->setClient($client);
+        $this->em->persist($group);
+        $this->em->flush();
+
+        return $group;
+    }
+
+    public function testCreateGroupViaForm(): void
+    {
+        $crawler = $this->client->request('GET', '/groups/new');
+        $this->assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Anlegen')->form([
+            'group[name]' => 'Klimagruppen',
+            'group[client]' => (string) $this->findClient('Client A')->getId(),
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects();
+
+        $group = $this->em->getRepository(Group::class)->findOneBy(['name' => 'Klimagruppen']);
+        $this->assertNotNull($group);
+        $this->assertSame('Client A', $group->getClient()->getName());
+    }
+
+    public function testCreateGroupWithEmptyNameShowsFormErrorInsteadOf500(): void
+    {
+        $crawler = $this->client->request('GET', '/groups/new');
+        $form = $crawler->selectButton('Anlegen')->form([
+            'group[name]' => '',
+            'group[client]' => (string) $this->findClient('Client A')->getId(),
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertStringContainsString('Bitte einen Namen', $this->client->getResponse()->getContent());
+    }
+
+    public function testCreateGroupWithDuplicateNameShowsFormErrorInsteadOf500(): void
+    {
+        $clientA = $this->findClient('Client A');
+        $this->createGroup('Doppelt', $clientA);
+
+        $crawler = $this->client->request('GET', '/groups/new');
+        $form = $crawler->selectButton('Anlegen')->form([
+            'group[name]' => 'Doppelt',
+            'group[client]' => (string) $clientA->getId(),
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertStringContainsString('existiert für diesen Client bereits', $this->client->getResponse()->getContent());
+    }
+
+    public function testSameNameForDifferentClientIsAllowed(): void
+    {
+        $this->createGroup('Geteilt', $this->findClient('Client A'));
+
+        $crawler = $this->client->request('GET', '/groups/new');
+        $form = $crawler->selectButton('Anlegen')->form([
+            'group[name]' => 'Geteilt',
+            'group[client]' => (string) $this->findClient('Client B')->getId(),
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects();
+        $this->assertCount(2, $this->em->getRepository(Group::class)->findBy(['name' => 'Geteilt']));
+    }
+
+    public function testAdminCanAddUnlinkedProfileViaGroupPage(): void
+    {
+        // Group belongs to Client A; profile onlyB is linked to Client B only.
+        $group = $this->createGroup('Admin-Gruppe', $this->findClient('Client A'));
+        $profile = $this->findProfile('https://mastodon.social/@onlyb');
+
+        $crawler = $this->client->request('GET', '/groups/' . $group->getId());
+        $this->assertResponseIsSuccessful();
+
+        $token = $crawler->filter('form[action$="/profiles/add"] input[name="_token"]')->attr('value');
+
+        $this->client->request('POST', '/groups/' . $group->getId() . '/profiles/add', [
+            '_token' => $token,
+            'profileIds' => [(string) $profile->getId()],
+        ]);
+
+        $this->assertResponseRedirects('/groups/' . $group->getId());
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Group::class)->find($group->getId());
+        $this->assertSame(1, $reloaded->getProfileCount());
+    }
+
+    public function testAddProfileSkipsDeletedProfiles(): void
+    {
+        $group = $this->createGroup('Keine-Leichen', $this->findClient('Client A'));
+        $deleted = $this->findProfile('https://mastodon.social/@deleted');
+
+        $crawler = $this->client->request('GET', '/groups/' . $group->getId());
+        $token = $crawler->filter('form[action$="/profiles/add"] input[name="_token"]')->attr('value');
+
+        $this->client->request('POST', '/groups/' . $group->getId() . '/profiles/add', [
+            '_token' => $token,
+            'profileIds' => [(string) $deleted->getId()],
+        ]);
+
+        $this->assertResponseRedirects();
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Group::class)->find($group->getId());
+        $this->assertSame(0, $reloaded->getProfileCount());
+    }
+
+    public function testRenameGroupContainingUnlinkedMember(): void
+    {
+        // Regression: previously the edit form re-validated client linkage of
+        // all members and made such groups uneditable (deadlock).
+        $group = $this->createGroup('Vorher', $this->findClient('Client A'));
+        $group->addProfile($this->findProfile('https://mastodon.social/@onlyb'));
+        $this->em->flush();
+
+        $crawler = $this->client->request('GET', '/groups/' . $group->getId() . '/edit');
+        $form = $crawler->selectButton('Speichern')->form([
+            'group[name]' => 'Nachher',
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects();
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Group::class)->find($group->getId());
+        $this->assertSame('Nachher', $reloaded->getName());
+        $this->assertSame(1, $reloaded->getProfileCount(), 'Mitglieder dürfen beim Umbenennen nicht verloren gehen');
+    }
+
+    public function testProfileSearchExcludesMembersAndDeleted(): void
+    {
+        $group = $this->createGroup('Suche', $this->findClient('Client A'));
+        $member = $this->findProfile('https://mastodon.social/@shared');
+        $group->addProfile($member);
+        $this->em->flush();
+
+        $this->client->request('GET', '/groups/' . $group->getId() . '/profiles/search', ['q' => 'mastodon']);
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+
+        $ids = array_column($data['results'], 'id');
+        $this->assertNotContains($member->getId(), $ids, 'Mitglieder dürfen nicht erneut angeboten werden');
+
+        $identifiers = array_column($data['results'], 'identifier');
+        $this->assertContains('https://mastodon.social/@onlyb', $identifiers);
+        $this->assertNotContains('https://mastodon.social/@deleted', $identifiers, 'Gelöschte Profile dürfen nicht angeboten werden');
+    }
+
+    public function testAddProfileWithInvalidCsrfShowsErrorFlash(): void
+    {
+        $group = $this->createGroup('CSRF-Gruppe', $this->findClient('Client A'));
+        $profile = $this->findProfile('https://mastodon.social/@onlyb');
+
+        $this->client->request('POST', '/groups/' . $group->getId() . '/profiles/add', [
+            '_token' => 'kaputt',
+            'profileIds' => [(string) $profile->getId()],
+        ]);
+
+        $this->assertResponseRedirects();
+        $crawler = $this->client->followRedirect();
+
+        $this->assertStringContainsString('ungültiges Sicherheitstoken', $crawler->html());
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Group::class)->find($group->getId());
+        $this->assertSame(0, $reloaded->getProfileCount());
+    }
+}


### PR DESCRIPTION
## Anlass

End-to-End-Verifikation des Gruppen-Features (Anlegen + Profil-Zuordnung) gegen die laufende App. Ergebnis: Happy Path funktionierte, aber vier handfeste Probleme:

1. **Duplikat-Gruppenname → HTTP 500** (`SQLSTATE 23505`, ungefangene Unique-Violation)
2. **Leerer Name → HTTP 500** (`SQLSTATE 23502`, kein NotBlank)
3. **Widersprüchliche Zuordnungsregeln bis zum Deadlock:** Die Profilseite (#67) erlaubt Admins, jedes Profil jeder Gruppe zuzuordnen — das Gruppen-Edit-Formular erzwang aber Client-Verknüpfung aller Mitglieder. Folge: Eine Gruppe mit einem per Profilseite zugeordneten, unverknüpften Profil ließ sich **nicht einmal mehr umbenennen** (422). Zudem ersetzte jeder Edit-Submit die komplette Mitgliederliste.
4. **Unbenutzbare Profil-Auswahl:** nacktes `<select multiple>` mit ~2000 Einträgen ohne Suche; auf der Gruppen-Seite selbst gab es **gar kein** Add-UI (`app_group_profile_add` war ein toter Endpoint ohne Template).

## Änderungen (3 Commits)

1. **Validierung:** `UniqueEntity(client, name)` + `NotBlank` auf der Entity → 422 mit Feldmeldung statt 500. Client-Pflicht als Form-Constraint (Entity-Level würde den API-Processor brechen, der den Client erst nach der Validierung setzt — API-Tests bleiben grün).
2. **Picker + Regeln:** Profiles-Multi-Select aus dem Formular entfernt (Edit fasst Mitglieder nicht mehr an → Deadlock weg). Neue durchsuchbare Auswahl direkt auf der Gruppen-Seite: Live-Suche über neuen JSON-Endpoint (`/groups/{id}/profiles/search`, max. 20 Treffer, Mitglieder/gelöschte ausgeschlossen), Hinzufügen als regulärer Form-POST an die bisher verwaiste Add-Route. `addProfile` folgt jetzt derselben Regel wie die Profilseite (Admin: alles; Client-User: nur verknüpfte). CSRF-Fehler zeigen eine Flash-Meldung statt still zu redirecten.
3. **Tests:** 9 neue Functional-Tests (`tests/Functional/Web/GroupManagementTest.php`) decken alle obigen Fälle ab, inkl. Regression für den Umbenennen-Deadlock und Mitglieder-Erhalt beim Edit.

## Verifikation

Identische Live-HTTP-Flows vor/nach dem Fix (Login als Web-Admin, echte Form-POSTs):

| Flow | vorher | nachher |
|---|---|---|
| Duplikatname | **500** | 422 „existiert für diesen Client bereits" |
| Leerer Name | **500** | 422 „Bitte einen Namen … angeben" |
| Ohne Client | ungeprüft | 422 „Bitte einen Client wählen" |
| Admin: unverknüpftes Profil über Gruppen-Seite | übersprungen (und kein UI) | ✅ Mitglied, durchsuchbarer Picker |
| Gruppe mit unverknüpftem Mitglied umbenennen | **422-Deadlock** | ✅ 302, Mitglied bleibt erhalten |
| Picker-Suche `?q=cmhannover` | — | ✅ JSON, netzwerkübergreifend |

`bin/phpunit`: 233 Tests / 637 Assertions — einzige Failure ist das bekannte uncommittete Wahlkampf-WIP (unabhängig, per stash verifiziert).

Hinweis: Die Gruppen-Seiten fehlen generell noch in der README (Web-UI-Abschnitt) — gehört zu #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)