### PR TITLE
Add Web-UI surface tests for profile identifier change

### DIFF
--- a/src/DataFixtures/TestFixtures.php
+++ b/src/DataFixtures/TestFixtures.php
@@ -23,6 +23,8 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
         $networkMastodon = $this->getReference(NetworkFixtures::NETWORK_MASTODON, Network::class);
         /** @var Network $networkBluesky */
         $networkBluesky = $this->getReference(NetworkFixtures::NETWORK_BLUESKY_PROFILE, Network::class);
+        /** @var Network $networkInstagram */
+        $networkInstagram = $this->getReference(NetworkFixtures::NETWORK_INSTAGRAM_PROFILE, Network::class);
 
         // --- Clients ---
         $clientA = new Client();
@@ -70,6 +72,18 @@ class TestFixtures extends Fixture implements DependentFixtureInterface
         $profileOnlyB->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($profileOnlyB);
         $clientB->addProfile($profileOnlyB);
+
+        // RSS.app-based profile, intentionally linked to NO client and carrying NO items,
+        // so it stays invisible to the client-scoped API/timeline (keeping those tests
+        // untouched) while remaining reachable by the admin Web UI. Used to exercise the
+        // RSS.app feed re-link path on an identifier change.
+        $profileInstagram = new Profile();
+        $profileInstagram->setId(90005);
+        $profileInstagram->setIdentifier('https://www.instagram.com/oldname/');
+        $profileInstagram->setNetwork($networkInstagram);
+        $profileInstagram->setCreatedAt(new \DateTimeImmutable());
+        $profileInstagram->setRssAppFeedId('fixture-feed-instagram');
+        $manager->persist($profileInstagram);
 
         $profileDeleted = new Profile();
         $profileDeleted->setId(90004);

--- a/tests/Functional/AbstractWebTestCase.php
+++ b/tests/Functional/AbstractWebTestCase.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\DataFixtures\NetworkFixtures;
+use App\DataFixtures\TestFixtures;
+use App\Security\WebUserProvider;
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Base class for admin Web-UI (browser) functional tests. Boots a KernelBrowser,
+ * loads the shared test fixtures, and offers a helper to authenticate as the
+ * in-memory admin (ROLE_ADMIN) that guards the `/` firewall.
+ */
+abstract class AbstractWebTestCase extends WebTestCase
+{
+    protected KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->loadFixtures();
+    }
+
+    protected function loginAsAdmin(): void
+    {
+        // Load the exact user the WebUserProvider will return on refresh — a
+        // hand-built InMemoryUser with a different password would be treated as
+        // "user changed" and deauthenticated on the next request.
+        /** @var WebUserProvider $provider */
+        $provider = static::getContainer()->get(WebUserProvider::class);
+        $this->client->loginUser($provider->loadUserByIdentifier('admin'), 'main');
+    }
+
+    protected function entityManager(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine.orm.entity_manager');
+
+        return $em;
+    }
+
+    private function loadFixtures(): void
+    {
+        $loader = new Loader();
+        $loader->addFixture(new NetworkFixtures());
+        $loader->addFixture(new TestFixtures());
+
+        $purger = new ORMPurger($this->entityManager());
+        $executor = new ORMExecutor($this->entityManager(), $purger);
+        $executor->execute($loader->getFixtures());
+    }
+}

--- a/tests/Functional/Web/ProfileChangeIdentifierWebTest.php
+++ b/tests/Functional/Web/ProfileChangeIdentifierWebTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * Surface (browser) tests for the admin Web-UI "Identifier ändern" flow on the
+ * profile detail page: rendering, the happy path, every validation branch, the
+ * RSS.app re-link path, CSRF protection and authentication.
+ */
+class ProfileChangeIdentifierWebTest extends AbstractWebTestCase
+{
+    private const MASTODON_ID = 90001;                       // https://mastodon.social/@shared (non-RSS)
+    private const MASTODON_IDENTIFIER = 'https://mastodon.social/@shared';
+    private const INSTAGRAM_ID = 90005;                      // https://www.instagram.com/oldname/ (RSS.app)
+    private const INSTAGRAM_IDENTIFIER = 'https://www.instagram.com/oldname/';
+
+    public function testShowPageRendersChangeIdentifierCardWithCurrentIdentifier(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->client->request('GET', '/profiles/' . self::MASTODON_ID);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', 'Identifier ändern');
+
+        $input = $crawler->filter($this->formSelector(self::MASTODON_ID) . ' input[name="identifier"]');
+        self::assertCount(1, $input, 'The change-identifier form input should be rendered.');
+        self::assertSame(self::MASTODON_IDENTIFIER, $input->attr('value'));
+    }
+
+    public function testChangeIdentifierSuccessOnNonRssNetwork(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->submitIdentifierChange(self::MASTODON_ID, 'https://mastodon.social/@renamed');
+
+        self::assertSelectorExists('.alert-success');
+        self::assertSelectorTextContains('.alert', 'Identifier wurde aktualisiert.');
+        self::assertSame('https://mastodon.social/@renamed', $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierRejectsInvalidValue(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->submitIdentifierChange(self::MASTODON_ID, 'not-a-valid-mastodon-handle');
+
+        self::assertSelectorExists('.alert-danger');
+        self::assertSelectorTextContains('.alert', 'kein gültiger Identifier');
+        self::assertSame(self::MASTODON_IDENTIFIER, $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierRejectsEmptyValue(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->submitIdentifierChange(self::MASTODON_ID, '   ');
+
+        self::assertSelectorExists('.alert-danger');
+        self::assertSelectorTextContains('.alert', 'darf nicht leer sein');
+        self::assertSame(self::MASTODON_IDENTIFIER, $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierRejectsDuplicateInSameNetwork(): void
+    {
+        $this->loginAsAdmin();
+
+        // @onlyb already exists as profile 90003 on the mastodon network.
+        $crawler = $this->submitIdentifierChange(self::MASTODON_ID, 'https://mastodon.social/@onlyb');
+
+        self::assertSelectorExists('.alert-danger');
+        self::assertSelectorTextContains('.alert', 'existiert bereits');
+        self::assertSame(self::MASTODON_IDENTIFIER, $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierUnchangedReportsNoChange(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->submitIdentifierChange(self::MASTODON_ID, self::MASTODON_IDENTIFIER);
+
+        self::assertSelectorTextContains('.alert', 'Identifier unverändert.');
+        self::assertSame(self::MASTODON_IDENTIFIER, $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierRelinksRssAppFeed(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->submitIdentifierChange(self::INSTAGRAM_ID, 'https://www.instagram.com/newname/');
+
+        self::assertSelectorExists('.alert-success');
+        self::assertSelectorTextContains('.alert', 'neuer RSS.app-Feed');
+        self::assertSame('https://www.instagram.com/newname/', $this->renderedIdentifier($crawler, self::INSTAGRAM_ID));
+
+        // The stub RSS.app client creates a fresh feed ("null-feed-id"); the old
+        // fixture feed id must have been replaced.
+        $this->entityManager()->clear();
+        $profile = $this->entityManager()->getRepository(Profile::class)->find(self::INSTAGRAM_ID);
+        self::assertNotNull($profile);
+        self::assertSame('null-feed-id', $profile->getRssAppFeedId());
+    }
+
+    public function testChangeIdentifierWithInvalidCsrfTokenIsIgnored(): void
+    {
+        $this->loginAsAdmin();
+
+        $this->client->request('POST', '/profiles/' . self::MASTODON_ID . '/change-identifier', [
+            'identifier' => 'https://mastodon.social/@hacked',
+            '_token' => 'invalid-token',
+        ]);
+
+        self::assertResponseRedirects('/profiles/' . self::MASTODON_ID);
+        $crawler = $this->client->followRedirect();
+
+        self::assertSelectorNotExists('.alert-success');
+        self::assertSame(self::MASTODON_IDENTIFIER, $this->renderedIdentifier($crawler, self::MASTODON_ID));
+    }
+
+    public function testChangeIdentifierRequiresAdminAuthentication(): void
+    {
+        // Not logged in — the main firewall must bounce to the login form.
+        $this->client->request('POST', '/profiles/' . self::MASTODON_ID . '/change-identifier', [
+            'identifier' => 'https://mastodon.social/@anon',
+            '_token' => 'whatever',
+        ]);
+
+        self::assertResponseStatusCodeSame(302);
+        self::assertStringContainsString('/login', (string) $this->client->getResponse()->headers->get('Location'));
+
+        // And the identifier is untouched.
+        $this->entityManager()->clear();
+        $profile = $this->entityManager()->getRepository(Profile::class)->find(self::MASTODON_ID);
+        self::assertSame(self::MASTODON_IDENTIFIER, $profile?->getIdentifier());
+    }
+
+    /**
+     * Loads the profile page, fills the "Identifier ändern" form (which carries a
+     * valid CSRF token) with $newIdentifier, submits it and follows the redirect
+     * back to the show page. Returns the resulting crawler.
+     */
+    private function submitIdentifierChange(int $profileId, string $newIdentifier): \Symfony\Component\DomCrawler\Crawler
+    {
+        $crawler = $this->client->request('GET', '/profiles/' . $profileId);
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter($this->formSelector($profileId))->form();
+        $form['identifier'] = $newIdentifier;
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/profiles/' . $profileId);
+
+        return $this->client->followRedirect();
+    }
+
+    private function renderedIdentifier(\Symfony\Component\DomCrawler\Crawler $crawler, int $profileId): string
+    {
+        return $crawler->filter($this->formSelector($profileId) . ' input[name="identifier"]')->attr('value');
+    }
+
+    private function formSelector(int $profileId): string
+    {
+        return sprintf('form[action="/profiles/%d/change-identifier"]', $profileId);
+    }
+}


### PR DESCRIPTION
## Was

Ausführliche **Oberflächentests** (Browser/`WebTestCase`) für den Admin-Web-UI-Flow „Identifier ändern" auf der Profil-Detailseite. Ergänzt die bereits vorhandenen Unit- und API-Tests des Features (PR #102, gemergt) um die tatsächlich gerenderte Oberfläche.

## Abgedeckte Fälle

Jeder Test treibt die **gerenderte Seite** und schickt das Formular inkl. gültigem CSRF-Token ab:

- Karte „Identifier ändern" wird mit aktuellem Identifier gerendert
- Erfolg auf Nicht-RSS-Netzwerk (Success-Flash + aktualisierter Wert)
- ungültiger / leerer / doppelter Identifier → Danger-Flash, Identifier unverändert
- unveränderter Identifier → „unverändert"-Meldung
- RSS.app-Netzwerk: Feed wird neu verknüpft (neue Feed-ID via Stub), Flash bestätigt es
- ungültiges CSRF-Token wird ignoriert (keine Änderung)
- nicht angemeldete Requests werden zum Login umgeleitet

## Infrastruktur

- **`AbstractWebTestCase`** — `KernelBrowser` + Fixtures + Admin-Login-Helfer (lädt den echten Admin-User aus dem `WebUserProvider`, sonst würde der Token beim Refresh als „user changed" verworfen)
- Neues Fixture-Profil **90005** (Instagram) — bewusst **ohne Client und ohne Items**, damit es für die client-gescopte API/Timeline unsichtbar bleibt und bestehende Tests unberührt lässt

## Tests

`bin/phpunit` grün (258 Tests, 9 neue). Keine bestehenden Tests betroffen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)