### PR TITLE
Fix: PUT /api/groups/{id} aktualisiert in-place statt Duplikat

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ Tokens are generated via `app:client:create`.
 - `GET /api/groups` — List the client's groups (slim: includes `profileCount`, not the embedded profiles)
 - `GET /api/groups/{id}` — Get a single group with its embedded `profiles`
 - `POST /api/groups` — Create a group. Body: `{"name": "My Mix", "color": "#16a34a", "description": "...", "profiles": ["/api/profiles/42"]}` (all but `name` optional)
-- `PATCH /api/groups/{id}` — Update a group (e.g. `{"name": "Renamed", "profiles": ["/api/profiles/42"]}`, Content-Type `application/merge-patch+json`). **Use PATCH for updates** — `PUT` currently does not update in place (see note below).
+- `PUT /api/groups/{id}` — Replace a group in place (full replacement, including the `profiles` list)
+- `PATCH /api/groups/{id}` — Partial update (e.g. `{"name": "Renamed"}`, Content-Type `application/merge-patch+json`)
 - `DELETE /api/groups/{id}` — Delete the group (the profiles themselves stay untouched)
 - `POST /api/groups/{id}/profiles` — Add profiles (idempotent). Body: `{"profileIds": [42, 43]}` *or* `{"profiles": ["/api/profiles/42"]}`
 - `DELETE /api/groups/{id}/profiles/{profileId}` — Remove a single profile from the group
@@ -212,8 +213,6 @@ Tokens are generated via `app:client:create`.
 - `GET /api/feeds/groups/{id}.rss` — The same feed as RSS 2.0
 
   Every profile referenced when creating/updating a group or adding members must already be linked to the authenticated client (otherwise `400`); foreign or unknown groups return `404`.
-
-  > **Known issue:** `PUT /api/groups/{id}` currently creates a *new* group instead of updating the existing one (the processor persists the deserialized object without the existing id). Use `PATCH` to update a group until this is fixed.
 
 **Timeline**:
 - `GET /api/timeline` — Chronological feed (default: last 24h, max 100 items)

--- a/src/State/ClientScopedGroupProcessor.php
+++ b/src/State/ClientScopedGroupProcessor.php
@@ -34,11 +34,21 @@ class ClientScopedGroupProcessor implements ProcessorInterface
             return $this->handleDelete($client, (int) $uriVariables['id']);
         }
 
-        return $this->handleUpsert($client, $data);
+        return $this->handleUpsert($client, $data, $uriVariables);
     }
 
-    private function handleUpsert(Client $client, Group $group): Group
+    /** @param array<string, mixed> $uriVariables */
+    private function handleUpsert(Client $client, Group $group, array $uriVariables): Group
     {
+        // PUT hands us a freshly deserialized object without an id, so a blind
+        // persist() would INSERT a duplicate instead of updating. When the URI
+        // carries an id (PUT/PATCH), rebind the incoming data onto the managed
+        // entity so we UPDATE in place. PATCH already arrives as the managed
+        // entity (id set) and is left untouched.
+        if ($group->getId() === null && isset($uriVariables['id'])) {
+            $group = $this->applyOntoExisting($client, (int) $uriVariables['id'], $group);
+        }
+
         $existingClient = $group->getClient();
 
         if ($existingClient !== null && $existingClient->getId() !== $client->getId()) {
@@ -57,6 +67,32 @@ class ClientScopedGroupProcessor implements ProcessorInterface
         $this->em->flush();
 
         return $group;
+    }
+
+    /**
+     * Copy the deserialized group's writable fields onto the existing managed
+     * entity (full replacement, PUT semantics) so the operation updates in place.
+     */
+    private function applyOntoExisting(Client $client, int $id, Group $incoming): Group
+    {
+        $existing = $this->em->getRepository(Group::class)->find($id);
+
+        if ($existing === null || $existing->getClient()?->getId() !== $client->getId()) {
+            throw new NotFoundHttpException('Group not found.');
+        }
+
+        $existing->setName($incoming->getName());
+        $existing->setDescription($incoming->getDescription());
+        $existing->setColor($incoming->getColor());
+
+        foreach ($existing->getProfiles()->toArray() as $profile) {
+            $existing->removeProfile($profile);
+        }
+        foreach ($incoming->getProfiles() as $profile) {
+            $existing->addProfile($profile);
+        }
+
+        return $existing;
     }
 
     private function handleDelete(Client $client, int $groupId): null

--- a/tests/Functional/Api/GroupApiTest.php
+++ b/tests/Functional/Api/GroupApiTest.php
@@ -167,6 +167,30 @@ class GroupApiTest extends AbstractApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testPutReplacesGroupNameAndProfiles(): void
+    {
+        $sharedIri = $this->ownedProfileIri('https://mastodon.social/@shared');
+        $groupId = $this->createGroup('Before Put', [$sharedIri]);
+
+        $this->requestAsClientA('PUT', '/api/groups/' . $groupId, [
+            'json' => [
+                'name' => 'After Put',
+                'color' => '#123456',
+                'profiles' => [],
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Update happens in place (no duplicate group is created)
+        $collection = $this->extractMembers($this->requestAsClientA('GET', '/api/groups'));
+        $this->assertCount(1, $collection);
+
+        $check = $this->requestAsClientA('GET', '/api/groups/' . $groupId)->toArray();
+        $this->assertSame('After Put', $check['name']);
+        $this->assertSame('#123456', $check['color']);
+        $this->assertSame([], $check['profiles']);
+    }
+
     public function testPutForeignGroupReturns404(): void
     {
         $groupId = $this->createGroup('Foreign Put', [], 'B');


### PR DESCRIPTION
## Bug

`PUT /api/groups/{id}` legte eine **neue** Gruppe an, statt die bestehende zu aktualisieren. Nachweis: nach `POST` (id=1 „Before Put") + `PUT /api/groups/1` {name:„After Put"} existierten **beide** Gruppen (`1:Before Put`, `2:After Put`).

Ursache: API Platform reicht dem `ClientScopedGroupProcessor` bei PUT ein frisch deserialisiertes `Group`-Objekt **ohne id**; das blinde `persist()` führte daher ein INSERT statt UPDATE aus.

## Fix

`ClientScopedGroupProcessor::handleUpsert()` bindet die eingehenden Daten auf die **verwaltete** Entität um, wenn die URI eine id trägt und das deserialisierte Objekt keine hat (der PUT-Fall): `name`/`description`/`color` werden kopiert, die Profil-Mitgliedschaft vollständig ersetzt (PUT-Semantik). PATCH kommt bereits als verwaltete Entität (id gesetzt) und bleibt unberührt.

## Tests

- Neu: `testPutReplacesGroupNameAndProfiles` — prüft in-place-Update **und** dass kein Duplikat entsteht (Collection-Count bleibt 1).
- Volle Suite grün: **222 Tests, 598 Assertions, 0 Failures/0 Errors**.

## Hinweis zur Reihenfolge

Gestapelt auf `feature/group-api-docs` (PR #99) — Basis ist dieser Branch. Nach Merge von #99 retargetet GitHub diesen PR automatisch auf `main`. Reihenfolge: **#99 zuerst, dann dieser PR.** Dieser PR entfernt auch den „Known issue"-Hinweis aus der in #99 ergänzten README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)