### PR TITLE
API: Media-(Re)Download anstoßen + Profil-Flags per PATCH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ php bin/console app:rssapp:sync-feed-ids -v           # show all profiles includ
 
 php bin/console app:download-media                    # download media for all enabled profiles
 php bin/console app:download-media --profile=42       # download for specific profile
+php bin/console app:download-media --pending          # process items queued via the API (mediaStatus=pending)
 php bin/console app:download-media --retry-failed     # retry previously failed downloads
 php bin/console app:download-media --photos-only      # only photos
 php bin/console app:download-media --videos-only      # only videos
@@ -90,10 +91,11 @@ Profiles can opt into automatic photo/video downloads via `savePhotos` and `save
 - **`PhotoDownloader`** — downloads images via HttpClient, stores as `{profileId}/{itemId}/photo_{index}.{ext}` in Flysystem
 - **`YtDlpPhotoDownloader`** — extracts photos (including carousel/album images) via `yt-dlp` in original quality. Used for Instagram, Threads, and Facebook where RSS.app only provides a single thumbnail. Falls back to `PhotoDownloader` if `yt-dlp` is unavailable or returns no results.
 - **`VideoDownloader`** — downloads videos via `yt-dlp` process, stores as `{profileId}/{itemId}/video.{ext}` on disk. Requires `yt-dlp` to be installed; gracefully skips if unavailable.
-- **`MediaDownloadService`** — orchestrates downloads, manages `mediaStatus` lifecycle (`downloading` → `completed`/`failed`). Selects download strategy per network: `yt-dlp` for RSS.app-based networks (Instagram, Threads, Facebook), direct URL download for Bluesky/Mastodon.
-- **`DownloadMediaCommand`** — CLI for bulk downloads with `--profile`, `--retry-failed`, `--photos-only`, `--videos-only` options
+- **`MediaDownloadService`** — orchestrates downloads, manages `mediaStatus` lifecycle (`pending` → `downloading` → `completed`/`failed`). Selects download strategy per network: `yt-dlp` for RSS.app-based networks (Instagram, Threads, Facebook), direct URL download for Bluesky/Mastodon. `queueItem()`/`queueProfile()` mark items `pending` (used by the API trigger); `downloadPendingItems()` processes the queue.
+- **`DownloadMediaCommand`** — CLI for bulk downloads with `--profile-id`, `--pending`, `--retry-failed`, `--photos-only`, `--videos-only` options. `--pending` drains the API-queued items.
 - Auto-download triggers after feed fetch when profile has `savePhotos`/`saveVideos` enabled
 - Manual download via button on item detail page (Stimulus `media_download_controller`)
+- **API-triggered (re)download**: `POST /api/items/{id}/download-media` and `POST /api/profiles/{id}/download-media` (`?force=true` to re-queue all) mark items `pending` via `ItemMediaDownloadProcessor`/`ProfileMediaDownloadProcessor` (client-scoped, 202, require `savePhotos`/`saveVideos`); the actual download runs out-of-band via the `app:download-media --pending` cron. No Messenger — the queue is the `mediaStatus=pending` column.
 - Item entity stores `photoPaths` (JSON array of relative paths), `videoPath` (string), `mediaStatus`, `mediaError`
 
 ### Serializer
@@ -125,6 +127,8 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - All endpoints under `/api/` require Bearer token (except `/api/docs`)
 - Profiles, items: client-scoped via custom State Providers/Processors
 - Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
+- `PATCH /api/profiles/{id}` (merge-patch): partial profile update, e.g. toggle `savePhotos`/`saveVideos`
+- `POST /api/profiles/{id}/download-media` and `POST /api/items/{id}/download-media`: queue media (re)download (202, client-scoped, drained by `app:download-media --pending`)
 - Networks: public read access
 - OpenAPI docs at `/api/docs`
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,19 @@ Download photos and videos for feed items. For Instagram, Threads, and Facebook,
 ```bash
 php bin/console app:download-media                    # all profiles with savePhotos/saveVideos enabled
 php bin/console app:download-media --profile=42       # specific profile
+php bin/console app:download-media --pending          # process items queued via the API (mediaStatus=pending)
 php bin/console app:download-media --retry-failed     # retry previously failed downloads
 php bin/console app:download-media --photos-only      # only photos
 php bin/console app:download-media --videos-only      # only videos (requires yt-dlp)
 ```
 
 Media files are stored in `public/media/{profileId}/{itemId}/`. Profiles must have `savePhotos` and/or `saveVideos` enabled (toggle in Web UI or API). When enabled, media is also downloaded automatically after each feed fetch.
+
+Downloads can also be triggered through the REST API (see below): the trigger endpoints mark items `mediaStatus=pending` and return immediately, and the actual (slow) download is performed out-of-band by `app:download-media --pending`. Schedule that command on a cron, e.g.:
+
+```
+*/5 * * * * cd /path/to/app && php bin/console app:download-media --pending >/dev/null 2>&1
+```
 
 ## Web UI
 
@@ -192,13 +199,18 @@ Tokens are generated via `app:client:create`.
 - `GET /api/profiles/{id}` — Get single profile
 - `POST /api/profiles` — Create or link an existing profile (idempotent)
 - `PUT /api/profiles/{id}` — Update profile
+- `PATCH /api/profiles/{id}` — Partially update a profile, e.g. toggle media storage with `{"savePhotos": true}` (Content-Type: `application/merge-patch+json`)
 - `DELETE /api/profiles/{id}` — Unlink from client; soft-deletes if no other clients remain
+- `POST /api/profiles/{id}/download-media` — Queue a media (re)download for the profile's items (new + previously failed; `?force=true` re-queues all). Returns 202; requires `savePhotos`/`saveVideos` enabled (422 otherwise)
 
 **Items** (client-scoped):
-- `GET /api/items` — List feed items (paginated, 50 per page)
+- `GET /api/items` — List feed items (paginated, 50 per page). Each item exposes `mediaStatus` and absolute `photoUrls`/`videoUrl` for any media stored on the server
 - `GET /api/items/{id}` — Get single item
 - `POST /api/items` — Create item
 - `PUT /api/items/{id}` — Update item
+- `POST /api/items/{id}/download-media` — Queue a media (re)download for this single item. Returns 202; requires the item's profile to have `savePhotos`/`saveVideos` enabled (422 otherwise)
+
+Media downloads triggered via the API are processed asynchronously by the `app:download-media --pending` cron (see Media Download above). Once stored, an item's `photoUrls`/`videoUrl` point to the locally hosted files under `/media/...` instead of the original CDN URLs.
 
 **Timeline**:
 - `GET /api/timeline` — Chronological feed (default: last 24h, max 100 items)

--- a/src/Command/DownloadMediaCommand.php
+++ b/src/Command/DownloadMediaCommand.php
@@ -28,6 +28,7 @@ class DownloadMediaCommand extends Command
             ->setName('app:download-media')
             ->setDescription('Download media (photos/videos) for feed items')
             ->addOption('profile-id', null, InputOption::VALUE_REQUIRED, 'Download media for a specific profile ID')
+            ->addOption('pending', null, InputOption::VALUE_NONE, 'Process items queued for download via the API (mediaStatus=pending)')
             ->addOption('retry-failed', null, InputOption::VALUE_NONE, 'Retry previously failed downloads')
             ->addOption('photos-only', null, InputOption::VALUE_NONE, 'Download only photos')
             ->addOption('videos-only', null, InputOption::VALUE_NONE, 'Download only videos')
@@ -37,6 +38,14 @@ class DownloadMediaCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('pending')) {
+            $count = $this->mediaDownloadService->downloadPendingItems();
+            $io->success(sprintf('Processed %d pending item(s).', $count));
+
+            return Command::SUCCESS;
+        }
+
         $profileId = $input->getOption('profile-id');
         $retryFailed = $input->getOption('retry-failed');
         $photosOnly = $input->getOption('photos-only');

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -16,6 +16,7 @@ use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use App\State\GroupItemsProvider;
+use App\State\ItemMediaDownloadProcessor;
 use App\State\TimelineProvider;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -79,6 +80,18 @@ use Symfony\Component\Serializer\Attribute\Groups;
         ),
         new Post(
             description: 'Creates a new feed item.',
+        ),
+        new Post(
+            uriTemplate: '/items/{id}/download-media',
+            status: 202,
+            read: true,
+            deserialize: false,
+            validate: false,
+            processor: ItemMediaDownloadProcessor::class,
+            normalizationContext: ['groups' => ['item:read']],
+            description: <<<'TEXT'
+            Queues a (re)download of this item's media (photos/videos) onto the server. The item is marked `mediaStatus=pending` and the files are fetched out-of-band by the `app:download-media --pending` cron, so the request returns immediately (202). Once downloaded, `photoUrls`/`videoUrl` point to the locally stored copies. Requires the item's profile to have `savePhotos` and/or `saveVideos` enabled (422 otherwise). Returns 404 if the item is not linked to the authenticated client.
+            TEXT,
         ),
         new Put(
             description: 'Updates an existing feed item.',

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -8,11 +8,13 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use App\State\ClientScopedProfileProcessor;
+use App\State\ProfileMediaDownloadProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -41,6 +43,20 @@ use Symfony\Component\Serializer\Attribute\Groups;
         ),
         new Put(
             description: 'Updates an existing profile.',
+        ),
+        new Patch(
+            description: 'Partially updates a profile linked to the authenticated client — e.g. to toggle media storage with `{"savePhotos": true}` (Content-Type: application/merge-patch+json). Returns 404 if the profile is not linked to the client.',
+        ),
+        new Post(
+            uriTemplate: '/profiles/{id}/download-media',
+            status: 202,
+            read: true,
+            deserialize: false,
+            validate: false,
+            processor: ProfileMediaDownloadProcessor::class,
+            description: <<<'TEXT'
+            Queues a (re)download of media for this profile's items onto the server. By default it queues items that have no media yet and items whose last attempt failed; pass `?force=true` to re-queue every item (e.g. to renew expired media). Items are marked `mediaStatus=pending` and fetched out-of-band by the `app:download-media --pending` cron, so the request returns immediately (202). Requires `savePhotos` and/or `saveVideos` enabled (422 otherwise). Returns 404 if the profile is not linked to the authenticated client.
+            TEXT,
         ),
     ],
     description: 'A social network profile (e.g. a Mastodon account, Instagram page). Profiles are scoped to the authenticated API client.',

--- a/src/MediaDownloader/MediaDownloadService.php
+++ b/src/MediaDownloader/MediaDownloadService.php
@@ -166,4 +166,63 @@ class MediaDownloadService
             $this->downloadMedia($item, $profile->isSavePhotos(), $profile->isSaveVideos());
         }
     }
+
+    /**
+     * Queue a single item for (re)download. The actual download is performed
+     * out-of-band by `app:download-media --pending`, so this returns immediately.
+     */
+    public function queueItem(Item $item): void
+    {
+        $item->setMediaStatus('pending');
+        $item->setMediaError(null);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Queue a profile's items for (re)download. By default this covers items
+     * without media yet (mediaStatus null) and items whose last attempt failed.
+     * With $force = true, every item of the profile is re-queued (e.g. to renew
+     * expired CDN media). Returns the number of items queued.
+     */
+    public function queueProfile(Profile $profile, bool $force = false): int
+    {
+        $items = $force
+            ? $this->itemRepository->findBy(['profile' => $profile])
+            : $this->itemRepository->findNewOrFailedForProfile($profile);
+
+        foreach ($items as $item) {
+            $item->setMediaStatus('pending');
+            $item->setMediaError(null);
+        }
+
+        $this->entityManager->flush();
+
+        return count($items);
+    }
+
+    /**
+     * Download all items currently queued (mediaStatus = 'pending'), respecting
+     * each item's profile savePhotos/saveVideos flags. Returns the number of
+     * items processed.
+     */
+    public function downloadPendingItems(?int $limit = null): int
+    {
+        $items = $this->itemRepository->findBy(
+            ['mediaStatus' => 'pending'],
+            ['id' => 'ASC'],
+            $limit,
+        );
+
+        foreach ($items as $item) {
+            $profile = $item->getProfile();
+
+            if (!$profile) {
+                continue;
+            }
+
+            $this->downloadMedia($item, $profile->isSavePhotos(), $profile->isSaveVideos());
+        }
+
+        return count($items);
+    }
 }

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -25,6 +25,23 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * Items of a profile that have no media yet (mediaStatus null) or whose last
+     * download attempt failed. Used to (re)queue media downloads.
+     *
+     * @return list<Item>
+     */
+    public function findNewOrFailedForProfile(Profile $profile): array
+    {
+        return $this->createQueryBuilder('i')
+            ->andWhere('i.profile = :profile')
+            ->andWhere('i.mediaStatus IS NULL OR i.mediaStatus = :failed')
+            ->setParameter('profile', $profile)
+            ->setParameter('failed', 'failed')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Paginated items across all profiles in a group, excluding hidden /
      * soft-deleted items and items belonging to soft-deleted profiles.
      *

--- a/src/State/ItemMediaDownloadProcessor.php
+++ b/src/State/ItemMediaDownloadProcessor.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Item;
+use App\MediaDownloader\MediaDownloadService;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Queues a (re)download of a single item's media. The item is loaded by the
+ * default item provider, so the client-scoping Doctrine extension already
+ * enforces 404 for items the client may not see.
+ *
+ * @implements ProcessorInterface<Item, Item>
+ */
+class ItemMediaDownloadProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly MediaDownloadService $mediaDownloadService,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Item
+    {
+        if (!$this->security->getUser() instanceof Client) {
+            throw new BadRequestHttpException('Authentication required.');
+        }
+
+        if (!$data instanceof Item) {
+            throw new NotFoundHttpException('Item not found.');
+        }
+
+        $profile = $data->getProfile();
+
+        if (!$profile || (!$profile->isSavePhotos() && !$profile->isSaveVideos())) {
+            throw new UnprocessableEntityHttpException(
+                'Enable savePhotos and/or saveVideos on the item\'s profile before triggering a media download.',
+            );
+        }
+
+        $this->mediaDownloadService->queueItem($data);
+
+        return $data;
+    }
+}

--- a/src/State/ProfileMediaDownloadProcessor.php
+++ b/src/State/ProfileMediaDownloadProcessor.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Profile;
+use App\MediaDownloader\MediaDownloadService;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Queues a (re)download of media for every (new or previously failed) item of a
+ * profile. Pass ?force=true to re-queue all items, e.g. to renew expired media.
+ * The profile is loaded by the default provider, so client-scoping enforces 404
+ * for profiles the client is not linked to.
+ *
+ * @implements ProcessorInterface<Profile, Profile>
+ */
+class ProfileMediaDownloadProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly MediaDownloadService $mediaDownloadService,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Profile
+    {
+        if (!$this->security->getUser() instanceof Client) {
+            throw new BadRequestHttpException('Authentication required.');
+        }
+
+        if (!$data instanceof Profile) {
+            throw new NotFoundHttpException('Profile not found.');
+        }
+
+        if (!$data->isSavePhotos() && !$data->isSaveVideos()) {
+            throw new UnprocessableEntityHttpException(
+                'Enable savePhotos and/or saveVideos on the profile before triggering a media download.',
+            );
+        }
+
+        $request = $context['request'] ?? null;
+        $force = $request instanceof Request
+            && filter_var($request->query->get('force'), FILTER_VALIDATE_BOOL);
+
+        $this->mediaDownloadService->queueProfile($data, $force);
+
+        return $data;
+    }
+}

--- a/tests/Functional/Api/ItemApiTest.php
+++ b/tests/Functional/Api/ItemApiTest.php
@@ -215,4 +215,67 @@ class ItemApiTest extends AbstractApiTestCase
         $this->assertNotContains('Shared item 3', $texts);
         $this->assertNotContains('OnlyA item 2', $texts);
     }
+
+    private function firstItemIdForProfile(int $profileId): int
+    {
+        $data = $this->requestAsClientA('GET', '/api/items?profile=/api/profiles/' . $profileId)->toArray();
+        $items = $data['hydra:member'] ?? $data['member'] ?? [];
+        $this->assertNotEmpty($items, 'Expected at least one item for profile ' . $profileId);
+
+        return $items[0]['id'];
+    }
+
+    private function enableSavePhotos(int $profileId): void
+    {
+        $this->requestWithToken('PATCH', '/api/profiles/' . $profileId, self::TOKEN_A, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['savePhotos' => true]),
+        ]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testDownloadMediaTriggerQueuesItem(): void
+    {
+        $this->enableSavePhotos(90001);
+        $itemId = $this->firstItemIdForProfile(90001);
+
+        $this->requestAsClientA('POST', '/api/items/' . $itemId . '/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(202);
+
+        $detail = $this->requestAsClientA('GET', '/api/items/' . $itemId)->toArray();
+        $this->assertSame('pending', $detail['mediaStatus']);
+    }
+
+    public function testDownloadMediaTriggerRequiresProfileFlag(): void
+    {
+        // profileOnlyA (90002) has savePhotos/saveVideos disabled by default
+        $itemId = $this->firstItemIdForProfile(90002);
+
+        $this->requestAsClientA('POST', '/api/items/' . $itemId . '/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDownloadMediaTriggerNotOwnedReturns404(): void
+    {
+        $dataB = $this->requestAsClientB('GET', '/api/items')->toArray();
+        $itemsB = $dataB['hydra:member'] ?? $dataB['member'] ?? [];
+
+        $onlyBItemId = null;
+        foreach ($itemsB as $item) {
+            if (str_contains($item['text'], 'OnlyB')) {
+                $onlyBItemId = $item['id'];
+                break;
+            }
+        }
+        $this->assertNotNull($onlyBItemId);
+
+        $this->requestAsClientA('POST', '/api/items/' . $onlyBItemId . '/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
 }

--- a/tests/Functional/Api/ProfileApiTest.php
+++ b/tests/Functional/Api/ProfileApiTest.php
@@ -247,6 +247,71 @@ class ProfileApiTest extends AbstractApiTestCase
         }
     }
 
+    public function testPatchTogglesMediaFlags(): void
+    {
+        $response = $this->requestWithToken('PATCH', '/api/profiles/90001', self::TOKEN_A, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['savePhotos' => true, 'saveVideos' => true]),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertTrue($data['savePhotos']);
+        $this->assertTrue($data['saveVideos']);
+    }
+
+    public function testPatchProfileNotLinkedReturns404(): void
+    {
+        // profileOnlyA (90002) is linked to client A, not client B
+        $this->requestWithToken('PATCH', '/api/profiles/90002', self::TOKEN_B, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['savePhotos' => true]),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testDownloadMediaTriggerRequiresFlag(): void
+    {
+        // profileOnlyA (90002) belongs to client A but has no media flags set
+        $this->requestAsClientA('POST', '/api/profiles/90002/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDownloadMediaTriggerQueuesProfileItems(): void
+    {
+        $this->requestWithToken('PATCH', '/api/profiles/90002', self::TOKEN_A, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['savePhotos' => true]),
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->requestAsClientA('POST', '/api/profiles/90002/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(202);
+
+        $data = $this->requestAsClientA('GET', '/api/items?profile=/api/profiles/90002')->toArray();
+        $items = $data['hydra:member'] ?? $data['member'] ?? [];
+        $this->assertNotEmpty($items);
+        foreach ($items as $item) {
+            $this->assertSame('pending', $item['mediaStatus']);
+        }
+    }
+
+    public function testDownloadMediaTriggerProfileNotLinkedReturns404(): void
+    {
+        // profileOnlyB (90003) is not linked to client A
+        $this->requestAsClientA('POST', '/api/profiles/90003/download-media', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     private function getMastodonNetworkIri(): string
     {
         return $this->getNetworkIri('mastodon');

--- a/tests/MediaDownloader/MediaDownloadServiceTest.php
+++ b/tests/MediaDownloader/MediaDownloadServiceTest.php
@@ -312,4 +312,91 @@ class MediaDownloadServiceTest extends TestCase
         $this->assertStringContainsString('Photo:', $item->getMediaError());
         $this->assertStringContainsString('Video:', $item->getMediaError());
     }
+
+    public function testQueueItemSetsPendingAndClearsError(): void
+    {
+        $item = $this->createItem();
+        $item->setMediaStatus('failed');
+        $item->setMediaError('boom');
+
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->queueItem($item);
+
+        $this->assertSame('pending', $item->getMediaStatus());
+        $this->assertNull($item->getMediaError());
+    }
+
+    public function testQueueProfileQueuesNewAndFailedItems(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+
+        $a = $this->createItem();
+        $b = $this->createItem();
+
+        $this->itemRepository->expects($this->once())
+            ->method('findNewOrFailedForProfile')
+            ->with($profile)
+            ->willReturn([$a, $b]);
+        $this->itemRepository->expects($this->never())->method('findBy');
+        $this->em->expects($this->once())->method('flush');
+
+        $count = $this->service->queueProfile($profile);
+
+        $this->assertSame(2, $count);
+        $this->assertSame('pending', $a->getMediaStatus());
+        $this->assertSame('pending', $b->getMediaStatus());
+    }
+
+    public function testQueueProfileWithForceQueuesAllItems(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+
+        $a = $this->createItem();
+
+        $this->itemRepository->expects($this->once())
+            ->method('findBy')
+            ->with(['profile' => $profile])
+            ->willReturn([$a]);
+        $this->itemRepository->expects($this->never())->method('findNewOrFailedForProfile');
+
+        $count = $this->service->queueProfile($profile, force: true);
+
+        $this->assertSame(1, $count);
+        $this->assertSame('pending', $a->getMediaStatus());
+    }
+
+    public function testDownloadPendingItemsRespectsProfileFlags(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+        $profile->setSavePhotos(true);
+        $profile->setSaveVideos(false);
+
+        $item = $this->createItem();
+        $item->setProfile($profile);
+        $item->setMediaStatus('pending');
+
+        $this->itemRepository->expects($this->once())
+            ->method('findBy')
+            ->with(['mediaStatus' => 'pending'], ['id' => 'ASC'], null)
+            ->willReturn([$item]);
+
+        // savePhotos=true → photos attempted (none found here); saveVideos=false → video skipped
+        $this->extractor->method('extractPhotoUrls')->willReturn([]);
+        $this->extractor->expects($this->never())->method('extractVideoUrl');
+
+        $count = $this->service->downloadPendingItems();
+
+        $this->assertSame(1, $count);
+        $this->assertSame('completed', $item->getMediaStatus());
+    }
 }


### PR DESCRIPTION
## Was

Macht die bereits vorhandene Media-Speicherung (`savePhotos`/`saveVideos`, `MediaDownloadService`, yt-dlp, Flysystem `public/media/`) über die **REST-API** steuerbar.

### Neue Endpunkte (client-scoped)
- `POST /api/items/{id}/download-media` — Einzel-Item für (Re-)Download einreihen.
- `POST /api/profiles/{id}/download-media` — neue + zuvor fehlgeschlagene Items des Profils einreihen; `?force=true` reiht **alle** neu ein (z. B. abgelaufene CDN-Medien erneuern).
- `PATCH /api/profiles/{id}` — partielles Update (merge-patch), v. a. zum Setzen von `savePhotos`/`saveVideos`.

Beide Trigger antworten **202**, markieren Items als `mediaStatus=pending`, verlangen mindestens ein aktives Media-Flag (sonst **422**) und liefern **404** für nicht verknüpfte Ressourcen (Client-Scoping über die bestehenden Doctrine-Extensions).

### Ausführung (Queue + Cron)
Der eigentliche Download läuft out-of-band über den neuen Befehl **`app:download-media --pending`** (für Cron). Kein Messenger — die Queue ist die Spalte `mediaStatus=pending`. Lokal gespeicherte Medien liefert die API danach automatisch als absolute `/media/…`-URLs (vorhandener `ItemMediaUrlNormalizer`).

## Tests
- Service: `queueItem`/`queueProfile` (neu+failed bzw. force) / `downloadPendingItems`.
- Funktional: Item-/Profile-Trigger (202/422/404), Profile-`PATCH` (Toggle + 404).
- Gesamte Suite grün: **231 Tests, 624 Assertions, 0 Failures/0 Errors**.

## Doku
README + CLAUDE.md aktualisiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)