### PR TITLE
Add video transcription via whisper.cpp

### DIFF
--- a/.env
+++ b/.env
@@ -32,6 +32,17 @@ RSS_APP_API_SECRET=s_zlrGVS4T3dY4YCOfR1U8w5
 YT_DLP_COOKIES_FILE=
 ###< app/media ###
 
+###> app/transcription ###
+# Video-Transkription via whisper.cpp. Pfad zum CLI-Binary (z. B. whisper-cli),
+# zum ggml-Modell und die Sprache (auto = automatisch erkennen). Leerer
+# Modell-Pfad deaktiviert die Transkription (isAvailable() = false). Beispiel:
+# WHISPER_CLI_PATH=/opt/whisper.cpp/build/bin/whisper-cli
+# WHISPER_MODEL_PATH=/opt/whisper.cpp/models/ggml-base.bin
+WHISPER_CLI_PATH=whisper-cli
+WHISPER_MODEL_PATH=
+WHISPER_LANGUAGE=auto
+###< app/transcription ###
+
 ###> app/web-auth ###
 WEB_ADMIN_USERNAME=admin
 WEB_ADMIN_PASSWORD_HASH='$2y$13$changeme'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,12 @@ php bin/console app:download-media --pending          # process items queued via
 php bin/console app:download-media --retry-failed     # retry previously failed downloads
 php bin/console app:download-media --photos-only      # only photos
 php bin/console app:download-media --videos-only      # only videos
+
+php bin/console app:transcribe                        # transcribe videos for all profiles with transcribeVideos enabled
+php bin/console app:transcribe --profile-id=42        # transcribe a specific profile's videos
+php bin/console app:transcribe --item-id=99           # transcribe a single item's video
+php bin/console app:transcribe --pending              # process items queued via the API/fetch (transcriptStatus=pending)
+php bin/console app:transcribe --retry-failed         # retry previously failed transcriptions
 ```
 
 ## Architecture
@@ -78,8 +84,8 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 
 ### Entities
 
-- **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `savePhotos`, `saveVideos`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
-- **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`. Supports soft-delete, hide toggles, and media downloads.
+- **Profile** — Social network profile: `id`, `identifier` (URL), `title` (optional display name), `network` (FK), `autoFetch`, `fetchSource`, `savePhotos`, `saveVideos`, `transcribeVideos`, `additionalData` (JSON), `deleted`/`deletedAt` (soft delete). `getDisplayName()` returns `title` if set, otherwise `identifier`.
+- **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`, `transcript` (text), `transcriptStatus`, `transcriptError`. Supports soft-delete, hide toggles, media downloads, and video transcription.
 - **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
 - **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
 - **Group** — Named bundle of a client's profiles (table `profile_group`, unique `(client_id, name)`): `id`, `name`, `description`, `color`, `client` (ManyToOne, NOT NULL — a group belongs to exactly one client, unlike shared profiles), `profiles` (ManyToMany via `profile_group_profile`), `createdAt`. Serialization groups `group:read` (incl. `profileCount`), `group:detail` (embeds `profiles`), `group:write`. Used to read a combined feed per group.
@@ -98,6 +104,18 @@ Profiles can opt into automatic photo/video downloads via `savePhotos` and `save
 - Manual download via button on item detail page (Stimulus `media_download_controller`)
 - **API-triggered (re)download**: `POST /api/items/{id}/download-media` and `POST /api/profiles/{id}/download-media` (`?force=true` to re-queue all) mark items `pending` via `ItemMediaDownloadProcessor`/`ProfileMediaDownloadProcessor` (client-scoped, 202, require `savePhotos`/`saveVideos`); the actual download runs out-of-band via the `app:download-media --pending` cron. No Messenger — the queue is the `mediaStatus=pending` column.
 - Item entity stores `photoPaths` (JSON array of relative paths), `videoPath` (string), `mediaStatus`, `mediaError`
+
+### Video Transcription System
+
+Profiles can opt into automatic transcription of downloaded videos via the `transcribeVideos` flag (only meaningful together with `saveVideos` — a video must be downloaded first). Transcription runs local via whisper.cpp, decoupled from the fetch/download run through a `transcriptStatus` queue (`null` → `pending` → `running` → `completed`/`failed`), mirroring the media-download queue.
+
+- **`WhisperTranscriber`** (`src/Transcription/`) — low-level: extracts a 16 kHz mono WAV from the downloaded video with `ffmpeg`, then runs the whisper.cpp CLI (`-otxt`) and returns the transcript text. `isAvailable()` gracefully reports false unless the whisper binary, the model file and `ffmpeg` are all present. Configured via `$whisperCliPath`/`$whisperModelPath`/`$whisperLanguage` binds.
+- **`TranscriptionService`** (`src/Transcription/`) — orchestrates the status lifecycle and persistence. `transcribe(Item)` does the work; `queueItem()`/`queueProfile()` mark items `pending` (used by the API trigger); `transcribePendingItems()` drains the queue.
+- **Auto-queue**: after a video is downloaded, `MediaDownloadService::downloadMedia()` marks the item `transcriptStatus=pending` when the profile has `transcribeVideos` enabled. The actual transcription runs out-of-band via `app:transcribe --pending` (cron). No Messenger — the queue is the `transcriptStatus=pending` column, same pattern as media downloads.
+- **`TranscribeCommand`** (`app:transcribe`) — CLI for bulk/targeted transcription with `--profile-id`, `--item-id`, `--pending`, `--retry-failed`. Backfills videos downloaded before the flag was enabled. Errors out cleanly if whisper.cpp/ffmpeg are unavailable.
+- **API-triggered (re)transcription**: `POST /api/items/{id}/transcribe` and `POST /api/profiles/{id}/transcribe` (`?force=true` to re-queue all) mark items `pending` via `ItemTranscriptionProcessor`/`ProfileTranscriptionProcessor` (client-scoped, 202, require `transcribeVideos`; item route also requires a downloaded video).
+- The transcript is shown on the item detail page (Web-UI) and exposed on the single-item API GET (`item:detail` group). `transcriptStatus`/`transcriptError` are in `item:read`.
+- **Ops**: whisper.cpp binary + ggml model are a manual server-side install (see `WHISPER_*` env vars). Schedule `app:transcribe --pending` in cron alongside `app:download-media --pending`.
 
 ### Serializer
 
@@ -130,6 +148,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - Timeline endpoint: `GET /api/timeline` (chronological feed, filters: limit, since, until, network)
 - `PATCH /api/profiles/{id}` (merge-patch): partial profile update, e.g. toggle `savePhotos`/`saveVideos`
 - `POST /api/profiles/{id}/download-media` and `POST /api/items/{id}/download-media`: queue media (re)download (202, client-scoped, drained by `app:download-media --pending`)
+- `POST /api/profiles/{id}/transcribe` and `POST /api/items/{id}/transcribe`: queue video (re)transcription (202, client-scoped, require `transcribeVideos`, drained by `app:transcribe --pending`)
 - Groups: full CRUD `GET/POST/PUT/PATCH/DELETE /api/groups[/{id}]` (writes via `ClientScopedGroupProcessor`, GET scoped by `ClientScopedGroupExtension`). Membership convenience routes `POST /api/groups/{id}/profiles` + `DELETE /api/groups/{id}/profiles/{profileId}` in `GroupMembershipController`. Combined feed `GET /api/groups/{groupId}/items` via `GroupItemsProvider` (filters since/until/network, excludes hidden/deleted), plus RSS at `GET /api/feeds/groups/{id}.rss`. Referenced profiles must belong to the client (400); foreign groups 404.
 - Networks: public read access
 - OpenAPI docs at `/api/docs`
@@ -169,7 +188,7 @@ The app can run as a standalone instance that imports data from the criticalmass
 
 ## Environment Variables
 
-Key vars in `.env`: `CRITICALMASS_HOSTNAME` (API base URL), `RSS_APP_API_KEY`, `RSS_APP_API_SECRET`, `WEB_ADMIN_USERNAME`, `WEB_ADMIN_PASSWORD_HASH`, `DATABASE_URL`. The `$criticalmassHostname` binding in `services.yaml` injects into `ProfileFetcher`, `ImportProfilesCommand`, `ImportItemsCommand`, and `ProfilePersister`.
+Key vars in `.env`: `CRITICALMASS_HOSTNAME` (API base URL), `RSS_APP_API_KEY`, `RSS_APP_API_SECRET`, `WEB_ADMIN_USERNAME`, `WEB_ADMIN_PASSWORD_HASH`, `DATABASE_URL`, `WHISPER_CLI_PATH`/`WHISPER_MODEL_PATH`/`WHISPER_LANGUAGE` (video transcription; empty model path disables it). The `$criticalmassHostname` binding in `services.yaml` injects into `ProfileFetcher`, `ImportProfilesCommand`, `ImportItemsCommand`, and `ProfilePersister`.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Symfony 8 application that fetches social media feeds from various networks and 
 - Composer
 - Docker & Docker Compose (for PostgreSQL)
 - yt-dlp (optional, for video downloads and Instagram/Threads/Facebook photo extraction)
+- ffmpeg + whisper.cpp CLI and a ggml model (optional, for automatic video transcription)
 
 ## Installation
 
@@ -169,6 +170,24 @@ Downloads can also be triggered through the REST API (see below): the trigger en
 */5 * * * * cd /path/to/app && php bin/console app:download-media --pending >/dev/null 2>&1
 ```
 
+### Video transcription
+
+Profiles with the `transcribeVideos` flag enabled (in addition to `saveVideos`) get their downloaded videos transcribed locally via [whisper.cpp](https://github.com/ggml-org/whisper.cpp). The transcript is shown on the item detail page in the Web UI and exposed on the single-item REST endpoint. Transcription runs decoupled from the fetch/download via a `transcriptStatus` queue (`pending` → `running` → `completed`/`failed`).
+
+```bash
+php bin/console app:transcribe                        # all profiles with transcribeVideos enabled
+php bin/console app:transcribe --profile-id=42        # specific profile (backfills existing videos)
+php bin/console app:transcribe --item-id=99           # single item
+php bin/console app:transcribe --pending              # process items queued via the API / after fetch
+php bin/console app:transcribe --retry-failed         # retry previously failed transcriptions
+```
+
+Requires `ffmpeg` and the whisper.cpp CLI + a ggml model installed on the server; configure `WHISPER_CLI_PATH`, `WHISPER_MODEL_PATH` and `WHISPER_LANGUAGE` (an empty model path disables transcription). After a feed fetch, videos are queued automatically; drain the queue on a cron alongside the media download:
+
+```
+*/5 * * * * cd /path/to/app && php bin/console app:transcribe --pending >/dev/null 2>&1
+```
+
 ## Web UI
 
 The admin interface is accessible after login at `/login`. It provides:
@@ -202,6 +221,7 @@ Tokens are generated via `app:client:create`.
 - `PATCH /api/profiles/{id}` — Partially update a profile, e.g. toggle media storage with `{"savePhotos": true}` (Content-Type: `application/merge-patch+json`)
 - `DELETE /api/profiles/{id}` — Unlink from client; soft-deletes if no other clients remain
 - `POST /api/profiles/{id}/download-media` — Queue a media (re)download for the profile's items (new + previously failed; `?force=true` re-queues all). Returns 202; requires `savePhotos`/`saveVideos` enabled (422 otherwise)
+- `POST /api/profiles/{id}/transcribe` — Queue a (re)transcription of the profile's videos (`?force=true` re-transcribes all). Returns 202; requires `transcribeVideos` enabled (422 otherwise)
 
 **Items** (client-scoped):
 - `GET /api/items` — List feed items (paginated, 50 per page). Each item exposes `mediaStatus` and absolute `photoUrls`/`videoUrl` for any media stored on the server
@@ -209,6 +229,7 @@ Tokens are generated via `app:client:create`.
 - `POST /api/items` — Create item
 - `PUT /api/items/{id}` — Update item
 - `POST /api/items/{id}/download-media` — Queue a media (re)download for this single item. Returns 202; requires the item's profile to have `savePhotos`/`saveVideos` enabled (422 otherwise)
+- `POST /api/items/{id}/transcribe` — Queue a (re)transcription of this item's video. Returns 202; requires `transcribeVideos` enabled and a downloaded video (422 otherwise). The transcript is available in the `transcript` field on the single-item GET
 
 Media downloads triggered via the API are processed asynchronously by the `app:download-media --pending` cron (see Media Download above). Once stored, an item's `photoUrls`/`videoUrl` point to the locally hosted files under `/media/...` instead of the original CDN URLs.
 
@@ -287,8 +308,8 @@ src/NetworkFeedFetcher/YourNetwork/
 
 | Entity | Purpose |
 |---|---|
-| `Profile` | Social network profile (URL identifier, optional title, network reference, fetch metadata, savePhotos/saveVideos flags) |
-| `Item` | Feed item (text, title, permalink, timestamps, hidden/deleted flags, photoPaths, videoPath, mediaStatus) |
+| `Profile` | Social network profile (URL identifier, optional title, network reference, fetch metadata, savePhotos/saveVideos/transcribeVideos flags) |
+| `Item` | Feed item (text, title, permalink, timestamps, hidden/deleted flags, photoPaths, videoPath, mediaStatus, transcript/transcriptStatus) |
 | `Network` | Social network definition (name, icon, colors, cron expression) |
 | `Client` | API client (name, Bearer token, enabled flag, linked profiles) |
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,9 @@ services:
             $webAdminPasswordHash: '%env(WEB_ADMIN_PASSWORD_HASH)%'
             $mediaDirectory: '%kernel.project_dir%/public/media'
             $ytDlpCookiesFile: '%env(YT_DLP_COOKIES_FILE)%'
+            $whisperCliPath: '%env(WHISPER_CLI_PATH)%'
+            $whisperModelPath: '%env(WHISPER_MODEL_PATH)%'
+            $whisperLanguage: '%env(WHISPER_LANGUAGE)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/docs/profile-migrations/2026-05-24-retired-twitter-and-facebook.md
+++ b/docs/profile-migrations/2026-05-24-retired-twitter-and-facebook.md
@@ -1,0 +1,52 @@
+# Profil-Migrationen — 2026-05-24
+
+Notizen zum Aufräumen stiller RSS.app-Profile.
+Anlass: Reihe von Twitter- und Facebook-Konten, die in ihren letzten Posts
+ausdrücklich Migration zu Bluesky/Mastodon/Fediverse angekündigt haben und
+seitdem verstummt sind.
+
+## Neu angelegte Nachfolger-Profile
+
+Für jedes alte Profil wurde – sofern in der Abschiedsnachricht ein konkreter
+Handle genannt wurde – das neue Profil hier in der App angelegt. Die alten
+Profile bleiben unangetastet, damit historische Items erhalten bleiben.
+
+| Neue ID | Netzwerk | URL | Ersetzt (alte Profil-ID) | Quelltext der Ankündigung |
+|---:|---|---|---:|---|
+| 2263 | bluesky_profile | `https://bsky.app/profile/criticalmassleipzig.de` | 1698 `CMLPZcriticalmassleipzig` (facebook_page) | „Wir verabschieden uns von Facebook. Ihr könnt uns weiterhin folgen auf Bluesky, Instagram, Telegram, Whatsapp." (2025-01-26) |
+| 2264 | bluesky_profile | `https://bsky.app/profile/cmvie.bsky.social` | 136 `originalcmvie` (twitter) | „Wir sind nun drüben im blauen Himmel" (2025-03-20) |
+| 2265 | bluesky_profile | `https://bsky.app/profile/kidicalmassmh.bsky.social` | 1620 `kidicalmassmh` (instagram_profile) | „Wir sind jetzt auch mit einem Account auf #Bluesky vertreten. Folgt uns dort!" (2025-09-15) |
+| 2266 | bluesky_profile | `https://bsky.app/profile/criticalmassmh.bsky.social` | 1591 `criticalmassmuelheimruhr` (instagram_profile) | „Als Alternative zu Twitter (X) und anderen Sozialen Medien könnt ihr uns jetzt auch bei Bluesky folgen: CriticalMassMH.bsky.social" (2024-01-05) |
+| 2267 | bluesky_profile | `https://bsky.app/profile/kidicalmasss.bsky.social` | 2215 `KidicalMass_S` (twitter) | „Ihr findet uns auch im Fediverse … Insta … bluesky … #byebyeElon" (2024-06-21) |
+| 2268 | mastodon | `https://verkehrswende.social/@CritMassHann` | 2208 `critmasshann` (twitter) | „Mit X ist jetzt Schluss. Selten fällt ein Abschied leichter." (2025-11-28) |
+| 2269 | mastodon | `https://verkehrswende.social/@KidicalMass_S` | 2215 `KidicalMass_S` (twitter) | s.o. (gleiche Ankündigung wie 2267) |
+
+## Nicht angelegt
+
+Schon vorhanden, nichts zu tun:
+- `https://www.instagram.com/criticalmassleipzig/` (im Leipzig-Abschied erwähnt)
+- `https://www.instagram.com/kidicalmass_s/` (im KidicalMass_S-Abschied erwähnt)
+
+Mangels nennenswerter Quell-Handles in den Abschiedstexten nicht angelegt:
+- 1498 `ClimaticalMass` (twitter) — Abschied 2020 ohne Nennung einer Nachfolge-Plattform
+- 1711 `criticalmassdd` (twitter) — nur „Fediverse oder Mastodon" ohne konkreten Handle
+- 2213 `cm_muenchen` (twitter) — nur „Wir sind bei Mastodon und anderen socials" ohne Handle
+
+## RSS.app-Aufräumen (gleicher Zeitpunkt)
+
+Beim selben Lauf wurden **131 RSS.app-Feeds gelöscht** — strikt nur bei RSS.app,
+Profile in dieser Anwendung blieben unangetastet:
+
+- 9 Feeds aus Gruppe A (die oben genannten Profile + ClimaticalMass / criticalmassdd / cm_muenchen)
+- 123 Feeds aus Gruppe C: RSS.app-verknüpfte Profile, deren letzter Post ≥ 3 Jahre zurücklag (61 twitter, 32 instagram_profile, 30 facebook_page)
+- 1 Überschneidung (1498 ClimaticalMass war in beiden Gruppen)
+
+## Nachzieh-Aufräumen in der DB
+
+Direkt im Anschluss wurde bei genau denselben 131 Profilen der
+`rss_feed_id`-Eintrag aus `additional_data` per `JSON_REMOVE` entfernt.
+Damit zeigen `/rssapp-profiles` und die RSS.app-Sync-Logik wieder einen
+konsistenten Stand und der Cron läuft nicht mehr in 404 gegen tote
+Feed-IDs. Profile, Items und alle übrigen Felder bleiben unverändert.
+
+Vorher / nachher auf `/rssapp-profiles`: **465 → 334**.

--- a/migrations/Version20260707120000.php
+++ b/migrations/Version20260707120000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260707120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add transcribeVideos flag to profile and transcript/transcriptStatus/transcriptError columns to item';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('profile')
+            ->addColumn('transcribe_videos', 'boolean', ['default' => false]);
+
+        $item = $schema->getTable('item');
+        $item->addColumn('transcript', 'text', ['notnull' => false]);
+        $item->addColumn('transcript_status', 'string', ['length' => 20, 'notnull' => false]);
+        $item->addColumn('transcript_error', 'text', ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('profile')->dropColumn('transcribe_videos');
+
+        $item = $schema->getTable('item');
+        $item->dropColumn('transcript');
+        $item->dropColumn('transcript_status');
+        $item->dropColumn('transcript_error');
+    }
+}

--- a/src/Command/TranscribeCommand.php
+++ b/src/Command/TranscribeCommand.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\ItemRepository;
+use App\Repository\ProfileRepository;
+use App\Transcription\TranscriptionService;
+use App\Transcription\WhisperTranscriber;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class TranscribeCommand extends Command
+{
+    public function __construct(
+        private readonly TranscriptionService $transcriptionService,
+        private readonly WhisperTranscriber $whisperTranscriber,
+        private readonly ProfileRepository $profileRepository,
+        private readonly ItemRepository $itemRepository,
+    ) {
+        parent::__construct(null);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:transcribe')
+            ->setDescription('Transcribe downloaded videos for feed items via whisper.cpp')
+            ->addOption('profile-id', null, InputOption::VALUE_REQUIRED, 'Transcribe videos for a specific profile ID')
+            ->addOption('item-id', null, InputOption::VALUE_REQUIRED, 'Transcribe the video of a specific item ID')
+            ->addOption('pending', null, InputOption::VALUE_NONE, 'Process items queued for transcription (transcriptStatus=pending)')
+            ->addOption('retry-failed', null, InputOption::VALUE_NONE, 'Retry previously failed transcriptions')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->whisperTranscriber->isAvailable()) {
+            $io->error('whisper.cpp and/or ffmpeg are not available. Set WHISPER_CLI_PATH / WHISPER_MODEL_PATH and install ffmpeg.');
+
+            return Command::FAILURE;
+        }
+
+        if ($input->getOption('pending')) {
+            $count = $this->transcriptionService->transcribePendingItems();
+            $io->success(sprintf('Processed %d pending item(s).', $count));
+
+            return Command::SUCCESS;
+        }
+
+        $itemId = $input->getOption('item-id');
+
+        if ($itemId) {
+            $item = $this->itemRepository->find((int) $itemId);
+
+            if (!$item) {
+                $io->error(sprintf('Item with ID %d not found.', $itemId));
+
+                return Command::FAILURE;
+            }
+
+            $this->transcriptionService->transcribe($item);
+            $io->success(sprintf('Transcribed item #%d (status: %s).', $item->getId(), $item->getTranscriptStatus() ?? 'skipped'));
+
+            return Command::SUCCESS;
+        }
+
+        $profileId = $input->getOption('profile-id');
+        $retryFailed = (bool) $input->getOption('retry-failed');
+
+        if ($profileId) {
+            $profile = $this->profileRepository->find((int) $profileId);
+
+            if (!$profile) {
+                $io->error(sprintf('Profile with ID %d not found.', $profileId));
+
+                return Command::FAILURE;
+            }
+
+            $profiles = [$profile];
+        } else {
+            $profiles = $this->profileRepository->findBy(['deleted' => false]);
+            $profiles = array_filter($profiles, fn ($p) => $p->isTranscribeVideos());
+        }
+
+        if (empty($profiles)) {
+            $io->info('No profiles with video transcription enabled found.');
+
+            return Command::SUCCESS;
+        }
+
+        $totalItems = 0;
+
+        foreach ($profiles as $profile) {
+            $io->section(sprintf('Profile #%d: %s', $profile->getId(), $profile->getDisplayName()));
+
+            $items = $retryFailed
+                ? array_filter(
+                    $this->itemRepository->findBy(['profile' => $profile, 'transcriptStatus' => 'failed']),
+                    fn ($i) => $i->hasVideo(),
+                )
+                : $this->itemRepository->findTranscribableForProfile($profile);
+
+            if (empty($items)) {
+                $io->text('No videos to transcribe.');
+
+                continue;
+            }
+
+            $io->text(sprintf('Transcribing %d video(s)...', count($items)));
+            $io->progressStart(count($items));
+
+            foreach ($items as $item) {
+                $this->transcriptionService->transcribe($item);
+                $io->progressAdvance();
+                $totalItems++;
+            }
+
+            $io->progressFinish();
+        }
+
+        $io->success(sprintf('Processed %d video(s) across %d profile(s).', $totalItems, count($profiles)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -325,7 +325,7 @@ class ProfileController extends AbstractController
         $this->addFlash('success', 'Feed wurde von RSS.app entfernt.');
     }
 
-    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource|savePhotos|saveVideos'], methods: ['POST'])]
+    #[Route('/{id}/toggle-{field}', name: 'app_profile_toggle', requirements: ['id' => '\d+', 'field' => 'autoFetch|fetchSource|savePhotos|saveVideos|transcribeVideos'], methods: ['POST'])]
     public function toggle(Request $request, Profile $profile, string $field, EntityManagerInterface $em): JsonResponse
     {
         if (!$this->isCsrfTokenValid('toggle-profile-' . $profile->getId(), $request->request->getString('_token'))) {
@@ -338,6 +338,7 @@ class ProfileController extends AbstractController
             'fetchSource' => 'isFetchSource',
             'savePhotos' => 'isSavePhotos',
             'saveVideos' => 'isSaveVideos',
+            'transcribeVideos' => 'isTranscribeVideos',
         };
 
         $newValue = !$profile->$getter();

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -17,6 +17,7 @@ use ApiPlatform\OpenApi\Model\Operation as OpenApiOperation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use App\State\GroupItemsProvider;
 use App\State\ItemMediaDownloadProcessor;
+use App\State\ItemTranscriptionProcessor;
 use App\State\TimelineProvider;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -91,6 +92,18 @@ use Symfony\Component\Serializer\Attribute\Groups;
             normalizationContext: ['groups' => ['item:read']],
             description: <<<'TEXT'
             Queues a (re)download of this item's media (photos/videos) onto the server. The item is marked `mediaStatus=pending` and the files are fetched out-of-band by the `app:download-media --pending` cron, so the request returns immediately (202). Once downloaded, `photoUrls`/`videoUrl` point to the locally stored copies. Requires the item's profile to have `savePhotos` and/or `saveVideos` enabled (422 otherwise). Returns 404 if the item is not linked to the authenticated client.
+            TEXT,
+        ),
+        new Post(
+            uriTemplate: '/items/{id}/transcribe',
+            status: 202,
+            read: true,
+            deserialize: false,
+            validate: false,
+            processor: ItemTranscriptionProcessor::class,
+            normalizationContext: ['groups' => ['item:read']],
+            description: <<<'TEXT'
+            Queues a (re)transcription of this item's downloaded video onto the server. The item is marked `transcriptStatus=pending` and the transcript is generated out-of-band by the `app:transcribe --pending` cron, so the request returns immediately (202). Once done, the `transcript` field (item:detail) holds the text. Requires the item's profile to have `transcribeVideos` enabled and the item to have a downloaded video (422 otherwise). Returns 404 if the item is not linked to the authenticated client.
             TEXT,
         ),
         new Put(
@@ -228,6 +241,21 @@ class Item
     #[Groups(['item:read'])]
     #[ApiProperty(description: 'Error message from a failed media download attempt.', readable: true, writable: false)]
     private ?string $mediaError = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['item:detail'])]
+    #[ApiProperty(description: 'Transcribed text of the downloaded video, if transcription is enabled for the profile. Only included on the single-item endpoint, not in collections.', readable: true, writable: false)]
+    private ?string $transcript = null;
+
+    #[ORM\Column(type: 'string', length: 20, nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Video transcription status: null, pending, running, completed, failed.', readable: true, writable: false)]
+    private ?string $transcriptStatus = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['item:read'])]
+    #[ApiProperty(description: 'Error message from a failed transcription attempt.', readable: true, writable: false)]
+    private ?string $transcriptError = null;
 
     public function __construct()
     {
@@ -436,6 +464,42 @@ class Item
     public function setMediaError(?string $mediaError): self
     {
         $this->mediaError = $mediaError;
+
+        return $this;
+    }
+
+    public function getTranscript(): ?string
+    {
+        return $this->transcript;
+    }
+
+    public function setTranscript(?string $transcript): self
+    {
+        $this->transcript = $transcript;
+
+        return $this;
+    }
+
+    public function getTranscriptStatus(): ?string
+    {
+        return $this->transcriptStatus;
+    }
+
+    public function setTranscriptStatus(?string $transcriptStatus): self
+    {
+        $this->transcriptStatus = $transcriptStatus;
+
+        return $this;
+    }
+
+    public function getTranscriptError(): ?string
+    {
+        return $this->transcriptError;
+    }
+
+    public function setTranscriptError(?string $transcriptError): self
+    {
+        $this->transcriptError = $transcriptError;
 
         return $this;
     }

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -15,6 +15,7 @@ use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use App\State\ClientScopedProfileProcessor;
 use App\State\ProfileMediaDownloadProcessor;
+use App\State\ProfileTranscriptionProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -56,6 +57,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             processor: ProfileMediaDownloadProcessor::class,
             description: <<<'TEXT'
             Queues a (re)download of media for this profile's items onto the server. By default it queues items that have no media yet and items whose last attempt failed; pass `?force=true` to re-queue every item (e.g. to renew expired media). Items are marked `mediaStatus=pending` and fetched out-of-band by the `app:download-media --pending` cron, so the request returns immediately (202). Requires `savePhotos` and/or `saveVideos` enabled (422 otherwise). Returns 404 if the profile is not linked to the authenticated client.
+            TEXT,
+        ),
+        new Post(
+            uriTemplate: '/profiles/{id}/transcribe',
+            status: 202,
+            read: true,
+            deserialize: false,
+            validate: false,
+            processor: ProfileTranscriptionProcessor::class,
+            description: <<<'TEXT'
+            Queues a (re)transcription of this profile's downloaded videos onto the server. By default it queues items with a video that have not been transcribed yet and items whose last attempt failed; pass `?force=true` to re-transcribe every video. Items are marked `transcriptStatus=pending` and processed out-of-band by the `app:transcribe --pending` cron, so the request returns immediately (202). Requires `transcribeVideos` enabled (422 otherwise). Returns 404 if the profile is not linked to the authenticated client.
             TEXT,
         ),
     ],
@@ -161,6 +173,11 @@ class Profile
     #[Groups(['profile:read', 'profile:write'])]
     #[ApiProperty(description: 'Whether to automatically download videos for new feed items.')]
     private bool $saveVideos = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['profile:read', 'profile:write'])]
+    #[ApiProperty(description: 'Whether to automatically transcribe downloaded videos for new feed items. Only takes effect together with saveVideos (a video must be downloaded first).')]
+    private bool $transcribeVideos = false;
 
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     #[Groups(['profile:read'])]
@@ -350,6 +367,18 @@ class Profile
     public function setSaveVideos(bool $saveVideos): self
     {
         $this->saveVideos = $saveVideos;
+
+        return $this;
+    }
+
+    public function isTranscribeVideos(): bool
+    {
+        return $this->transcribeVideos;
+    }
+
+    public function setTranscribeVideos(bool $transcribeVideos): self
+    {
+        $this->transcribeVideos = $transcribeVideos;
 
         return $this;
     }

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -58,6 +58,11 @@ class ProfileType extends AbstractType
                 'label' => 'Videos speichern',
                 'required' => false,
             ])
+            ->add('transcribeVideos', CheckboxType::class, [
+                'label' => 'Videos transkribieren',
+                'required' => false,
+                'help' => 'Heruntergeladene Videos automatisch per whisper.cpp transkribieren (benötigt „Videos speichern")',
+            ])
             ->add('additionalData', TextareaType::class, [
                 'label' => 'Zusätzliche Daten (JSON)',
                 'required' => false,

--- a/src/MediaDownloader/MediaDownloadService.php
+++ b/src/MediaDownloader/MediaDownloadService.php
@@ -98,6 +98,14 @@ class MediaDownloadService
             $item->setMediaError($videoOnlyFailure ? implode("\n", $errors) : null);
         }
 
+        // Queue transcription of the freshly downloaded video. The actual work is
+        // done out-of-band by `app:transcribe --pending`, so this only flags the
+        // item and does not block the download run.
+        if ($videoDownloaded && $profile->isTranscribeVideos()) {
+            $item->setTranscriptStatus('pending');
+            $item->setTranscriptError(null);
+        }
+
         $this->entityManager->flush();
     }
 

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -42,6 +42,25 @@ class ItemRepository extends ServiceEntityRepository
     }
 
     /**
+     * Items of a profile that have a downloaded video and either no transcript
+     * yet or whose last transcription attempt failed. Used to (re)queue
+     * transcriptions.
+     *
+     * @return list<Item>
+     */
+    public function findTranscribableForProfile(Profile $profile): array
+    {
+        return $this->createQueryBuilder('i')
+            ->andWhere('i.profile = :profile')
+            ->andWhere('i.videoPath IS NOT NULL')
+            ->andWhere('i.transcript IS NULL OR i.transcriptStatus = :failed')
+            ->setParameter('profile', $profile)
+            ->setParameter('failed', 'failed')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Paginated items across all profiles in a group, excluding hidden /
      * soft-deleted items and items belonging to soft-deleted profiles.
      *

--- a/src/State/ItemTranscriptionProcessor.php
+++ b/src/State/ItemTranscriptionProcessor.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Item;
+use App\Transcription\TranscriptionService;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Queues a (re)transcription of a single item's video. The item is loaded by the
+ * default item provider, so the client-scoping Doctrine extension already
+ * enforces 404 for items the client may not see.
+ *
+ * @implements ProcessorInterface<Item, Item>
+ */
+class ItemTranscriptionProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly TranscriptionService $transcriptionService,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Item
+    {
+        if (!$this->security->getUser() instanceof Client) {
+            throw new BadRequestHttpException('Authentication required.');
+        }
+
+        if (!$data instanceof Item) {
+            throw new NotFoundHttpException('Item not found.');
+        }
+
+        $profile = $data->getProfile();
+
+        if (!$profile || !$profile->isTranscribeVideos()) {
+            throw new UnprocessableEntityHttpException(
+                'Enable transcribeVideos on the item\'s profile before triggering a transcription.',
+            );
+        }
+
+        if (!$data->hasVideo()) {
+            throw new UnprocessableEntityHttpException(
+                'The item has no downloaded video to transcribe.',
+            );
+        }
+
+        $this->transcriptionService->queueItem($data);
+
+        return $data;
+    }
+}

--- a/src/State/ProfileTranscriptionProcessor.php
+++ b/src/State/ProfileTranscriptionProcessor.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Entity\Profile;
+use App\Transcription\TranscriptionService;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Queues a (re)transcription of every (new or previously failed) video item of a
+ * profile. Pass ?force=true to re-transcribe all videos. The profile is loaded by
+ * the default provider, so client-scoping enforces 404 for profiles the client is
+ * not linked to.
+ *
+ * @implements ProcessorInterface<Profile, Profile>
+ */
+class ProfileTranscriptionProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly TranscriptionService $transcriptionService,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Profile
+    {
+        if (!$this->security->getUser() instanceof Client) {
+            throw new BadRequestHttpException('Authentication required.');
+        }
+
+        if (!$data instanceof Profile) {
+            throw new NotFoundHttpException('Profile not found.');
+        }
+
+        if (!$data->isTranscribeVideos()) {
+            throw new UnprocessableEntityHttpException(
+                'Enable transcribeVideos on the profile before triggering a transcription.',
+            );
+        }
+
+        $request = $context['request'] ?? null;
+        $force = $request instanceof Request
+            && filter_var($request->query->get('force'), FILTER_VALIDATE_BOOL);
+
+        $this->transcriptionService->queueProfile($data, $force);
+
+        return $data;
+    }
+}

--- a/src/Transcription/TranscriptionService.php
+++ b/src/Transcription/TranscriptionService.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace App\Transcription;
+
+use App\Entity\Item;
+use App\Entity\Profile;
+use App\Repository\ItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Orchestrates video transcription and its status lifecycle
+ * (null → pending → running → completed/failed), mirroring
+ * {@see \App\MediaDownloader\MediaDownloadService}. The heavy lifting is done by
+ * {@see WhisperTranscriber}; this class owns queueing and persistence.
+ */
+class TranscriptionService
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly WhisperTranscriber $whisperTranscriber,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ItemRepository $itemRepository,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Transcribe a single item's downloaded video. Items without a video are
+     * silently skipped (transcriptStatus reset to null). The transcript and the
+     * resulting status are persisted.
+     */
+    public function transcribe(Item $item): void
+    {
+        $profile = $item->getProfile();
+        $videoPath = $item->getVideoPath();
+
+        if (!$profile || $videoPath === null) {
+            $item->setTranscriptStatus(null);
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $item->setTranscriptStatus('running');
+        $item->setTranscriptError(null);
+        $this->entityManager->flush();
+
+        try {
+            $transcript = $this->whisperTranscriber->transcribe($videoPath, $profile->getId(), $item->getId());
+
+            $item->setTranscript($transcript);
+            $item->setTranscriptStatus('completed');
+            $item->setTranscriptError(null);
+        } catch (\Throwable $e) {
+            $this->logger->error('Transcription failed for item {itemId}: {message}', [
+                'itemId' => $item->getId(),
+                'message' => $e->getMessage(),
+                'exception' => $e,
+            ]);
+
+            $item->setTranscriptStatus('failed');
+            $item->setTranscriptError($e->getMessage());
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Queue a single item for (re)transcription. The actual work is performed
+     * out-of-band by `app:transcribe --pending`, so this returns immediately.
+     */
+    public function queueItem(Item $item): void
+    {
+        $item->setTranscriptStatus('pending');
+        $item->setTranscriptError(null);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Queue a profile's video items for (re)transcription. By default this covers
+     * items with a video that have no transcript yet or whose last attempt failed.
+     * With $force = true, every item with a video is re-queued. Returns the number
+     * of items queued.
+     *
+     * @return int
+     */
+    public function queueProfile(Profile $profile, bool $force = false): int
+    {
+        $items = $force
+            ? array_filter($this->itemRepository->findBy(['profile' => $profile]), fn (Item $i) => $i->hasVideo())
+            : $this->itemRepository->findTranscribableForProfile($profile);
+
+        foreach ($items as $item) {
+            $item->setTranscriptStatus('pending');
+            $item->setTranscriptError(null);
+        }
+
+        $this->entityManager->flush();
+
+        return count($items);
+    }
+
+    /**
+     * Transcribe all items currently queued (transcriptStatus = 'pending').
+     * Returns the number of items processed.
+     */
+    public function transcribePendingItems(?int $limit = null): int
+    {
+        $items = $this->itemRepository->findBy(
+            ['transcriptStatus' => 'pending'],
+            ['id' => 'ASC'],
+            $limit,
+        );
+
+        foreach ($items as $item) {
+            $this->transcribe($item);
+        }
+
+        return count($items);
+    }
+}

--- a/src/Transcription/WhisperTranscriber.php
+++ b/src/Transcription/WhisperTranscriber.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace App\Transcription;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Low-level video transcription via whisper.cpp. Extracts the audio track from a
+ * downloaded video with ffmpeg, then runs the whisper.cpp CLI on it. Mirrors
+ * {@see \App\MediaDownloader\VideoDownloader} in structure: file paths are
+ * relative to the configured media directory, availability is probed via the
+ * external binaries, and failures surface as RuntimeExceptions.
+ */
+class WhisperTranscriber
+{
+    public function __construct(
+        private readonly string $mediaDirectory,
+        private readonly string $whisperCliPath = 'whisper-cli',
+        private readonly string $whisperModelPath = '',
+        private readonly string $whisperLanguage = 'auto',
+    ) {
+    }
+
+    /**
+     * Transcribe the video stored at $videoRelativePath (relative to the media
+     * directory) and return the transcript text. Intermediate audio/text files
+     * are written next to the video and cleaned up afterwards.
+     */
+    public function transcribe(string $videoRelativePath, int $profileId, int $itemId): string
+    {
+        $videoPath = sprintf('%s/%s', $this->mediaDirectory, $videoRelativePath);
+
+        if (!is_file($videoPath)) {
+            throw new \RuntimeException(sprintf('Video file not found: %s', $videoRelativePath));
+        }
+
+        $workDir = sprintf('%s/%d/%d', $this->mediaDirectory, $profileId, $itemId);
+
+        if (!is_dir($workDir)) {
+            mkdir($workDir, 0755, true);
+        }
+
+        $audioPath = $workDir . '/audio.wav';
+        $outputPrefix = $workDir . '/transcript';
+        $textPath = $outputPrefix . '.txt';
+
+        try {
+            $this->extractAudio($videoPath, $audioPath);
+            $this->runWhisper($audioPath, $outputPrefix);
+
+            if (!is_file($textPath)) {
+                throw new \RuntimeException('whisper.cpp produced no transcript output file');
+            }
+
+            return trim((string) file_get_contents($textPath));
+        } finally {
+            @unlink($audioPath);
+            @unlink($textPath);
+        }
+    }
+
+    private function extractAudio(string $videoPath, string $audioPath): void
+    {
+        // whisper.cpp expects 16 kHz mono PCM WAV.
+        $process = new Process([
+            'ffmpeg',
+            '-y',
+            '-i', $videoPath,
+            '-vn',
+            '-ar', '16000',
+            '-ac', '1',
+            '-c:a', 'pcm_s16le',
+            $audioPath,
+        ]);
+        $process->setTimeout(300);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf(
+                'ffmpeg audio extraction failed: %s',
+                $process->getErrorOutput() ?: $process->getOutput(),
+            ));
+        }
+    }
+
+    private function runWhisper(string $audioPath, string $outputPrefix): void
+    {
+        $process = new Process([
+            $this->whisperCliPath,
+            '-m', $this->whisperModelPath,
+            '-f', $audioPath,
+            '-l', $this->whisperLanguage !== '' ? $this->whisperLanguage : 'auto',
+            '-nt',
+            '-otxt',
+            '-of', $outputPrefix,
+        ]);
+        $process->setTimeout(1800);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf(
+                'whisper.cpp failed: %s',
+                $process->getErrorOutput() ?: $process->getOutput(),
+            ));
+        }
+    }
+
+    /**
+     * True only when the whisper.cpp CLI, the model file and ffmpeg are all
+     * present, so callers can gracefully skip transcription otherwise.
+     */
+    public function isAvailable(): bool
+    {
+        return $this->whisperModelPath !== ''
+            && is_file($this->whisperModelPath)
+            && $this->binaryRuns([$this->whisperCliPath, '--help'])
+            && $this->binaryRuns(['ffmpeg', '-version']);
+    }
+
+    /** @param list<string> $command */
+    private function binaryRuns(array $command): bool
+    {
+        try {
+            $process = new Process($command);
+            $process->setTimeout(10);
+            $process->run();
+
+            // Exit code 127 means "command not found"; any other outcome means
+            // the binary exists and could be invoked.
+            return $process->getExitCode() !== 127;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/templates/item/show.html.twig
+++ b/templates/item/show.html.twig
@@ -85,6 +85,44 @@
                 </div>
             </div>
 
+            {% if item.videoPath or item.transcript or item.transcriptStatus %}
+                <div class="data-card mb-4" id="transcript-card">
+                    <div class="data-card-header">Transkript</div>
+                    <div class="data-card-body">
+                        {% if item.transcript %}
+                            <p class="mb-0" style="white-space: pre-wrap;">{{ item.transcript }}</p>
+                        {% elseif item.transcriptStatus in ['pending', 'running'] %}
+                            <p class="text-muted mb-0">
+                                <i class="fas fa-hourglass-half me-1"></i>Transkription {{ item.transcriptStatus == 'running' ? 'läuft' : 'ausstehend' }}…
+                            </p>
+                        {% elseif item.transcriptStatus == 'failed' %}
+                            <p class="text-muted mb-0">Transkription fehlgeschlagen.</p>
+                        {% else %}
+                            <p class="text-muted mb-0">Kein Transkript vorhanden.</p>
+                        {% endif %}
+                        {% if item.transcriptStatus == 'failed' and item.transcriptError %}
+                            <div class="alert alert-danger mt-3 mb-0">
+                                <i class="fas fa-exclamation-triangle me-1"></i>{{ item.transcriptError }}
+                            </div>
+                        {% endif %}
+                        {% if item.transcriptStatus %}
+                            <div class="mt-2">
+                                <small class="text-muted">Status: </small>
+                                {% if item.transcriptStatus == 'completed' %}
+                                    <span class="badge bg-success">{{ item.transcriptStatus }}</span>
+                                {% elseif item.transcriptStatus == 'failed' %}
+                                    <span class="badge bg-danger">{{ item.transcriptStatus }}</span>
+                                {% elseif item.transcriptStatus == 'running' %}
+                                    <span class="badge bg-info">{{ item.transcriptStatus }}</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">{{ item.transcriptStatus }}</span>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
             {% if item.raw %}
                 <div class="data-card mb-4">
                     <div class="data-card-header">Rohdaten</div>

--- a/templates/profile/_form.html.twig
+++ b/templates/profile/_form.html.twig
@@ -22,6 +22,9 @@
                 <div class="col-md-4">
                     {{ form_row(form.saveVideos) }}
                 </div>
+                <div class="col-md-4">
+                    {{ form_row(form.transcribeVideos) }}
+                </div>
             </div>
             {{ form_row(form.additionalData) }}
         </div>

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -81,6 +81,12 @@
                             </td>
                         </tr>
                         <tr>
+                            <th>Videos transkribieren</th>
+                            <td>
+                                {% include '_partials/_profile_toggle.html.twig' with { profile: profile, field: 'transcribeVideos', state: profile.transcribeVideos } %}
+                            </td>
+                        </tr>
+                        <tr>
                             <th>Erstellt am</th>
                             <td>{{ profile.createdAt ? profile.createdAt|date('d.m.Y H:i:s') : '-' }}</td>
                         </tr>

--- a/tests/MediaDownloader/MediaDownloadServiceTest.php
+++ b/tests/MediaDownloader/MediaDownloadServiceTest.php
@@ -313,6 +313,47 @@ class MediaDownloadServiceTest extends TestCase
         $this->assertStringContainsString('Video:', $item->getMediaError());
     }
 
+    public function testVideoDownloadQueuesTranscriptionWhenEnabled(): void
+    {
+        $network = new Network();
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setNetwork($network);
+        $profile->setIdentifier('test');
+        $profile->setTranscribeVideos(true);
+
+        $item = new Item();
+        $ref = new \ReflectionProperty(Item::class, 'id');
+        $ref->setValue($item, 100);
+        $item->setProfile($profile);
+
+        $this->extractor->method('extractPhotoUrls')->willReturn([]);
+        $this->extractor->method('extractVideoUrl')->willReturn('https://example.com/post/1');
+        $this->videoDownloader->method('isAvailable')->willReturn(true);
+        $this->videoDownloader->method('download')->willReturn('42/100/video.mp4');
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertSame('42/100/video.mp4', $item->getVideoPath());
+        $this->assertSame('pending', $item->getTranscriptStatus());
+    }
+
+    public function testVideoDownloadDoesNotQueueTranscriptionWhenDisabled(): void
+    {
+        $item = $this->createItem();
+
+        $this->extractor->method('extractPhotoUrls')->willReturn([]);
+        $this->extractor->method('extractVideoUrl')->willReturn('https://example.com/post/1');
+        $this->videoDownloader->method('isAvailable')->willReturn(true);
+        $this->videoDownloader->method('download')->willReturn('42/100/video.mp4');
+
+        $this->service->downloadMedia($item);
+
+        $this->assertSame('completed', $item->getMediaStatus());
+        $this->assertNull($item->getTranscriptStatus());
+    }
+
     public function testQueueItemSetsPendingAndClearsError(): void
     {
         $item = $this->createItem();

--- a/tests/Transcription/TranscriptionServiceTest.php
+++ b/tests/Transcription/TranscriptionServiceTest.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Transcription;
+
+use App\Entity\Item;
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\Repository\ItemRepository;
+use App\Transcription\TranscriptionService;
+use App\Transcription\WhisperTranscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class TranscriptionServiceTest extends TestCase
+{
+    private WhisperTranscriber $whisperTranscriber;
+    private EntityManagerInterface $em;
+    private ItemRepository $itemRepository;
+    private TranscriptionService $service;
+
+    protected function setUp(): void
+    {
+        $this->whisperTranscriber = $this->createMock(WhisperTranscriber::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->itemRepository = $this->createMock(ItemRepository::class);
+
+        $this->service = new TranscriptionService(
+            $this->whisperTranscriber,
+            $this->em,
+            $this->itemRepository,
+        );
+    }
+
+    private function createItem(bool $withVideo = true): Item
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setNetwork(new Network());
+        $profile->setIdentifier('test');
+
+        $item = new Item();
+        $ref = new \ReflectionProperty(Item::class, 'id');
+        $ref->setValue($item, 100);
+        $item->setProfile($profile);
+
+        if ($withVideo) {
+            $item->setVideoPath('42/100/video.mp4');
+        }
+
+        return $item;
+    }
+
+    public function testTranscribeSetsCompletedTranscript(): void
+    {
+        $item = $this->createItem();
+
+        $this->whisperTranscriber->expects($this->once())
+            ->method('transcribe')
+            ->with('42/100/video.mp4', 42, 100)
+            ->willReturn('Hallo Welt');
+
+        $this->em->expects($this->exactly(2))->method('flush');
+
+        $this->service->transcribe($item);
+
+        $this->assertSame('completed', $item->getTranscriptStatus());
+        $this->assertSame('Hallo Welt', $item->getTranscript());
+        $this->assertNull($item->getTranscriptError());
+    }
+
+    public function testTranscribeSetsFailedOnError(): void
+    {
+        $item = $this->createItem();
+
+        $this->whisperTranscriber->method('transcribe')
+            ->willThrowException(new \RuntimeException('whisper.cpp failed'));
+
+        $this->service->transcribe($item);
+
+        $this->assertSame('failed', $item->getTranscriptStatus());
+        $this->assertStringContainsString('whisper.cpp failed', (string) $item->getTranscriptError());
+        $this->assertNull($item->getTranscript());
+    }
+
+    public function testTranscribeSkipsItemWithoutVideo(): void
+    {
+        $item = $this->createItem(withVideo: false);
+        $item->setTranscriptStatus('pending');
+
+        $this->whisperTranscriber->expects($this->never())->method('transcribe');
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->transcribe($item);
+
+        $this->assertNull($item->getTranscriptStatus());
+    }
+
+    public function testTranscribeSkipsItemWithoutProfile(): void
+    {
+        $item = new Item();
+
+        $this->whisperTranscriber->expects($this->never())->method('transcribe');
+
+        $this->service->transcribe($item);
+
+        $this->assertNull($item->getTranscriptStatus());
+    }
+
+    public function testQueueItemSetsPendingAndClearsError(): void
+    {
+        $item = $this->createItem();
+        $item->setTranscriptStatus('failed');
+        $item->setTranscriptError('boom');
+
+        $this->em->expects($this->once())->method('flush');
+
+        $this->service->queueItem($item);
+
+        $this->assertSame('pending', $item->getTranscriptStatus());
+        $this->assertNull($item->getTranscriptError());
+    }
+
+    public function testQueueProfileQueuesTranscribableItems(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+
+        $a = $this->createItem();
+        $b = $this->createItem();
+
+        $this->itemRepository->expects($this->once())
+            ->method('findTranscribableForProfile')
+            ->with($profile)
+            ->willReturn([$a, $b]);
+        $this->itemRepository->expects($this->never())->method('findBy');
+        $this->em->expects($this->once())->method('flush');
+
+        $count = $this->service->queueProfile($profile);
+
+        $this->assertSame(2, $count);
+        $this->assertSame('pending', $a->getTranscriptStatus());
+        $this->assertSame('pending', $b->getTranscriptStatus());
+    }
+
+    public function testQueueProfileWithForceQueuesAllVideoItems(): void
+    {
+        $profile = new Profile();
+        $profile->setId(42);
+        $profile->setIdentifier('test');
+        $profile->setNetwork(new Network());
+
+        $withVideo = $this->createItem();
+        $withoutVideo = $this->createItem(withVideo: false);
+
+        $this->itemRepository->expects($this->once())
+            ->method('findBy')
+            ->with(['profile' => $profile])
+            ->willReturn([$withVideo, $withoutVideo]);
+        $this->itemRepository->expects($this->never())->method('findTranscribableForProfile');
+
+        $count = $this->service->queueProfile($profile, force: true);
+
+        $this->assertSame(1, $count);
+        $this->assertSame('pending', $withVideo->getTranscriptStatus());
+        $this->assertNull($withoutVideo->getTranscriptStatus());
+    }
+
+    public function testTranscribePendingItems(): void
+    {
+        $item = $this->createItem();
+        $item->setTranscriptStatus('pending');
+
+        $this->itemRepository->expects($this->once())
+            ->method('findBy')
+            ->with(['transcriptStatus' => 'pending'], ['id' => 'ASC'], null)
+            ->willReturn([$item]);
+
+        $this->whisperTranscriber->method('transcribe')->willReturn('Text');
+
+        $count = $this->service->transcribePendingItems();
+
+        $this->assertSame(1, $count);
+        $this->assertSame('completed', $item->getTranscriptStatus());
+        $this->assertSame('Text', $item->getTranscript());
+    }
+}


### PR DESCRIPTION
## Was

Profile können ihre heruntergeladenen Videos automatisch lokal per [whisper.cpp](https://github.com/ggml-org/whisper.cpp) transkribieren lassen (neues Flag `transcribeVideos`, nur zusammen mit `saveVideos` sinnvoll). Die Transkription läuft entkoppelt vom Fetch/Download über eine `transcriptStatus`-Queue (`null → pending → running → completed/failed`), analog zur Media-Download-Queue.

## Änderungen

- **`WhisperTranscriber` / `TranscriptionService`** (`src/Transcription/`) — ffmpeg-WAV-Extraktion, whisper.cpp-CLI-Aufruf, Status-Lifecycle; `isAvailable()` meldet sauber `false`, wenn Binary/Modell/ffmpeg fehlen
- **`app:transcribe`** — CLI mit `--profile-id` / `--item-id` / `--pending` / `--retry-failed`
- **Auto-Queue** nach Video-Download bei aktivem `transcribeVideos`
- **API**: `POST /api/profiles|items/{id}/transcribe` (202, client-scoped) via `Profile`/`ItemTranscriptionProcessor`
- Transkript auf der Item-Detailseite (Web-UI) und im Single-Item-API-GET
- Migration `Version20260707120000` (transcript-Spalten, Schema-API/MySQL-kompatibel)
- Env: `WHISPER_CLI_PATH` / `WHISPER_MODEL_PATH` / `WHISPER_LANGUAGE`

## Tests

`bin/phpunit` grün. whisper.cpp-Binary + ggml-Modell sind ein manueller Server-Install (leerer Modell-Pfad deaktiviert die Transkription).

## Ops-Hinweis

Auf Prod muss `app:transcribe --pending` per Cron laufen (neben `app:download-media --pending`), und whisper.cpp/ffmpeg müssen installiert sein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)