### PR TITLE
Fix 500 on group show page with paginated items

### DIFF
--- a/templates/_partials/_pagination.html.twig
+++ b/templates/_partials/_pagination.html.twig
@@ -1,8 +1,12 @@
 {% if pages > 1 %}
+{# Keep the current route's path parameters (e.g. the group id on app_group_show)
+   alongside the query string, otherwise regenerating the route drops required
+   path params and throws MissingMandatoryParametersException. #}
+{% set base_params = app.request.attributes.get('_route_params')|default({})|merge(app.request.query.all) %}
 <nav aria-label="Seitennavigation">
     <ul class="pagination justify-content-center">
         <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-            <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({page: page - 1})) }}">
+            <a class="page-link" href="{{ path(app.request.attributes.get('_route'), base_params|merge({page: page - 1})) }}">
                 <i class="fas fa-chevron-left"></i>
             </a>
         </li>
@@ -11,14 +15,14 @@
                 <li class="page-item active"><span class="page-link">{{ p }}</span></li>
             {% elseif p <= 3 or p > pages - 2 or (p >= page - 1 and p <= page + 1) %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({page: p})) }}">{{ p }}</a>
+                    <a class="page-link" href="{{ path(app.request.attributes.get('_route'), base_params|merge({page: p})) }}">{{ p }}</a>
                 </li>
             {% elseif p == 4 or p == pages - 2 %}
                 <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
             {% endif %}
         {% endfor %}
         <li class="page-item {% if page >= pages %}disabled{% endif %}">
-            <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({page: page + 1})) }}">
+            <a class="page-link" href="{{ path(app.request.attributes.get('_route'), base_params|merge({page: page + 1})) }}">
                 <i class="fas fa-chevron-right"></i>
             </a>
         </li>

--- a/tests/Functional/Group/GroupShowPaginationWebTest.php
+++ b/tests/Functional/Group/GroupShowPaginationWebTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Group;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Item;
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * Regression test: the group show page renders a pagination bar once a group has
+ * more than one page of items. The shared _pagination partial regenerates the
+ * current route from the query string only, so it must also carry the route's
+ * path parameters (the group id) — otherwise app_group_show cannot be generated
+ * and the whole page 500s with MissingMandatoryParametersException.
+ */
+class GroupShowPaginationWebTest extends AbstractWebTestCase
+{
+    public function testShowRendersPaginationForMultiPageGroup(): void
+    {
+        $group = $this->createGroupWithItems(60);
+
+        $this->loginAsAdmin();
+        $this->client->request('GET', sprintf('/groups/%d', $group->getId()));
+
+        // Before the fix this returned 500 (missing "id" for app_group_show).
+        self::assertResponseIsSuccessful();
+        // Pagination links must keep the group id in the path, not drop it.
+        self::assertSelectorExists(
+            sprintf('.pagination a[href*="/groups/%d?"][href*="page=2"]', $group->getId()),
+        );
+    }
+
+    private function createGroupWithItems(int $itemCount): Group
+    {
+        $em = $this->entityManager();
+
+        /** @var Client $client */
+        $client = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        /** @var Profile $profile */
+        $profile = $em->getRepository(Profile::class)->find(90001);
+
+        $group = new Group();
+        $group->setName('Pagination Group');
+        $group->setClient($client);
+        $group->setCreatedAt(new \DateTimeImmutable());
+        $group->addProfile($profile);
+        $em->persist($group);
+
+        $now = new \DateTimeImmutable();
+        for ($i = 0; $i < $itemCount; ++$i) {
+            $item = new Item();
+            $item->setProfile($profile);
+            $item->setUniqueIdentifier(sprintf('pagination-item-%d', $i));
+            $item->setPermalink(sprintf('https://mastodon.social/@shared/pagination-%d', $i));
+            $item->setText(sprintf('Pagination item %d', $i));
+            $item->setDateTime($now->modify(sprintf('-%d minutes', $i)));
+            $em->persist($item);
+        }
+
+        $em->flush();
+
+        return $group;
+    }
+}


### PR DESCRIPTION
## Problem

Die Gruppen-Detailseite (`/groups/{id}`) liefert einen **500 Internal Server Error**, sobald eine Gruppe mehr als eine Seite Items hat (>50). Aufgetreten live bei Gruppe 2 („Wahlkampf-Dashboard Lüneburg", 503 Items → 26 Seiten).

## Ursache

Das geteilte Partial `templates/_partials/_pagination.html.twig` erzeugt die Seiten-Links nur aus dem Query-String (`app.request.query.all`). Für die Route `app_group_show` fehlt damit der Pflicht-Pfadparameter `id` → `MissingMandatoryParametersException` beim Rendern.

Die Index-Seiten (Items/Profile/Gruppen-Liste) sind nicht betroffen, weil deren Routen keinen Pflicht-Pfadparameter haben.

## Fix

Beim Regenerieren der Route werden jetzt die Pfad-Parameter der aktuellen Route (`_route_params`, z. B. `id`) zusätzlich zum Query-String mitgegeben. Rückwärtskompatibel: Bei Routen ohne Pfad-Parameter ist `_route_params` leer.

## Test

Neuer Regressionstest `tests/Functional/Group/GroupShowPaginationWebTest.php`: legt eine Gruppe mit >1 Seite Items an und prüft, dass `/groups/{id}` mit 200 antwortet und die Pagination-Links die Gruppen-`id` behalten. Red-green verifiziert (ohne Fix: 500, mit Fix: 200). Gesamte Suite grün (269 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)