### PR TITLE
Gruppen-API dokumentieren + PATCH/Scoping-Tests (PUT-Bug entdeckt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 - **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`. Supports soft-delete, hide toggles, and media downloads.
 - **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
 - **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
+- **Group** — Named bundle of a client's profiles (table `profile_group`, unique `(client_id, name)`): `id`, `name`, `description`, `color`, `client` (ManyToOne, NOT NULL — a group belongs to exactly one client, unlike shared profiles), `profiles` (ManyToMany via `profile_group_profile`), `createdAt`. Serialization groups `group:read` (incl. `profileCount`), `group:detail` (embeds `profiles`), `group:write`. Used to read a combined feed per group.
 
 ### Media Download System
 
@@ -125,6 +126,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - All endpoints under `/api/` require Bearer token (except `/api/docs`)
 - Profiles, items: client-scoped via custom State Providers/Processors
 - Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
+- Groups: full CRUD `GET/POST/PUT/PATCH/DELETE /api/groups[/{id}]` (writes via `ClientScopedGroupProcessor`, GET scoped by `ClientScopedGroupExtension`). Membership convenience routes `POST /api/groups/{id}/profiles` + `DELETE /api/groups/{id}/profiles/{profileId}` in `GroupMembershipController`. Combined feed `GET /api/groups/{groupId}/items` via `GroupItemsProvider` (filters since/until/network, excludes hidden/deleted), plus RSS at `GET /api/feeds/groups/{id}.rss`. Referenced profiles must belong to the client (400); foreign groups 404.
 - Networks: public read access
 - OpenAPI docs at `/api/docs`
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ Tokens are generated via `app:client:create`.
 - `POST /api/items` — Create item
 - `PUT /api/items/{id}` — Update item
 
+**Groups** (client-scoped): bundle a client's profiles and read their combined feed. A group belongs to exactly one client (it is *not* shared across clients like profiles are).
+- `GET /api/groups` — List the client's groups (slim: includes `profileCount`, not the embedded profiles)
+- `GET /api/groups/{id}` — Get a single group with its embedded `profiles`
+- `POST /api/groups` — Create a group. Body: `{"name": "My Mix", "color": "#16a34a", "description": "...", "profiles": ["/api/profiles/42"]}` (all but `name` optional)
+- `PATCH /api/groups/{id}` — Update a group (e.g. `{"name": "Renamed", "profiles": ["/api/profiles/42"]}`, Content-Type `application/merge-patch+json`). **Use PATCH for updates** — `PUT` currently does not update in place (see note below).
+- `DELETE /api/groups/{id}` — Delete the group (the profiles themselves stay untouched)
+- `POST /api/groups/{id}/profiles` — Add profiles (idempotent). Body: `{"profileIds": [42, 43]}` *or* `{"profiles": ["/api/profiles/42"]}`
+- `DELETE /api/groups/{id}/profiles/{profileId}` — Remove a single profile from the group
+- `GET /api/groups/{groupId}/items` — Combined feed of all member profiles, `dateTime` DESC, paginated (50/page, max 200). Filters: `since`, `until` (ISO 8601), `network` (identifier). Hidden / soft-deleted items and items of soft-deleted profiles are excluded.
+- `GET /api/feeds/groups/{id}.rss` — The same feed as RSS 2.0
+
+  Every profile referenced when creating/updating a group or adding members must already be linked to the authenticated client (otherwise `400`); foreign or unknown groups return `404`.
+
+  > **Known issue:** `PUT /api/groups/{id}` currently creates a *new* group instead of updating the existing one (the processor persists the deserialized object without the existing id). Use `PATCH` to update a group until this is fixed.
+
 **Timeline**:
 - `GET /api/timeline` — Chronological feed (default: last 24h, max 100 items)
   - Query params: `limit`, `since`, `until`, `network`

--- a/tests/Functional/Api/GroupApiTest.php
+++ b/tests/Functional/Api/GroupApiTest.php
@@ -167,6 +167,37 @@ class GroupApiTest extends AbstractApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testPutForeignGroupReturns404(): void
+    {
+        $groupId = $this->createGroup('Foreign Put', [], 'B');
+
+        $this->requestAsClientA('PUT', '/api/groups/' . $groupId, [
+            'json' => ['name' => 'Hijacked', 'profiles' => []],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testPatchUpdatesNameAndKeepsProfiles(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Before Patch', [$sharedIri]);
+
+        $response = $this->requestWithToken('PATCH', '/api/groups/' . $groupId, self::TOKEN_A, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['name' => 'After Patch', 'color' => '#00aa00']),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertSame('After Patch', $data['name']);
+        $this->assertSame('#00aa00', $data['color']);
+
+        // Partielles Update lässt die Mitgliedschaft unberührt
+        $check = $this->requestAsClientA('GET', '/api/groups/' . $groupId)->toArray();
+        $this->assertCount(1, $check['profiles']);
+    }
+
     public function testGroupItemsEndpoint(): void
     {
         $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');


### PR DESCRIPTION
## Was

Die Gruppen-API (`/api/groups`, Mitgliedschaft, `/api/groups/{id}/items`, RSS) ist seit „Groups PR A/C" auf `main`, war aber in **README/CLAUDE.md gar nicht dokumentiert**. Dieser PR holt die Doku nach und schließt eine Test-Lücke.

### Doku
- README „REST API": neue **Groups**-Sektion (CRUD, Membership-Routen, `/items`, RSS, 400/404-Regeln).
- CLAUDE.md: `Group`-Entity im Entity-Verzeichnis + Gruppen-Endpunkte im REST-Abschnitt.

### Tests
- `testPatchUpdatesNameAndKeepsProfiles` — merge-patch aktualisiert Name/Farbe in-place, Mitgliedschaft bleibt.
- `testPutForeignGroupReturns404` — PUT ist client-scoped.

## ⚠️ Dabei entdeckter Bug (nicht in diesem PR gefixt)

`PUT /api/groups/{id}` **aktualisiert nicht in-place, sondern legt eine neue Gruppe an**. Belegt: nach `POST` (id=1 „Before Put") + `PUT /api/groups/1` {name:„After Put"} existieren **beide** Gruppen (`1:Before Put`, `2:After Put`). Ursache: `ClientScopedGroupProcessor::handleUpsert()` `persist()`et das deserialisierte Objekt; bei PUT trägt es keine id → INSERT statt UPDATE. PATCH liest/füllt die bestehende Entität und ist korrekt.

Daher: kein PUT-Replace-Test (würde kaputtes Verhalten zementieren); README enthält einen „Known issue"-Hinweis und empfiehlt PATCH. **Soll ich den PUT-Bug in einem separaten PR fixen?**

## Tests
Volle Suite lokal grün: **221 Tests, 592 Assertions, 0 Failures/0 Errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)