### PR TITLE
Change profile identifier with RSS.app feed re-linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,15 @@ Profiles can opt into automatic photo/video downloads via `savePhotos` and `save
 - **API-triggered (re)download**: `POST /api/items/{id}/download-media` and `POST /api/profiles/{id}/download-media` (`?force=true` to re-queue all) mark items `pending` via `ItemMediaDownloadProcessor`/`ProfileMediaDownloadProcessor` (client-scoped, 202, require `savePhotos`/`saveVideos`); the actual download runs out-of-band via the `app:download-media --pending` cron. No Messenger — the queue is the `mediaStatus=pending` column.
 - Item entity stores `photoPaths` (JSON array of relative paths), `videoPath` (string), `mediaStatus`, `mediaError`
 
+### Changing a Profile Identifier
+
+When an account is renamed (e.g. a new Instagram username), the profile's `identifier` can be changed while preserving the profile row and all its items. RSS.app cannot re-point an existing feed to a new source URL (PATCH only edits title/description/icon), so for RSS.app-based networks the old feed is deleted and a fresh one created (or an already-existing feed for the new URL is adopted), then its current items are imported.
+
+- **`IdentifierChanger`** (`src/Profile/`) — shared orchestration: validates the new identifier (non-empty, matches `Network.profileUrlPattern`, not already used by another profile in the same network — throws `IdentifierChangeException` otherwise), sets it, calls `FeedRegistrar::relinkRssAppFeed()`, flushes. Returns an `IdentifierChangeResult` describing the outcome.
+- **`FeedRegistrar::relinkRssAppFeed(Profile)`** — the RSS.app side: deletes the old feed (best-effort), creates/links the new feed for the (already updated) identifier, imports its items. Non-RSS networks return `identifierOnly()`; a failed feed re-creation returns `relinkFailed()` (identifier stays changed, `rssAppFeedId` cleared — re-register manually).
+- **Web UI**: "Identifier ändern" card on the profile show page → `POST /profiles/{id}/change-identifier` (`ProfileController::changeIdentifier`).
+- **API**: `POST /api/profiles/{id}/change-identifier` (body `{"identifier": "…"}`) via `ProfileChangeIdentifierProcessor` (200, client-scoped; 422 on invalid/duplicate identifier). The generic `PATCH`/`PUT` still change `identifier` as a plain field **without** RSS.app re-linking — use the dedicated action to re-link.
+
 ### Serializer
 
 Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `NullableDateTimeNormalizer` to handle null values and Unix timestamps from the API. CamelCase-to-snake_case name conversion. `SKIP_NULL_VALUES` on serialization.
@@ -129,6 +138,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - Profiles, items: client-scoped via custom State Providers/Processors
 - Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
 - `PATCH /api/profiles/{id}` (merge-patch): partial profile update, e.g. toggle `savePhotos`/`saveVideos`
+- `POST /api/profiles/{id}/change-identifier`: change a profile's identifier (body `{"identifier": "…"}`), re-linking the RSS.app feed for RSS.app networks (200, client-scoped, `ProfileChangeIdentifierProcessor`). See "Changing a Profile Identifier" below
 - `POST /api/profiles/{id}/download-media` and `POST /api/items/{id}/download-media`: queue media (re)download (202, client-scoped, drained by `app:download-media --pending`)
 - Groups: full CRUD `GET/POST/PUT/PATCH/DELETE /api/groups[/{id}]` (writes via `ClientScopedGroupProcessor`, GET scoped by `ClientScopedGroupExtension`). Membership convenience routes `POST /api/groups/{id}/profiles` + `DELETE /api/groups/{id}/profiles/{profileId}` in `GroupMembershipController`. Combined feed `GET /api/groups/{groupId}/items` via `GroupItemsProvider` (filters since/until/network, excludes hidden/deleted), plus RSS at `GET /api/feeds/groups/{id}.rss`. Referenced profiles must belong to the client (400); foreign groups 404.
 - Networks: public read access

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ php bin/console app:rssapp:sync-feed-ids --network=instagram_profile
 php bin/console app:rssapp:sync-feed-ids --force      # re-check existing feed IDs
 ```
 
+**Changing an identifier:** when an account is renamed (e.g. a new Instagram username), change the profile's identifier via the "Identifier ändern" action on the profile page in the Web UI or the `POST /api/profiles/{id}/change-identifier` endpoint. RSS.app cannot re-point an existing feed to a new source URL, so the old feed is deleted and a new one is created for the new identifier and its current items imported. The profile row and all previously imported items are kept, so no history is lost.
+
 ### Media download
 
 Download photos and videos for feed items. For Instagram, Threads, and Facebook, photos (including carousel/album images) are extracted in original quality via `yt-dlp`, with a fallback to the RSS.app thumbnail. Bluesky and Mastodon photos are downloaded directly from their API response (supports multiple photos per post natively). Videos are downloaded via `yt-dlp` from the item's permalink URL. For Mastodon and Bluesky, yt-dlp is only invoked when the post's raw data actually contains a video — posts without a video are skipped instead of being recorded as failed downloads.
@@ -200,6 +202,7 @@ Tokens are generated via `app:client:create`.
 - `POST /api/profiles` — Create or link an existing profile (idempotent)
 - `PUT /api/profiles/{id}` — Update profile
 - `PATCH /api/profiles/{id}` — Partially update a profile, e.g. toggle media storage with `{"savePhotos": true}` (Content-Type: `application/merge-patch+json`)
+- `POST /api/profiles/{id}/change-identifier` — Change the profile's identifier, e.g. after an account is renamed, with `{"identifier": "https://…"}`. For RSS.app-based networks the RSS.app feed is re-linked (old feed deleted, new one created and its items imported); the profile and all previously imported items are preserved. Returns 422 if the identifier is invalid for the network or already used by another profile in the same network
 - `DELETE /api/profiles/{id}` — Unlink from client; soft-deletes if no other clients remain
 - `POST /api/profiles/{id}/download-media` — Queue a media (re)download for the profile's items (new + previously failed; `?force=true` re-queues all). Returns 202; requires `savePhotos`/`saveVideos` enabled (422 otherwise)
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -11,6 +11,9 @@ use App\FeedFetcher\FetchInfo;
 use App\FeedFetcher\FetchResult;
 use App\FeedItemPersister\FeedItemPersisterInterface;
 use App\Model\Profile as ModelProfile;
+use App\Profile\IdentifierChangeException;
+use App\Profile\IdentifierChangeResult;
+use App\Profile\IdentifierChanger;
 use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
@@ -247,6 +250,53 @@ class ProfileController extends AbstractController
             'profile' => $profile,
             'form' => $form,
         ]);
+    }
+
+    #[Route('/{id}/change-identifier', name: 'app_profile_change_identifier', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function changeIdentifier(Request $request, Profile $profile, IdentifierChanger $identifierChanger): Response
+    {
+        if (!$this->isCsrfTokenValid('change-identifier-' . $profile->getId(), $request->request->getString('_token'))) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        try {
+            $result = $identifierChanger->change($profile, $request->request->getString('identifier'));
+
+            $this->addFlash(
+                $result->relinkError !== null ? 'warning' : 'success',
+                $this->buildIdentifierChangeFlashMessage($result),
+            );
+        } catch (IdentifierChangeException $e) {
+            $this->addFlash('danger', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
+    private function buildIdentifierChangeFlashMessage(IdentifierChangeResult $result): string
+    {
+        if (!$result->changed) {
+            return 'Identifier unverändert.';
+        }
+
+        if (!$result->rssAppApplicable) {
+            return 'Identifier wurde aktualisiert.';
+        }
+
+        if ($result->relinkError !== null) {
+            return sprintf(
+                'Identifier wurde aktualisiert, aber die RSS.app-Neuverknüpfung ist fehlgeschlagen: %s. Bitte manuell bei RSS.app registrieren.',
+                $result->relinkError,
+            );
+        }
+
+        return sprintf(
+            'Identifier wurde aktualisiert und %s RSS.app-Feed %s (%d Item%s importiert).',
+            $result->linkedToExistingFeed ? 'mit einem bestehenden' : 'ein neuer',
+            $result->linkedToExistingFeed ? 'verknüpft' : 'angelegt',
+            $result->importedItems,
+            $result->importedItems === 1 ? '' : 's',
+        );
     }
 
     #[Route('/{id}/delete', name: 'app_profile_delete', requirements: ['id' => '\d+'], methods: ['POST'])]

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -14,6 +14,7 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use App\State\ClientScopedProfileProcessor;
+use App\State\ProfileChangeIdentifierProcessor;
 use App\State\ProfileMediaDownloadProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -56,6 +57,18 @@ use Symfony\Component\Serializer\Attribute\Groups;
             processor: ProfileMediaDownloadProcessor::class,
             description: <<<'TEXT'
             Queues a (re)download of media for this profile's items onto the server. By default it queues items that have no media yet and items whose last attempt failed; pass `?force=true` to re-queue every item (e.g. to renew expired media). Items are marked `mediaStatus=pending` and fetched out-of-band by the `app:download-media --pending` cron, so the request returns immediately (202). Requires `savePhotos` and/or `saveVideos` enabled (422 otherwise). Returns 404 if the profile is not linked to the authenticated client.
+            TEXT,
+        ),
+        new Post(
+            uriTemplate: '/profiles/{id}/change-identifier',
+            status: 200,
+            read: true,
+            deserialize: false,
+            validate: false,
+            processor: ProfileChangeIdentifierProcessor::class,
+            normalizationContext: ['groups' => ['profile:read', 'profile:detail']],
+            description: <<<'TEXT'
+            Changes this profile's network identifier — e.g. after a user renames their account — and, for RSS.app-based networks, re-links the RSS.app feed. Because RSS.app cannot re-point an existing feed, the old feed is deleted and a new one is created (or an existing feed for the new URL is adopted), then its current items are imported. The profile row and all previously imported items are preserved, so no history is lost. Send the new value as `{"identifier": "https://…"}`. Returns 422 if the identifier is empty, invalid for the network, or already used by another profile in the same network; 404 if the profile is not linked to the authenticated client.
             TEXT,
         ),
     ],

--- a/src/Profile/IdentifierChangeException.php
+++ b/src/Profile/IdentifierChangeException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace App\Profile;
+
+/**
+ * Thrown by {@see IdentifierChanger} when the requested identifier cannot be
+ * applied (empty, invalid for the network, or already used by another profile).
+ * These are client errors — no destructive action has been performed yet.
+ */
+class IdentifierChangeException extends \RuntimeException
+{
+}

--- a/src/Profile/IdentifierChangeResult.php
+++ b/src/Profile/IdentifierChangeResult.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace App\Profile;
+
+/**
+ * Outcome of an identifier change on a profile, including the RSS.app re-link
+ * result for RSS.app-based networks.
+ */
+final class IdentifierChangeResult
+{
+    public function __construct(
+        public readonly bool $changed,
+        public readonly bool $rssAppApplicable,
+        public readonly bool $oldFeedRemoved,
+        public readonly bool $linkedToExistingFeed,
+        public readonly int $importedItems,
+        public readonly ?string $relinkError,
+    ) {
+    }
+
+    /** The new identifier equals the current one — nothing was done. */
+    public static function unchanged(): self
+    {
+        return new self(false, false, false, false, 0, null);
+    }
+
+    /** Identifier updated on a non-RSS.app network — no feed re-link necessary. */
+    public static function identifierOnly(): self
+    {
+        return new self(true, false, false, false, 0, null);
+    }
+
+    /** Identifier updated and the RSS.app feed successfully re-linked. */
+    public static function relinked(bool $oldFeedRemoved, bool $linkedToExistingFeed, int $importedItems): self
+    {
+        return new self(true, true, $oldFeedRemoved, $linkedToExistingFeed, $importedItems, null);
+    }
+
+    /** Identifier updated, but re-creating the RSS.app feed failed; the profile now has no feed. */
+    public static function relinkFailed(bool $oldFeedRemoved, string $error): self
+    {
+        return new self(true, true, $oldFeedRemoved, false, 0, $error);
+    }
+}

--- a/src/Profile/IdentifierChanger.php
+++ b/src/Profile/IdentifierChanger.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\Profile;
+
+use App\Entity\Profile;
+use App\Repository\ProfileRepository;
+use App\RssApp\FeedRegistrar;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Changes the network identifier of an existing profile and, for RSS.app-based
+ * networks, re-links its RSS.app feed to the new identifier (see
+ * {@see FeedRegistrar::relinkRssAppFeed()}).
+ *
+ * The profile row and all of its already-imported items are preserved, so a
+ * username change (e.g. a renamed Instagram account) keeps the full history in
+ * the feeds app while future fetches follow the new identifier.
+ */
+class IdentifierChanger
+{
+    public function __construct(
+        private readonly ProfileRepository $profileRepository,
+        private readonly FeedRegistrar $feedRegistrar,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @throws IdentifierChangeException when the identifier is empty, invalid for
+     *                                   the network, or already taken by another
+     *                                   profile in the same network.
+     */
+    public function change(Profile $profile, string $newIdentifier): IdentifierChangeResult
+    {
+        $newIdentifier = trim($newIdentifier);
+
+        if ($newIdentifier === '') {
+            throw new IdentifierChangeException('Der Identifier darf nicht leer sein.');
+        }
+
+        $network = $profile->getNetwork();
+
+        if ($network !== null
+            && $network->getProfileUrlPattern() !== null
+            && !$network->isValidProfileUrl($newIdentifier)
+        ) {
+            throw new IdentifierChangeException(sprintf(
+                '„%s" ist kein gültiger Identifier für das Netzwerk %s.',
+                $newIdentifier,
+                $network->getName() ?? $network->getIdentifier() ?? '',
+            ));
+        }
+
+        if ($newIdentifier === $profile->getIdentifier()) {
+            return IdentifierChangeResult::unchanged();
+        }
+
+        if ($network !== null) {
+            $existing = $this->profileRepository->findOneByNetworkAndIdentifier($network, $newIdentifier);
+
+            if ($existing !== null && $existing->getId() !== $profile->getId()) {
+                throw new IdentifierChangeException(sprintf(
+                    'Es existiert bereits ein Profil mit dem Identifier „%s" in diesem Netzwerk.',
+                    $newIdentifier,
+                ));
+            }
+        }
+
+        $profile->setIdentifier($newIdentifier);
+
+        $result = $this->feedRegistrar->relinkRssAppFeed($profile);
+
+        $this->em->flush();
+
+        return $result;
+    }
+}

--- a/src/RssApp/FeedRegistrar.php
+++ b/src/RssApp/FeedRegistrar.php
@@ -8,6 +8,7 @@ use App\FeedFetcher\FetchInfo;
 use App\FeedFetcher\FetchResult;
 use App\FeedItemPersister\FeedItemPersisterInterface;
 use App\Model\Profile as ModelProfile;
+use App\Profile\IdentifierChangeResult;
 use Psr\Log\LoggerInterface;
 
 class FeedRegistrar
@@ -71,6 +72,74 @@ class FeedRegistrar
         $profile->setRssAppFeedId($feedId);
 
         return $this->importInitialItems($profile);
+    }
+
+    /**
+     * Re-links the profile's RSS.app feed after its identifier has changed.
+     *
+     * RSS.app cannot re-point an existing feed to a new source URL, so the old
+     * feed is deleted and a fresh feed is created (or an already-existing feed
+     * for the new URL is adopted) and its current items are imported. The
+     * profile is expected to already carry the new identifier; its stored items
+     * are untouched, so no historical data is lost.
+     */
+    public function relinkRssAppFeed(Profile $profile): IdentifierChangeResult
+    {
+        $networkIdentifier = $profile->getNetwork()?->getIdentifier();
+
+        if (!in_array($networkIdentifier, self::RSS_APP_NETWORKS, true)) {
+            return IdentifierChangeResult::identifierOnly();
+        }
+
+        $sourceUrl = $profile->getIdentifier();
+
+        if ($sourceUrl === null) {
+            return IdentifierChangeResult::identifierOnly();
+        }
+
+        $oldFeedId = $profile->getRssAppFeedId();
+        $oldFeedRemoved = false;
+
+        if ($oldFeedId !== null) {
+            try {
+                $this->rssApp->deleteFeed($oldFeedId);
+                $oldFeedRemoved = true;
+            } catch (\Throwable $e) {
+                $this->logger->warning('Failed to delete old RSS.app feed {feedId} while re-linking profile {id}: {message}', [
+                    'feedId' => $oldFeedId,
+                    'id' => $profile->getId(),
+                    'message' => $e->getMessage(),
+                ]);
+            }
+
+            $profile->setRssAppFeedId(null);
+        }
+
+        try {
+            $existingFeedId = $this->rssApp->findRssAppFeedIdBySourceUrl($sourceUrl);
+
+            if ($existingFeedId !== null) {
+                $importedCount = $this->linkExistingFeedAndImport($profile, $existingFeedId);
+
+                return IdentifierChangeResult::relinked($oldFeedRemoved, true, $importedCount);
+            }
+
+            $feedData = $this->rssApp->createFeed($sourceUrl);
+            $profile->setRssAppFeedId($feedData['id']);
+
+            $importedCount = $this->importInitialItems($profile);
+
+            return IdentifierChangeResult::relinked($oldFeedRemoved, false, $importedCount);
+        } catch (\Throwable $e) {
+            $this->logger->error('RSS.app feed re-link failed for {identifier}: {message}', [
+                'identifier' => $sourceUrl,
+                'message' => $e->getMessage(),
+            ]);
+
+            $profile->setRssAppFeedId(null);
+
+            return IdentifierChangeResult::relinkFailed($oldFeedRemoved, $e->getMessage());
+        }
     }
 
     private function importInitialItems(Profile $profile): int

--- a/src/State/ProfileChangeIdentifierProcessor.php
+++ b/src/State/ProfileChangeIdentifierProcessor.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Profile;
+use App\Profile\IdentifierChangeException;
+use App\Profile\IdentifierChanger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Changes a profile's network identifier and, for RSS.app-based networks,
+ * re-links its RSS.app feed. The new identifier is read from the request body
+ * ({"identifier": "…"}). The profile is loaded by the default provider, so
+ * client-scoping enforces 404 for profiles the client is not linked to.
+ *
+ * @implements ProcessorInterface<Profile, Profile>
+ */
+class ProfileChangeIdentifierProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly IdentifierChanger $identifierChanger,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Profile
+    {
+        if (!$this->security->getUser() instanceof Client) {
+            throw new BadRequestHttpException('Authentication required.');
+        }
+
+        if (!$data instanceof Profile) {
+            throw new NotFoundHttpException('Profile not found.');
+        }
+
+        $request = $context['request'] ?? null;
+
+        if (!$request instanceof Request) {
+            throw new BadRequestHttpException('Request context is required.');
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        $identifier = is_array($payload) ? ($payload['identifier'] ?? null) : null;
+
+        if (!is_string($identifier) || trim($identifier) === '') {
+            throw new BadRequestHttpException('A non-empty "identifier" field is required.');
+        }
+
+        try {
+            $this->identifierChanger->change($data, $identifier);
+        } catch (IdentifierChangeException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage());
+        }
+
+        return $data;
+    }
+}

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -102,6 +102,29 @@
             </div>
 
             <div class="data-card mb-4">
+                <div class="data-card-header">Identifier ändern</div>
+                <div class="data-card-body">
+                    <p class="text-muted small mb-2">
+                        Ändert den Identifier dieses Profils, z.&nbsp;B. nach einer Umbenennung des Accounts.
+                        Bei RSS.app-Netzwerken wird der bestehende Feed entfernt und für den neuen Identifier neu
+                        angelegt; das Profil und alle bereits importierten Items bleiben erhalten.
+                    </p>
+                    <form method="post" action="{{ path('app_profile_change_identifier', {id: profile.id}) }}"
+                          data-controller="confirm"
+                          data-confirm-message-value="Identifier wirklich ändern? Ein bestehender RSS.app-Feed wird dabei gelöscht und neu angelegt.">
+                        <input type="hidden" name="_token" value="{{ csrf_token('change-identifier-' ~ profile.id) }}">
+                        <div class="input-group">
+                            <input type="text" name="identifier" class="form-control"
+                                   value="{{ profile.identifier }}" required aria-label="Neuer Identifier">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-exchange-alt me-1"></i>Ändern
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="data-card mb-4">
                 <div class="data-card-header">Clients ({{ profile.clients|length }})</div>
                 <div class="data-card-body">
                     {% if profile.clients|length > 0 %}

--- a/tests/Functional/Api/ProfileApiTest.php
+++ b/tests/Functional/Api/ProfileApiTest.php
@@ -312,6 +312,49 @@ class ProfileApiTest extends AbstractApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testChangeIdentifierUpdatesProfile(): void
+    {
+        $this->requestAsClientA('POST', '/api/profiles/90001/change-identifier', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'body' => json_encode(['identifier' => 'https://mastodon.social/@renamed']),
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $data = $this->requestAsClientA('GET', '/api/profiles/90001')->toArray();
+        $this->assertSame('https://mastodon.social/@renamed', $data['identifier']);
+    }
+
+    public function testChangeIdentifierRejectsInvalidValue(): void
+    {
+        $this->requestAsClientA('POST', '/api/profiles/90001/change-identifier', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'body' => json_encode(['identifier' => 'not-a-valid-mastodon-handle']),
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testChangeIdentifierRejectsEmptyValue(): void
+    {
+        $this->requestAsClientA('POST', '/api/profiles/90001/change-identifier', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'body' => json_encode(['identifier' => '']),
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testChangeIdentifierProfileNotLinkedReturns404(): void
+    {
+        // profileOnlyB (90003) is not linked to client A
+        $this->requestAsClientA('POST', '/api/profiles/90003/change-identifier', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'body' => json_encode(['identifier' => 'https://mastodon.social/@whatever']),
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     private function getMastodonNetworkIri(): string
     {
         return $this->getNetworkIri('mastodon');

--- a/tests/Unit/Profile/IdentifierChangerTest.php
+++ b/tests/Unit/Profile/IdentifierChangerTest.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Profile;
+
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\Profile\IdentifierChangeException;
+use App\Profile\IdentifierChangeResult;
+use App\Profile\IdentifierChanger;
+use App\Repository\ProfileRepository;
+use App\RssApp\FeedRegistrar;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class IdentifierChangerTest extends TestCase
+{
+    private ProfileRepository&MockObject $profileRepository;
+    private FeedRegistrar&MockObject $feedRegistrar;
+    private EntityManagerInterface&MockObject $em;
+    private IdentifierChanger $changer;
+
+    protected function setUp(): void
+    {
+        $this->profileRepository = $this->createMock(ProfileRepository::class);
+        $this->feedRegistrar = $this->createMock(FeedRegistrar::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+
+        $this->changer = new IdentifierChanger(
+            $this->profileRepository,
+            $this->feedRegistrar,
+            $this->em,
+        );
+    }
+
+    public function testUnchangedIdentifierDoesNotRelinkOrFlush(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/samename/');
+
+        $this->feedRegistrar->expects($this->never())->method('relinkRssAppFeed');
+        $this->em->expects($this->never())->method('flush');
+
+        $result = $this->changer->change($profile, 'https://www.instagram.com/samename/');
+
+        $this->assertFalse($result->changed);
+    }
+
+    public function testEmptyIdentifierThrows(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/foo/');
+
+        $this->expectException(IdentifierChangeException::class);
+
+        $this->changer->change($profile, '   ');
+    }
+
+    public function testInvalidIdentifierForNetworkThrows(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/foo/');
+
+        $this->feedRegistrar->expects($this->never())->method('relinkRssAppFeed');
+
+        $this->expectException(IdentifierChangeException::class);
+
+        $this->changer->change($profile, 'not-a-valid-instagram-url');
+    }
+
+    public function testDuplicateIdentifierThrows(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/foo/', 1);
+
+        $other = $this->makeProfile('https://www.instagram.com/newname/', 2);
+
+        $this->profileRepository->method('findOneByNetworkAndIdentifier')->willReturn($other);
+
+        $this->feedRegistrar->expects($this->never())->method('relinkRssAppFeed');
+
+        $this->expectException(IdentifierChangeException::class);
+
+        $this->changer->change($profile, 'https://www.instagram.com/newname/');
+    }
+
+    public function testValidChangeSetsIdentifierRelinksAndFlushes(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/oldname/', 1);
+
+        $this->profileRepository->method('findOneByNetworkAndIdentifier')->willReturn(null);
+
+        $expected = IdentifierChangeResult::relinked(true, false, 3);
+        $this->feedRegistrar->expects($this->once())
+            ->method('relinkRssAppFeed')
+            ->with($profile)
+            ->willReturnCallback(function (Profile $p) use ($expected): IdentifierChangeResult {
+                // Identifier must already be updated before the re-link runs.
+                $this->assertSame('https://www.instagram.com/newname/', $p->getIdentifier());
+                return $expected;
+            });
+
+        $this->em->expects($this->once())->method('flush');
+
+        $result = $this->changer->change($profile, 'https://www.instagram.com/newname/');
+
+        $this->assertSame($expected, $result);
+        $this->assertSame('https://www.instagram.com/newname/', $profile->getIdentifier());
+    }
+
+    public function testDuplicateCheckIgnoresSameProfile(): void
+    {
+        $profile = $this->makeProfile('https://www.instagram.com/oldname/', 7);
+
+        // Repository returns the very same profile (its own row) — must not be treated as a conflict.
+        $this->profileRepository->method('findOneByNetworkAndIdentifier')->willReturn($profile);
+
+        $this->feedRegistrar->expects($this->once())
+            ->method('relinkRssAppFeed')
+            ->willReturn(IdentifierChangeResult::relinked(false, false, 0));
+
+        $result = $this->changer->change($profile, 'https://www.instagram.com/newname/');
+
+        $this->assertTrue($result->changed);
+    }
+
+    private function makeProfile(string $identifier, ?int $id = null): Profile
+    {
+        $network = new Network();
+        $network->setIdentifier('instagram_profile');
+        $network->setName('Instagram-Profil');
+        $network->setProfileUrlPattern('#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9\-_]{5,}/?$#i');
+
+        $profile = new Profile();
+        $profile->setNetwork($network);
+        $profile->setIdentifier($identifier);
+
+        if ($id !== null) {
+            $profile->setId($id);
+        }
+
+        return $profile;
+    }
+}

--- a/tests/Unit/RssApp/FeedRegistrarTest.php
+++ b/tests/Unit/RssApp/FeedRegistrarTest.php
@@ -188,6 +188,120 @@ class FeedRegistrarTest extends TestCase
         $this->assertSame('adopted-feed-42', $profile->getRssAppFeedId());
     }
 
+    public function testRelinkNonRssNetworkReturnsIdentifierOnly(): void
+    {
+        $profile = $this->makeProfile('mastodon', 'https://mastodon.social/@foo');
+        $profile->setRssAppFeedId('should-stay');
+
+        $this->rssApp->expects($this->never())->method('deleteFeed');
+        $this->rssApp->expects($this->never())->method('createFeed');
+
+        $result = $this->registrar->relinkRssAppFeed($profile);
+
+        $this->assertTrue($result->changed);
+        $this->assertFalse($result->rssAppApplicable);
+        $this->assertSame('should-stay', $profile->getRssAppFeedId());
+    }
+
+    public function testRelinkDeletesOldFeedCreatesNewAndImports(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/newname', 42);
+        $profile->setRssAppFeedId('old-feed');
+
+        $this->rssApp->expects($this->once())->method('deleteFeed')->with('old-feed');
+        $this->rssApp->expects($this->once())
+            ->method('findRssAppFeedIdBySourceUrl')
+            ->with('https://instagram.com/newname')
+            ->willReturn(null);
+        $this->rssApp->expects($this->once())
+            ->method('createFeed')
+            ->with('https://instagram.com/newname')
+            ->willReturn(['id' => 'new-feed-777']);
+
+        $this->wireImport([new ItemModel(), new ItemModel()]);
+
+        $result = $this->registrar->relinkRssAppFeed($profile);
+
+        $this->assertTrue($result->changed);
+        $this->assertTrue($result->rssAppApplicable);
+        $this->assertTrue($result->oldFeedRemoved);
+        $this->assertFalse($result->linkedToExistingFeed);
+        $this->assertSame(2, $result->importedItems);
+        $this->assertNull($result->relinkError);
+        $this->assertSame('new-feed-777', $profile->getRssAppFeedId());
+    }
+
+    public function testRelinkAdoptsExistingFeedForNewIdentifier(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/newname', 42);
+        $profile->setRssAppFeedId('old-feed');
+
+        $this->rssApp->expects($this->once())->method('deleteFeed')->with('old-feed');
+        $this->rssApp->expects($this->once())
+            ->method('findRssAppFeedIdBySourceUrl')
+            ->with('https://instagram.com/newname')
+            ->willReturn('adopted-42');
+        $this->rssApp->expects($this->never())->method('createFeed');
+
+        $this->wireImport([new ItemModel()]);
+
+        $result = $this->registrar->relinkRssAppFeed($profile);
+
+        $this->assertTrue($result->linkedToExistingFeed);
+        $this->assertSame(1, $result->importedItems);
+        $this->assertSame('adopted-42', $profile->getRssAppFeedId());
+    }
+
+    public function testRelinkWithoutOldFeedDoesNotDelete(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/newname', 42);
+
+        $this->rssApp->expects($this->never())->method('deleteFeed');
+        $this->rssApp->method('findRssAppFeedIdBySourceUrl')->willReturn(null);
+        $this->rssApp->expects($this->once())->method('createFeed')->willReturn(['id' => 'fresh-1']);
+
+        $this->wireImport([]);
+
+        $result = $this->registrar->relinkRssAppFeed($profile);
+
+        $this->assertFalse($result->oldFeedRemoved);
+        $this->assertSame('fresh-1', $profile->getRssAppFeedId());
+    }
+
+    public function testRelinkReturnsFailedWhenCreateThrows(): void
+    {
+        $profile = $this->makeProfile('instagram_profile', 'https://instagram.com/newname', 42);
+        $profile->setRssAppFeedId('old-feed');
+
+        $this->rssApp->expects($this->once())->method('deleteFeed')->with('old-feed');
+        $this->rssApp->method('findRssAppFeedIdBySourceUrl')->willReturn(null);
+        $this->rssApp->method('createFeed')->willThrowException(new \RuntimeException('Unsupported source URL'));
+
+        $this->feedItemPersister->expects($this->never())->method('persistFeedItemList');
+
+        $result = $this->registrar->relinkRssAppFeed($profile);
+
+        $this->assertTrue($result->changed);
+        $this->assertTrue($result->rssAppApplicable);
+        $this->assertTrue($result->oldFeedRemoved);
+        $this->assertNotNull($result->relinkError);
+        $this->assertStringContainsString('Unsupported source URL', $result->relinkError);
+        $this->assertNull($profile->getRssAppFeedId());
+    }
+
+    /** @param list<ItemModel> $items */
+    private function wireImport(array $items): void
+    {
+        $networkFetcher = $this->createMock(NetworkFeedFetcherInterface::class);
+        $networkFetcher->method('supports')->willReturn(true);
+        $networkFetcher->method('fetch')->willReturn($items);
+
+        $this->feedFetcher->method('getNetworkFetcherList')->willReturn([$networkFetcher]);
+
+        $this->feedItemPersister->method('persistFeedItemList')->with($items)->willReturnSelf();
+        $this->feedItemPersister->method('flush')->willReturnSelf();
+    }
+
     private function makeProfile(string $networkIdentifier, string $url, ?int $id = null): Profile
     {
         $network = new Network();


### PR DESCRIPTION
## Was

Ermöglicht das Ändern des Identifiers eines bestehenden Profils — z.B. nach einer Account-Umbenennung (neuer Instagram-Benutzername) — und aktualisiert dabei die RSS.app-Verknüpfung. **Profil und alle bereits importierten Items bleiben dieselbe DB-Zeile**, dadurch bleiben in der Feeds-App alle Daten erhalten.

## Warum so

Die RSS.app-API kann die Quell-URL eines bestehenden Feeds **nicht** ändern (PATCH erlaubt nur Titel/Beschreibung/Icon). Deshalb wird für RSS.app-Netzwerke der alte Feed gelöscht und ein neuer für den neuen Identifier angelegt (oder ein bereits existierender Feed für die neue URL adoptiert), danach werden dessen aktuelle Items importiert (Dedup über `uniqueIdentifier`).

## Änderungen

- **`IdentifierChanger`** (`src/Profile/`) — validiert den neuen Identifier (Pattern via `Network.profileUrlPattern` + Eindeutigkeit pro Netzwerk), setzt ihn, ruft `FeedRegistrar::relinkRssAppFeed()`, flusht; wirft `IdentifierChangeException` bei ungültig/doppelt
- **`FeedRegistrar::relinkRssAppFeed()`** — alten Feed löschen → neuen anlegen/adoptieren → Items importieren; degradiert sauber bei RSS.app-Fehlern (`relinkFailed`)
- **Web-UI** — Karte „Identifier ändern" auf der Profil-Detailseite; das normale Bearbeiten-Formular ändert den Identifier weiterhin **ohne** RSS.app-Nebenwirkung
- **REST-API** — `POST /api/profiles/{id}/change-identifier` (Body `{"identifier": "…"}`), client-scoped, 200; 422 bei ungültigem/doppeltem Identifier; 404 wenn nicht verknüpft
- Unit-Tests + funktionale API-Tests; README + CLAUDE.md aktualisiert
- **Keine Migration nötig** — nutzt bestehende Spalten (`identifier`, `rss_app_feed_id`)

## Tests

`bin/phpunit` grün (249 Tests). Neue Tests decken Validierung, Duplikat, Re-Link (neu/adoptiert/fehlgeschlagen) und API-Scoping ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)