### PR TITLE
Instagram-Medien: Cookie-Support, Upload-Endpoint + Chrome-Extension

### DIFF
--- a/.env
+++ b/.env
@@ -25,6 +25,13 @@ CRITICALMASS_HOSTNAME="criticalmass.in"
 RSS_APP_API_KEY=c_ULGigpJGEh9ByT
 RSS_APP_API_SECRET=s_zlrGVS4T3dY4YCOfR1U8w5
 
+###> app/media ###
+# Optionaler Pfad zu einer Netscape-cookies.txt für yt-dlp (z. B. Instagram-Login).
+# Leer lassen, um ohne Cookies zu arbeiten. Auf dem Server z. B.:
+# YT_DLP_COOKIES_FILE=/var/www/feeds/var/yt-dlp-cookies.txt
+YT_DLP_COOKIES_FILE=
+###< app/media ###
+
 ###> app/web-auth ###
 WEB_ADMIN_USERNAME=admin
 WEB_ADMIN_PASSWORD_HASH='$2y$13$changeme'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,6 +17,7 @@ services:
             $webAdminUsername: '%env(WEB_ADMIN_USERNAME)%'
             $webAdminPasswordHash: '%env(WEB_ADMIN_PASSWORD_HASH)%'
             $mediaDirectory: '%kernel.project_dir%/public/media'
+            $ytDlpCookiesFile: '%env(YT_DLP_COOKIES_FILE)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Command/DownloadMediaCommand.php
+++ b/src/Command/DownloadMediaCommand.php
@@ -27,7 +27,7 @@ class DownloadMediaCommand extends Command
         $this
             ->setName('app:download-media')
             ->setDescription('Download media (photos/videos) for feed items')
-            ->addOption('profile', null, InputOption::VALUE_REQUIRED, 'Download media for a specific profile ID')
+            ->addOption('profile-id', null, InputOption::VALUE_REQUIRED, 'Download media for a specific profile ID')
             ->addOption('retry-failed', null, InputOption::VALUE_NONE, 'Retry previously failed downloads')
             ->addOption('photos-only', null, InputOption::VALUE_NONE, 'Download only photos')
             ->addOption('videos-only', null, InputOption::VALUE_NONE, 'Download only videos')
@@ -37,7 +37,7 @@ class DownloadMediaCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $profileId = $input->getOption('profile');
+        $profileId = $input->getOption('profile-id');
         $retryFailed = $input->getOption('retry-failed');
         $photosOnly = $input->getOption('photos-only');
         $videosOnly = $input->getOption('videos-only');

--- a/src/Controller/Api/CookieController.php
+++ b/src/Controller/Api/CookieController.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\Client;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Nimmt eine yt-dlp-cookies.txt (Netscape-Format) entgegen und legt sie unter
+ * dem konfigurierten Pfad (YT_DLP_COOKIES_FILE) ab. Damit kann z. B. eine
+ * Browser-Extension die Instagram-Session-Cookies direkt hochladen, ohne dass
+ * jemand manuell eine Datei per scp auf den Server kopieren muss.
+ *
+ * Auth: liegt unter /api → durch den ApiTokenAuthenticator (Bearer) geschützt
+ * (access_control: ^/api → ROLE_API_CLIENT).
+ */
+class CookieController
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly string $ytDlpCookiesFile = '',
+    ) {
+    }
+
+    #[Route('/api/yt-dlp-cookies', name: 'app_api_ytdlp_cookies', methods: ['PUT', 'POST'])]
+    #[OA\Put(
+        summary: 'Speichert eine yt-dlp cookies.txt (Netscape) für medienpflichtige Netzwerke (z. B. Instagram-Login).',
+        responses: [
+            new OA\Response(response: 200, description: 'Gespeichert.'),
+            new OA\Response(response: 400, description: 'Body ist keine gültige Netscape-cookies.txt.'),
+            new OA\Response(response: 401, description: 'Fehlender/ungültiger Bearer-Token.'),
+            new OA\Response(response: 503, description: 'YT_DLP_COOKIES_FILE nicht konfiguriert.'),
+        ],
+    )]
+    public function store(Request $request): Response
+    {
+        $this->requireClient();
+
+        if ($this->ytDlpCookiesFile === '') {
+            return new JsonResponse(['error' => 'YT_DLP_COOKIES_FILE ist nicht konfiguriert.'], 503);
+        }
+
+        $content = $request->getContent();
+
+        // JSON-Variante {"cookies":"..."} ebenfalls erlauben.
+        $contentType = (string) $request->headers->get('Content-Type', '');
+        if (str_starts_with(trim($contentType), 'application/json')) {
+            $data = json_decode($content, true);
+            $content = (is_array($data) && isset($data['cookies'])) ? (string) $data['cookies'] : '';
+        }
+
+        $content = trim($content);
+
+        // Grobe Plausibilitätsprüfung: Netscape-cookies.txt sind Tab-getrennt.
+        if (strlen($content) < 20 || !str_contains($content, "\t")) {
+            return new JsonResponse(
+                ['error' => 'Body sieht nicht nach einer Netscape-cookies.txt aus (Tab-getrennte Zeilen erwartet).'],
+                400,
+            );
+        }
+
+        if (!str_starts_with($content, '# Netscape HTTP Cookie File')) {
+            $content = "# Netscape HTTP Cookie File\n" . $content;
+        }
+        $content .= "\n";
+
+        $dir = \dirname($this->ytDlpCookiesFile);
+        if (!is_dir($dir) && !@mkdir($dir, 0775, true) && !is_dir($dir)) {
+            return new JsonResponse(['error' => 'Cookies-Verzeichnis nicht beschreibbar.'], 500);
+        }
+
+        // Atomar schreiben (temp + rename), restriktive Rechte (Session-Datei!).
+        $tmp = $this->ytDlpCookiesFile . '.tmp';
+        if (@file_put_contents($tmp, $content) === false) {
+            return new JsonResponse(['error' => 'Schreiben der Cookies-Datei fehlgeschlagen.'], 500);
+        }
+        @chmod($tmp, 0600);
+        if (!@rename($tmp, $this->ytDlpCookiesFile)) {
+            @unlink($tmp);
+            return new JsonResponse(['error' => 'Verschieben der Cookies-Datei fehlgeschlagen.'], 500);
+        }
+
+        return new JsonResponse([
+            'status' => 'ok',
+            'path'   => $this->ytDlpCookiesFile,
+            'bytes'  => strlen($content),
+            'cookies' => max(0, substr_count($content, "\n") - 1),
+        ]);
+    }
+
+    private function requireClient(): Client
+    {
+        $client = $this->security->getUser();
+        if (!$client instanceof Client) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return $client;
+    }
+}

--- a/src/MediaDownloader/MediaDownloadService.php
+++ b/src/MediaDownloader/MediaDownloadService.php
@@ -127,10 +127,20 @@ class MediaDownloadService
             && in_array($networkIdentifier, self::YTDLP_PHOTO_NETWORKS, true)
             && $this->ytDlpPhotoDownloader->isAvailable()
         ) {
-            $paths = $this->ytDlpPhotoDownloader->download($permalink, $profile->getId(), $item->getId());
+            try {
+                $paths = $this->ytDlpPhotoDownloader->download($permalink, $profile->getId(), $item->getId());
 
-            if (!empty($paths)) {
-                return $paths;
+                if (!empty($paths)) {
+                    return $paths;
+                }
+            } catch (\Throwable $e) {
+                // yt-dlp kann manche Instagram-Post-Typen nicht extrahieren
+                // ("No video formats found" o. Ä.). Kein harter Fehler – auf den
+                // raw-Daten-Fallback (description_html / thumbnail) ausweichen.
+                $this->logger->warning('yt-dlp photo extraction failed for item {itemId}, falling back to raw media URLs: {message}', [
+                    'itemId' => $item->getId(),
+                    'message' => $e->getMessage(),
+                ]);
             }
         }
 

--- a/src/MediaDownloader/VideoDownloader.php
+++ b/src/MediaDownloader/VideoDownloader.php
@@ -10,6 +10,7 @@ class VideoDownloader
 
     public function __construct(
         private readonly string $mediaDirectory,
+        private readonly string $ytDlpCookiesFile = '',
     ) {
     }
 
@@ -26,6 +27,7 @@ class VideoDownloader
         $process = new Process([
             'yt-dlp',
             '--no-playlist',
+            ...$this->cookieArgs(),
             '--max-filesize', '100M',
             '-o', $outputTemplate,
             $url,
@@ -65,6 +67,23 @@ class VideoDownloader
         }
 
         return null;
+    }
+
+    /**
+     * yt-dlp cookie arguments for sites that require a login (e.g. Instagram).
+     * Only applied when a non-empty cookies file is configured and present.
+     *
+     * @return list<string>
+     */
+    private function cookieArgs(): array
+    {
+        $file = $this->ytDlpCookiesFile;
+
+        if ($file !== '' && is_file($file) && filesize($file) > 0) {
+            return ['--cookies', $file];
+        }
+
+        return [];
     }
 
     public function isAvailable(): bool

--- a/src/MediaDownloader/YtDlpPhotoDownloader.php
+++ b/src/MediaDownloader/YtDlpPhotoDownloader.php
@@ -10,6 +10,7 @@ class YtDlpPhotoDownloader
 
     public function __construct(
         private readonly string $mediaDirectory,
+        private readonly string $ytDlpCookiesFile = '',
     ) {
     }
 
@@ -29,6 +30,7 @@ class YtDlpPhotoDownloader
         $process = new Process([
             'yt-dlp',
             '--no-playlist',
+            ...$this->cookieArgs(),
             '--write-thumbnail',
             '--skip-download',
             '--convert-thumbnails', 'jpg',
@@ -81,6 +83,23 @@ class YtDlpPhotoDownloader
         }
 
         return $images;
+    }
+
+    /**
+     * yt-dlp cookie arguments for sites that require a login (e.g. Instagram).
+     * Only applied when a non-empty cookies file is configured and present.
+     *
+     * @return list<string>
+     */
+    private function cookieArgs(): array
+    {
+        $file = $this->ytDlpCookiesFile;
+
+        if ($file !== '' && is_file($file) && filesize($file) > 0) {
+            return ['--cookies', $file];
+        }
+
+        return [];
     }
 
     public function isAvailable(): bool

--- a/tools/chrome-instagram-cookies/README.md
+++ b/tools/chrome-instagram-cookies/README.md
@@ -1,0 +1,28 @@
+# Instagram Cookies → feeds.maltehuebner.dev (Chrome-Extension)
+
+Liest die Instagram-Session-Cookies aus dem Browser (inkl. der httpOnly-Cookies
+wie `sessionid`, die ein normales Script **nicht** lesen kann) und lädt sie als
+yt-dlp-`cookies.txt` (Netscape-Format) per `PUT /api/yt-dlp-cookies` in die
+feeds-App. Dort schreibt der `CookieController` sie nach `YT_DLP_COOKIES_FILE`
+(`…/feeds.maltehuebner.dev/var/yt-dlp-cookies.txt`). Danach kann yt-dlp die
+Instagram-Medien herunterladen.
+
+## Installation (entpackt, „Developer Mode")
+1. Chrome → `chrome://extensions/`
+2. Oben rechts **Entwicklermodus** aktivieren
+3. **„Entpackte Erweiterung laden"** → diesen Ordner (`tools/chrome-instagram-cookies/`) wählen
+4. Auf das Extension-Icon → **Einstellungen…** → Endpoint (Default passt) + **API-Token** (der feeds-Bearer-Token, gleich wie im WP-Instagram-Block) eintragen, speichern.
+
+## Benutzung
+1. In **diesem** Chrome bei `instagram.com` mit dem gewünschten Account **einloggen**.
+2. Extension-Icon anklicken → **„Cookies an feeds senden"**.
+3. Erfolgsmeldung „✓ N Cookies gespeichert".
+
+## Hinweise
+- **Sicherheit:** Die Cookies = aktive Instagram-Session. Übertragung nur per HTTPS,
+  der Endpoint ist Bearer-Token-geschützt, die Datei wird mit `0600` geschrieben.
+- **Account:** Möglichst ein separater Instagram-Account, nicht der Hauptaccount.
+- **Ablauf:** Instagram-Cookies laufen nach Tagen/Wochen ab → bei Bedarf einfach
+  erneut „senden" klicken (kein scp, kein Server-Login nötig).
+- Kein Icon mitgeliefert — Chrome nutzt einen Platzhalter; optional eine
+  `icon128.png` ergänzen und im `manifest.json` referenzieren.

--- a/tools/chrome-instagram-cookies/manifest.json
+++ b/tools/chrome-instagram-cookies/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "Instagram Cookies → feeds.maltehuebner.dev",
+  "version": "1.0.0",
+  "description": "Liest die Instagram-Session-Cookies aus dem Browser und lädt sie als yt-dlp cookies.txt direkt in die feeds-App hoch.",
+  "permissions": ["cookies", "storage"],
+  "host_permissions": [
+    "https://*.instagram.com/*",
+    "https://feeds.maltehuebner.dev/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Instagram-Cookies an feeds senden"
+  },
+  "options_page": "options.html"
+}

--- a/tools/chrome-instagram-cookies/options.html
+++ b/tools/chrome-instagram-cookies/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Einstellungen – Instagram Cookies</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 520px; margin: 24px auto; padding: 0 16px; }
+    label { display: block; font-size: 13px; font-weight: 600; margin: 14px 0 4px; }
+    input { width: 100%; box-sizing: border-box; padding: 8px; font-size: 13px; }
+    button { margin-top: 16px; padding: 9px 14px; font-size: 14px; border: 0; border-radius: 6px;
+             background: #005538; color: #fff; cursor: pointer; }
+    #saved { color: #117a3d; font-size: 13px; margin-left: 10px; }
+    p { font-size: 12px; color: #555; }
+  </style>
+</head>
+<body>
+  <h1>Instagram-Cookies → feeds</h1>
+  <p>Token = der feeds-API-Bearer-Token (derselbe wie im WordPress-Instagram-Block).</p>
+  <label for="endpoint">Endpoint-URL</label>
+  <input id="endpoint" type="url" placeholder="https://feeds.maltehuebner.dev/api/yt-dlp-cookies">
+  <label for="token">API-Token (Bearer)</label>
+  <input id="token" type="password" placeholder="64-stelliger Hex-Token">
+  <div><button id="save">Speichern</button><span id="saved"></span></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/tools/chrome-instagram-cookies/options.js
+++ b/tools/chrome-instagram-cookies/options.js
@@ -1,0 +1,19 @@
+const DEFAULT_ENDPOINT = 'https://feeds.maltehuebner.dev/api/yt-dlp-cookies';
+
+const endpointEl = document.getElementById('endpoint');
+const tokenEl = document.getElementById('token');
+const savedEl = document.getElementById('saved');
+
+chrome.storage.sync.get(['endpoint', 'token']).then((cfg) => {
+  endpointEl.value = cfg.endpoint || DEFAULT_ENDPOINT;
+  tokenEl.value = cfg.token || '';
+});
+
+document.getElementById('save').addEventListener('click', async () => {
+  await chrome.storage.sync.set({
+    endpoint: (endpointEl.value || DEFAULT_ENDPOINT).trim(),
+    token: tokenEl.value.trim(),
+  });
+  savedEl.textContent = '✓ gespeichert';
+  setTimeout(() => { savedEl.textContent = ''; }, 2000);
+});

--- a/tools/chrome-instagram-cookies/popup.html
+++ b/tools/chrome-instagram-cookies/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: system-ui, sans-serif; width: 320px; margin: 0; padding: 14px; }
+    h1 { font-size: 15px; margin: 0 0 4px; }
+    p { font-size: 12px; color: #444; margin: 0 0 10px; }
+    button { font-size: 14px; padding: 9px 12px; width: 100%; border: 0; border-radius: 6px;
+             background: #EC008C; color: #fff; cursor: pointer; }
+    button:disabled { opacity: .6; cursor: default; }
+    #status { font-size: 12px; margin-top: 10px; white-space: pre-wrap; word-break: break-word; }
+    .ok { color: #117a3d; } .err { color: #b00020; }
+    a { font-size: 12px; }
+  </style>
+</head>
+<body>
+  <h1>Instagram-Cookies senden</h1>
+  <p>Lädt die aktuellen Instagram-Cookies dieses Browsers als <code>cookies.txt</code> in die feeds-App.</p>
+  <button id="send">Cookies an feeds senden</button>
+  <div id="status"></div>
+  <p style="margin-top:10px"><a href="#" id="opts">Einstellungen (Endpoint &amp; Token)…</a></p>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/tools/chrome-instagram-cookies/popup.js
+++ b/tools/chrome-instagram-cookies/popup.js
@@ -1,0 +1,79 @@
+const DEFAULT_ENDPOINT = 'https://feeds.maltehuebner.dev/api/yt-dlp-cookies';
+
+const statusEl = document.getElementById('status');
+const sendBtn = document.getElementById('send');
+
+document.getElementById('opts').addEventListener('click', (e) => {
+  e.preventDefault();
+  chrome.runtime.openOptionsPage();
+});
+
+function setStatus(msg, cls) {
+  statusEl.textContent = msg;
+  statusEl.className = cls || '';
+}
+
+// Wandelt ein chrome.cookies-Cookie in eine Netscape-cookies.txt-Zeile.
+function toNetscapeLine(c) {
+  const includeSub = c.domain.startsWith('.') ? 'TRUE' : 'FALSE';
+  const secure = c.secure ? 'TRUE' : 'FALSE';
+  // Session-Cookies (ohne expirationDate) -> 0
+  const expiry = c.expirationDate ? Math.floor(c.expirationDate) : 0;
+  const domainField = (c.httpOnly ? '#HttpOnly_' : '') + c.domain;
+  return [domainField, includeSub, c.path || '/', secure, expiry, c.name, c.value].join('\t');
+}
+
+async function buildCookiesTxt() {
+  // Alle instagram.com-Cookies (inkl. Subdomains).
+  const cookies = await chrome.cookies.getAll({ domain: 'instagram.com' });
+  if (!cookies || cookies.length === 0) {
+    throw new Error('Keine Instagram-Cookies gefunden. Bist du in diesem Browser bei instagram.com eingeloggt?');
+  }
+  const hasSession = cookies.some((c) => c.name === 'sessionid' && c.value);
+  const lines = cookies.map(toNetscapeLine);
+  const txt = '# Netscape HTTP Cookie File\n' + lines.join('\n') + '\n';
+  return { txt, count: cookies.length, hasSession };
+}
+
+sendBtn.addEventListener('click', async () => {
+  sendBtn.disabled = true;
+  setStatus('Lese Cookies …');
+  try {
+    const cfg = await chrome.storage.sync.get(['endpoint', 'token']);
+    const endpoint = (cfg.endpoint || DEFAULT_ENDPOINT).trim();
+    const token = (cfg.token || '').trim();
+    if (!token) {
+      setStatus('Kein API-Token gesetzt. Bitte unter „Einstellungen…" hinterlegen.', 'err');
+      return;
+    }
+
+    const { txt, count, hasSession } = await buildCookiesTxt();
+    if (!hasSession) {
+      setStatus('Warnung: kein „sessionid"-Cookie gefunden – evtl. nicht eingeloggt. Sende trotzdem …');
+    } else {
+      setStatus(`Sende ${count} Cookies …`);
+    }
+
+    const res = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': 'Bearer ' + token,
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+      body: txt,
+    });
+
+    const bodyText = await res.text();
+    if (!res.ok) {
+      setStatus(`Fehler ${res.status}: ${bodyText}`, 'err');
+      return;
+    }
+    let info = bodyText;
+    try { const j = JSON.parse(bodyText); info = `${j.cookies} Cookies gespeichert (${j.bytes} Bytes).`; } catch (_) {}
+    setStatus('✓ ' + info, 'ok');
+  } catch (err) {
+    setStatus('Fehler: ' + (err && err.message ? err.message : String(err)), 'err');
+  } finally {
+    sendBtn.disabled = false;
+  }
+});


### PR DESCRIPTION
## Worum geht es
Instagram liefert Medien (Fotos/Videos) inzwischen nur noch an eingeloggte Clients aus. Dadurch scheiterte der Medien-Download (`mediaStatus=failed`, „Instagram sent an empty media response … use --cookies"). Dieser PR macht die Instagram-Medien-Anbindung wieder funktionsfähig — inkl. eines bequemen Wegs, die nötigen Session-Cookies zu pflegen.

## Änderungen (3 Commits)
1. **yt-dlp Cookie-Support + Upload-Endpoint + Chrome-Extension**
   - `YtDlpPhotoDownloader`/`VideoDownloader` rufen yt-dlp mit `--cookies <datei>` auf, wenn `YT_DLP_COOKIES_FILE` gesetzt ist (sonst unverändert; abwärtskompatibel).
   - Neuer Endpoint `PUT /api/yt-dlp-cookies` (Bearer-Token-geschützt, liegt unter `^/api`) schreibt eine hochgeladene Netscape-`cookies.txt` atomar (`0600`) an den konfigurierten Pfad.
   - Chrome-Extension (`tools/chrome-instagram-cookies/`) liest die Instagram-Cookies des Browsers (inkl. httpOnly-`sessionid`) und lädt sie per `PUT` hoch — kein scp/Server-Login mehr nötig.
2. **Fix `app:download-media`**: eigene Option `--profile` kollidierte mit Symfonys globaler `--profile`-Option (`„An option named profile already exists"`) → der Command war in keiner Umgebung lauffähig. Umbenannt in `--profile-id`.
3. **`MediaDownloadService` Foto-Fallback**: bei Post-Typen, die yt-dlp nicht extrahieren kann (`„No video formats found"`), wurde der vorhandene raw-Fallback (`description_html`/`thumbnail`) komplett übersprungen, weil der yt-dlp-Aufruf eine Exception warf. Jetzt wird gefangen und auf die RSS.app-Medien-URLs zurückgefallen → alle Posts bekommen ein Bild statt `failed`.

## Getestet (produktiv verifiziert)
- Endpoint: ohne Token `401`, Müll-Body `400`, gültige cookies.txt `200` (atomar, `0600`).
- Mit hochgeladenen Cookies: alle 6 Items eines Test-Profils `completed`, Medien öffentlich abrufbar, Galerie zeigt die Bilder.
- Container-Lint (`prod`) ok.

## Hinweise zum Betrieb (nicht im Repo)
- yt-dlp muss aktuell sein und für den Cron-User erreichbar (Instagram-Extraktor ändert sich häufig).
- `YT_DLP_COOKIES_FILE` in `.env.local` setzen; die `cookies.txt` liefert die Extension.
- Cookies laufen ab → bei Bedarf erneut per Extension senden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)