### PR TITLE
Public group page: unauthenticated photo+text feed at /p/{slug}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Network fetchers are auto-discovered: any class implementing `NetworkFeedFetcher
 - **Item** — Feed item: `id`, `profile` (FK), `uniqueIdentifier`, `text`, `title`, `dateTime`, `permalink`, `raw`, `hidden`, `deleted`, `photoPaths` (JSON array), `videoPath`, `mediaStatus`, `mediaError`, `transcript` (text), `transcriptStatus`, `transcriptError`. Supports soft-delete, hide toggles, media downloads, and video transcription.
 - **Network** — Social network definition: `id`, `identifier`, `name`, `icon`, `backgroundColor`, `textColor`, `cronExpression`.
 - **Client** — API client: `id`, `name`, `token`, `enabled`, `profiles` (ManyToMany via `client_profile` join table), `createdAt`.
-- **Group** — Named bundle of a client's profiles (table `profile_group`, unique `(client_id, name)`): `id`, `name`, `description`, `color`, `client` (ManyToOne, NOT NULL — a group belongs to exactly one client, unlike shared profiles), `profiles` (ManyToMany via `profile_group_profile`), `createdAt`. Serialization groups `group:read` (incl. `profileCount`), `group:detail` (embeds `profiles`), `group:write`. Used to read a combined feed per group.
+- **Group** — Named bundle of a client's profiles (table `profile_group`, unique `(client_id, name)`): `id`, `name`, `description`, `color`, `client` (ManyToOne, NOT NULL — a group belongs to exactly one client, unlike shared profiles), `profiles` (ManyToMany via `profile_group_profile`), `createdAt`. Also carries the **public page** config: `publicPageEnabled`, `publicSlug` (unique), `publicPasswordHash`, `publicTitle`, `publicDescription`, `showPhotos`, `showVideos`, `showTranscript`, `showCaptions`, `timeWindowDays`. Serialization groups `group:read` (incl. `profileCount`, `publicUrl`, `publicPasswordProtected`), `group:detail` (embeds `profiles`), `group:write` (incl. write-only `publicPassword`). Used to read a combined feed per group. See "Public Group Page" below.
 
 ### Media Download System
 
@@ -126,6 +126,19 @@ When an account is renamed (e.g. a new Instagram username), the profile's `ident
 - **Web UI**: "Identifier ändern" card on the profile show page → `POST /profiles/{id}/change-identifier` (`ProfileController::changeIdentifier`).
 - **API**: `POST /api/profiles/{id}/change-identifier` (body `{"identifier": "…"}`) via `ProfileChangeIdentifierProcessor` (200, client-scoped; 422 on invalid/duplicate identifier). The generic `PATCH`/`PUT` still change `identifier` as a plain field **without** RSS.app re-linking — use the dedicated action to re-link.
 
+### Public Group Page
+
+A group can expose an unauthenticated, mobile-first feed page (Instagram-style
+single column) at `/p/{publicSlug}`, configurable per group.
+
+- **`Group` public-page fields** (see the entity above): `publicPageEnabled` gates reachability, `publicSlug` (unique, unguessable) is the URL token, `publicPasswordHash` an optional password, `publicTitle`/`publicDescription` the heading, `showPhotos`/`showVideos`/`showTranscript`/`showCaptions` the content toggles, `timeWindowDays` the look-back window (null = all).
+- **`PublicSlugGenerator`** (`src/Group/`) — 16-char base62 slug, collision-checked against `public_slug`. A slug is generated automatically the first time the page is enabled (Web-UI controller and API processor); it is never overwritten on later edits and can be rotated via the regenerate action.
+- **`PublicGroupController`** (`/p/{slug}`, no auth) — `page` renders the feed, `more` returns the next infinite-scroll fragment, `unlock` handles the password gate (verified password stored in the session). **Media/caption exposure is decided server-side** in `buildViewItems()` — disabled photos/videos/transcripts never reach the browser. Uses `ItemRepository::findPaginatedForPublicGroup()` / `countForPublicGroup()` (live members, hidden/deleted excluded, optional time window). 404 when the group is missing or its page is disabled.
+- **Security**: `/p/` is opened as `PUBLIC_ACCESS` in `security.yaml` (before the admin catch-all). Password-protected pages are gated purely in the controller via a session flag — no user/login system.
+- **Rendering**: standalone Twig under `templates/public/` (`base` with its own light/dark CSS, `group`, `_cards`, `_card`, `password`), a dedicated `public` importmap entrypoint (`assets/public.js`) that boots only the `public_feed` Stimulus controller (infinite scroll + "… mehr" caption clamp), and the `public_linkify` Twig filter (`src/Twig/`, escapes then linkifies URLs/hashtags/mentions).
+- **Admin Web-UI**: "Öffentliche Seite" section in `GroupType` (enable, title, description, time window, content toggles, optional password with a remove toggle — a blank password field keeps the existing one), a status/URL card on the group show page, and `POST /groups/{id}/regenerate-slug`.
+- **REST API**: the public-page fields are in `group:read`/`group:write`; `publicPassword` is write-only (hashed by the entity, never returned) and `publicUrl` is a computed absolute URL added by `GroupPublicUrlNormalizer`. Enabling the page via POST/PUT/PATCH auto-generates the slug; PUT preserves the non-writable slug.
+
 ### Serializer
 
 Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `NullableDateTimeNormalizer` to handle null values and Unix timestamps from the API. CamelCase-to-snake_case name conversion. `SKIP_NULL_VALUES` on serialization.
@@ -144,9 +157,9 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 ### Web UI
 
 - **Authentication**: Form login at `/login`, in-memory admin user via `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD_HASH` env vars, implemented in `WebUserProvider`
-- **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `LoginController`
+- **Controllers**: `DashboardController`, `NetworkController`, `ProfileController`, `ItemController`, `ClientController`, `GroupController`, `LoginController`. `PublicGroupController` serves the unauthenticated public group page at `/p/{slug}` (see "Public Group Page").
 - **Frontend stack**: Bootstrap 5.3, Stimulus controllers, Handlebars templates, Symfony Asset Mapper (no build step)
-- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`, `media_download_controller`
+- **Stimulus controllers** (`assets/controllers/`): `profile_list_controller`, `item_list_controller`, `profile_fetch_controller`, `profile_toggle_controller`, `toggle_controller`, `confirm_controller`, `flash_controller`, `media_download_controller`, `public_feed_controller` (public group page, loaded via the separate `public` importmap entrypoint)
 - **CSS**: Custom design system in `assets/styles/app.css` (dark sidebar, stat cards, network cards, data tables)
 - **AJAX patterns**: Profile and item lists use Stimulus + Handlebars for client-side rendering with AJAX pagination, search, and filtering. Controllers return JSON when `X-Requested-With: XMLHttpRequest` header is present.
 
@@ -159,7 +172,7 @@ Custom `App\Serializer\Serializer` (not Symfony's framework serializer). Uses `N
 - `POST /api/profiles/{id}/change-identifier`: change a profile's identifier (body `{"identifier": "…"}`), re-linking the RSS.app feed for RSS.app networks (200, client-scoped, `ProfileChangeIdentifierProcessor`). See "Changing a Profile Identifier" below
 - `POST /api/profiles/{id}/download-media` and `POST /api/items/{id}/download-media`: queue media (re)download (202, client-scoped, drained by `app:download-media --pending`)
 - `POST /api/profiles/{id}/transcribe` and `POST /api/items/{id}/transcribe`: queue video (re)transcription (202, client-scoped, require `transcribeVideos`, drained by `app:transcribe --pending`)
-- Groups: full CRUD `GET/POST/PUT/PATCH/DELETE /api/groups[/{id}]` (writes via `ClientScopedGroupProcessor`, GET scoped by `ClientScopedGroupExtension`). Membership convenience routes `POST /api/groups/{id}/profiles` + `DELETE /api/groups/{id}/profiles/{profileId}` in `GroupMembershipController`. Combined feed `GET /api/groups/{groupId}/items` via `GroupItemsProvider` (filters since/until/network, excludes hidden/deleted), plus RSS at `GET /api/feeds/groups/{id}.rss`. Referenced profiles must belong to the client (400); foreign groups 404.
+- Groups: full CRUD `GET/POST/PUT/PATCH/DELETE /api/groups[/{id}]` (writes via `ClientScopedGroupProcessor`, GET scoped by `ClientScopedGroupExtension`). Membership convenience routes `POST /api/groups/{id}/profiles` + `DELETE /api/groups/{id}/profiles/{profileId}` in `GroupMembershipController`. Combined feed `GET /api/groups/{groupId}/items` via `GroupItemsProvider` (filters since/until/network, excludes hidden/deleted), plus RSS at `GET /api/feeds/groups/{id}.rss`. Public-page settings (incl. write-only `publicPassword`, computed `publicUrl`) are read/written on the same resource — see "Public Group Page". Referenced profiles must belong to the client (400); foreign groups 404.
 - Networks: public read access
 - OpenAPI docs at `/api/docs`
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The admin interface is accessible after login at `/login`. It provides:
 - **Profiles** — Searchable/filterable list with auto-fetch toggle, save photos/videos toggles, fetch status, manual fetch trigger, RSS.app registration
 - **RSS.app** — Overview of all profiles linked to an RSS.app feed (sortable DataTable), showing feed ID and last-post date. Per-row button to delete the feed at RSS.app and unlink it locally.
 - **Items** — Searchable/filterable list with hide/delete toggles, media status indicators, network and profile filters, manual media download
+- **Groups** — Bundle a client's profiles, read their combined timeline, and configure a public feed page (`/p/{slug}`) with content toggles and an optional password
 - **Clients** — API client management with token display, enable/disable
 
 The frontend uses Bootstrap 5, Stimulus controllers for interactive features (toggles, AJAX pagination, search), Handlebars for client-side template rendering, and DataTables for client-side sortable tables (RSS.app overview). Assets are managed via Symfony Asset Mapper (no build step needed).
@@ -249,6 +250,20 @@ Media downloads triggered via the API are processed asynchronously by the `app:d
 - `GET /api/feeds/groups/{id}.rss` — The same feed as RSS 2.0
 
   Every profile referenced when creating/updating a group or adding members must already be linked to the authenticated client (otherwise `400`); foreign or unknown groups return `404`.
+
+  A group can also expose a **public page** (see below). The public-page settings are read/written on the same group resource: `publicPageEnabled`, `publicTitle`, `publicDescription`, `showPhotos`, `showVideos`, `showTranscript`, `showCaptions`, `timeWindowDays`, and the write-only `publicPassword` (send `""` to remove it, never returned). The response carries the generated `publicSlug`, the absolute `publicUrl`, and `publicPasswordProtected`. Enabling the page generates the slug automatically.
+
+### Public group page
+
+Each group can be published as an unauthenticated, mobile-first feed page at `/p/{slug}` (Instagram-style single column with photos, videos, transcripts and captions). Configure it in the group's settings in the Web UI (or via the API):
+
+- **Enable / disable** the page and set an optional **title** and **description**.
+- **Content toggles**: show photos, show videos, show video transcription, show captions.
+- **Time window**: how many days back to show (empty = all).
+- **Optional password**: protects the page behind an unlock form.
+- The URL uses an unguessable slug; the *"Link neu erzeugen"* action rotates it (invalidating the old link).
+
+Disabled media is filtered out server-side, so e.g. an unpublished transcript is never sent to the browser.
 
 **Timeline**:
 - `GET /api/timeline` — Chronological feed (default: last 24h, max 100 items)

--- a/assets/controllers/public_feed_controller.js
+++ b/assets/controllers/public_feed_controller.js
@@ -1,0 +1,97 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+ * Drives the public group feed page: infinite-scroll pagination against
+ * /p/{slug}/more and the "… mehr" caption clamp toggle. Media gating happens
+ * server-side, so this controller only deals with layout/interaction.
+ */
+export default class extends Controller {
+    static targets = ['feed', 'sentinel'];
+    static values = {
+        url: String,
+        page: Number,
+        hasMore: Boolean,
+    };
+
+    connect() {
+        this.loading = false;
+        this.setupClamps(this.feedTarget);
+
+        if (this.hasSentinelTarget && this.hasMoreValue) {
+            this.observer = new IntersectionObserver(
+                (entries) => entries.forEach((e) => e.isIntersecting && this.loadMore()),
+                { rootMargin: '400px' },
+            );
+            this.observer.observe(this.sentinelTarget);
+        }
+    }
+
+    disconnect() {
+        if (this.observer) this.observer.disconnect();
+    }
+
+    async loadMore() {
+        if (this.loading || !this.hasMoreValue) return;
+        this.loading = true;
+
+        const nextPage = this.pageValue + 1;
+        try {
+            const res = await fetch(`${this.urlValue}?page=${nextPage}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+            const html = await res.text();
+            const tmp = document.createElement('div');
+            tmp.innerHTML = html;
+
+            const meta = tmp.querySelector('[data-more-meta]');
+            const stillMore = meta ? meta.dataset.hasMore === '1' : false;
+            if (meta) meta.remove();
+
+            this.dedupeLeadingDayHeading(tmp);
+            this.setupClamps(tmp);
+
+            while (tmp.firstChild) this.feedTarget.appendChild(tmp.firstChild);
+
+            this.pageValue = nextPage;
+            this.hasMoreValue = stillMore;
+            if (!stillMore && this.observer) this.observer.disconnect();
+        } catch (e) {
+            // Stop trying on error; the user can reload the page.
+            if (this.observer) this.observer.disconnect();
+            this.hasMoreValue = false;
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    // Drop a leading day heading in the freshly loaded fragment when it repeats
+    // the last heading already visible (page boundary inside the same day).
+    dedupeLeadingDayHeading(fragment) {
+        const first = fragment.querySelector('.day-heading');
+        if (!first) return;
+
+        const existing = this.feedTarget.querySelectorAll('.day-heading');
+        const last = existing[existing.length - 1];
+        if (last && last.textContent.trim() === first.textContent.trim()) {
+            first.remove();
+        }
+    }
+
+    setupClamps(scope) {
+        scope.querySelectorAll('.caption.clamp').forEach((cap) => {
+            const more = cap.parentElement.querySelector('.more');
+            if (!more) return;
+            requestAnimationFrame(() => {
+                if (cap.scrollHeight - cap.clientHeight > 4) {
+                    more.hidden = false;
+                    more.addEventListener('click', () => {
+                        cap.classList.remove('clamp');
+                        more.hidden = true;
+                    });
+                }
+            });
+        });
+    }
+}

--- a/assets/public.js
+++ b/assets/public.js
@@ -1,0 +1,4 @@
+// Minimal entrypoint for the public group feed page. Boots Stimulus (which
+// auto-registers the public_feed controller) without pulling in the admin
+// Bootstrap/DataTables bundle — the public page ships its own self-contained CSS.
+import './stimulus_bootstrap.js';

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -45,6 +45,8 @@ security:
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: ROLE_API_CLIENT }
         - { path: ^/login, roles: PUBLIC_ACCESS }
+        # Public per-group feed pages are reachable without authentication.
+        - { path: ^/p/, roles: PUBLIC_ACCESS }
         # Group management is available to both admins and client-token users.
         - { path: ^/groups, roles: [ROLE_ADMIN, ROLE_API_CLIENT] }
         - { path: ^/, roles: ROLE_ADMIN }

--- a/importmap.php
+++ b/importmap.php
@@ -16,6 +16,10 @@ return [
         'path' => './assets/app.js',
         'entrypoint' => true,
     ],
+    'public' => [
+        'path' => './assets/public.js',
+        'entrypoint' => true,
+    ],
     'bootstrap' => [
         'version' => '5.3.8',
     ],

--- a/migrations/Version20260710120000.php
+++ b/migrations/Version20260710120000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260710120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add public-page configuration columns to profile_group (public feed page per group)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('profile_group');
+
+        $table->addColumn('public_page_enabled', 'boolean', ['default' => false]);
+        $table->addColumn('public_slug', 'string', ['length' => 32, 'notnull' => false]);
+        $table->addColumn('public_password_hash', 'string', ['length' => 255, 'notnull' => false]);
+        $table->addColumn('public_title', 'string', ['length' => 120, 'notnull' => false]);
+        $table->addColumn('public_description', 'text', ['notnull' => false]);
+        $table->addColumn('show_photos', 'boolean', ['default' => true]);
+        $table->addColumn('show_videos', 'boolean', ['default' => true]);
+        $table->addColumn('show_transcript', 'boolean', ['default' => false]);
+        $table->addColumn('show_captions', 'boolean', ['default' => true]);
+        $table->addColumn('time_window_days', 'integer', ['notnull' => false, 'default' => 30]);
+
+        $table->addUniqueIndex(['public_slug'], 'uniq_group_public_slug');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('profile_group');
+
+        $table->dropIndex('uniq_group_public_slug');
+
+        $table->dropColumn('public_page_enabled');
+        $table->dropColumn('public_slug');
+        $table->dropColumn('public_password_hash');
+        $table->dropColumn('public_title');
+        $table->dropColumn('public_description');
+        $table->dropColumn('show_photos');
+        $table->dropColumn('show_videos');
+        $table->dropColumn('show_transcript');
+        $table->dropColumn('show_captions');
+        $table->dropColumn('time_window_days');
+    }
+}

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -6,6 +6,7 @@ use App\Entity\Client;
 use App\Entity\Group;
 use App\Entity\Profile;
 use App\Form\GroupType;
+use App\Group\PublicSlugGenerator;
 use App\Repository\ClientRepository;
 use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
@@ -13,6 +14,7 @@ use App\Repository\NetworkRepository;
 use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -60,7 +62,7 @@ class GroupController extends AbstractController
     }
 
     #[Route('/new', name: 'app_group_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, EntityManagerInterface $em): Response
+    public function new(Request $request, EntityManagerInterface $em, PublicSlugGenerator $slugGenerator): Response
     {
         $group = new Group();
 
@@ -82,6 +84,7 @@ class GroupController extends AbstractController
             if ($error = $this->ensureProfilesBelongToClient($group)) {
                 $form->addError(new \Symfony\Component\Form\FormError($error));
             } else {
+                $this->applyPublicPageSettings($group, $form, $slugGenerator);
                 $em->persist($group);
                 $em->flush();
 
@@ -136,7 +139,7 @@ class GroupController extends AbstractController
     }
 
     #[Route('/{id}/edit', name: 'app_group_edit', requirements: ['id' => '\d+'], methods: ['GET', 'POST'])]
-    public function edit(Request $request, Group $group, EntityManagerInterface $em): Response
+    public function edit(Request $request, Group $group, EntityManagerInterface $em, PublicSlugGenerator $slugGenerator): Response
     {
         $this->denyForeignClient($group);
 
@@ -149,6 +152,7 @@ class GroupController extends AbstractController
             if ($error = $this->ensureProfilesBelongToClient($group)) {
                 $form->addError(new \Symfony\Component\Form\FormError($error));
             } else {
+                $this->applyPublicPageSettings($group, $form, $slugGenerator);
                 $em->flush();
 
                 $this->addFlash('success', 'Gruppe wurde aktualisiert.');
@@ -175,6 +179,20 @@ class GroupController extends AbstractController
         }
 
         return $this->redirectToRoute('app_group_index');
+    }
+
+    #[Route('/{id}/regenerate-slug', name: 'app_group_regenerate_slug', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function regenerateSlug(Request $request, Group $group, EntityManagerInterface $em, PublicSlugGenerator $slugGenerator): Response
+    {
+        $this->denyForeignClient($group);
+
+        if ($this->isCsrfTokenValid('group-regenerate-slug-' . $group->getId(), $request->request->getString('_token'))) {
+            $group->setPublicSlug($slugGenerator->generate());
+            $em->flush();
+            $this->addFlash('success', 'Der öffentliche Link wurde neu erzeugt. Der alte Link ist nicht mehr gültig.');
+        }
+
+        return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
     }
 
     #[Route('/{id}/profiles/add', name: 'app_group_profile_add', requirements: ['id' => '\d+'], methods: ['POST'])]
@@ -222,6 +240,27 @@ class GroupController extends AbstractController
         }
 
         return $this->redirectToRoute('app_group_show', ['id' => $group->getId()]);
+    }
+
+    /**
+     * Apply the unmapped public-page password fields and ensure an enabled page
+     * has a slug. An empty password field leaves an existing password untouched;
+     * the "remove" checkbox clears it.
+     */
+    private function applyPublicPageSettings(Group $group, FormInterface $form, PublicSlugGenerator $slugGenerator): void
+    {
+        if ($form->has('removePublicPassword') && $form->get('removePublicPassword')->getData() === true) {
+            $group->setPublicPasswordHash(null);
+        } elseif ($form->has('publicPassword')) {
+            $newPassword = (string) $form->get('publicPassword')->getData();
+            if ($newPassword !== '') {
+                $group->setPublicPassword($newPassword);
+            }
+        }
+
+        if ($group->isPublicPageEnabled() && $group->getPublicSlug() === null) {
+            $group->setPublicSlug($slugGenerator->generate());
+        }
     }
 
     private function loggedInClient(): ?Client

--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -175,10 +175,24 @@ class PublicGroupController extends AbstractController
                 'videoUrl' => $videoUrl,
                 'poster' => $poster,
                 'transcript' => $transcript,
+                'hue' => $this->avatarHue($item),
             ];
         }
 
         return $view;
+    }
+
+    /** Deterministic 0–359 hue for a profile's avatar, matching the reference page. */
+    private function avatarHue(Item $item): int
+    {
+        $key = ($item->getProfile()?->getIdentifier() ?? '') . ($item->getProfile()?->getId() ?? '');
+        $hash = 0;
+        $len = strlen($key);
+        for ($i = 0; $i < $len; $i++) {
+            $hash = ($hash * 31 + ord($key[$i])) & 0xffff;
+        }
+
+        return $hash % 360;
     }
 
     private function mediaUrl(string $relativePath): string

--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Group;
+use App\Entity\Item;
+use App\Repository\GroupRepository;
+use App\Repository\ItemRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\UrlHelper;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Public, unauthenticated feed page for a single group at /p/{slug}.
+ *
+ * The page is only reachable when the group has publicPageEnabled = true and a
+ * slug set. Password-protected groups show an unlock form first; a successful
+ * unlock is remembered in the session. Which media (photos/videos/transcripts)
+ * and captions are exposed is decided server-side from the group's settings, so
+ * disabled media never reaches the browser.
+ */
+#[Route('/p')]
+class PublicGroupController extends AbstractController
+{
+    private const ITEMS_PER_PAGE = 20;
+    private const MEDIA_PATH_PREFIX = '/media/';
+
+    public function __construct(
+        private readonly GroupRepository $groupRepository,
+        private readonly ItemRepository $itemRepository,
+        private readonly UrlHelper $urlHelper,
+    ) {
+    }
+
+    #[Route('/{slug}', name: 'app_public_group', methods: ['GET'])]
+    public function page(string $slug, Request $request): Response
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        if ($this->isLocked($group, $request)) {
+            return $this->render('public/password.html.twig', [
+                'group' => $group,
+                'error' => false,
+            ]);
+        }
+
+        $since = $this->windowStart($group);
+        $items = $this->itemRepository->findPaginatedForPublicGroup($group, 1, self::ITEMS_PER_PAGE, $since);
+        $total = $this->itemRepository->countForPublicGroup($group, $since);
+
+        return $this->render('public/group.html.twig', [
+            'group' => $group,
+            'viewItems' => $this->buildViewItems($items, $group),
+            'total' => $total,
+            'page' => 1,
+            'hasMore' => $total > self::ITEMS_PER_PAGE,
+        ]);
+    }
+
+    #[Route('/{slug}/more', name: 'app_public_group_more', methods: ['GET'])]
+    public function more(string $slug, Request $request): Response
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        if ($this->isLocked($group, $request)) {
+            throw new NotFoundHttpException();
+        }
+
+        $page = max(1, $request->query->getInt('page', 1));
+        $since = $this->windowStart($group);
+        $items = $this->itemRepository->findPaginatedForPublicGroup($group, $page, self::ITEMS_PER_PAGE, $since);
+        $total = $this->itemRepository->countForPublicGroup($group, $since);
+
+        return $this->render('public/_cards.html.twig', [
+            'group' => $group,
+            'viewItems' => $this->buildViewItems($items, $group),
+            'page' => $page,
+            'hasMore' => $total > $page * self::ITEMS_PER_PAGE,
+        ]);
+    }
+
+    #[Route('/{slug}/unlock', name: 'app_public_group_unlock', methods: ['POST'])]
+    public function unlock(string $slug, Request $request): Response
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        if (!$group->isPublicPasswordProtected()) {
+            return $this->redirectToRoute('app_public_group', ['slug' => $slug]);
+        }
+
+        $password = (string) $request->request->get('password', '');
+        if ($group->verifyPublicPassword($password)) {
+            $request->getSession()->set($this->sessionKey($group), true);
+
+            return $this->redirectToRoute('app_public_group', ['slug' => $slug]);
+        }
+
+        return $this->render('public/password.html.twig', [
+            'group' => $group,
+            'error' => true,
+        ]);
+    }
+
+    private function requirePublicGroup(string $slug): Group
+    {
+        $group = $this->groupRepository->findOneBy(['publicSlug' => $slug]);
+        if ($group === null || !$group->isPublicPageEnabled()) {
+            throw new NotFoundHttpException('Public page not found.');
+        }
+
+        return $group;
+    }
+
+    private function isLocked(Group $group, Request $request): bool
+    {
+        if (!$group->isPublicPasswordProtected()) {
+            return false;
+        }
+
+        return $request->getSession()->get($this->sessionKey($group)) !== true;
+    }
+
+    private function sessionKey(Group $group): string
+    {
+        return 'public_group_ok_' . $group->getId();
+    }
+
+    private function windowStart(Group $group): ?\DateTimeImmutable
+    {
+        $days = $group->getTimeWindowDays();
+        if ($days === null || $days <= 0) {
+            return null;
+        }
+
+        return new \DateTimeImmutable(sprintf('-%d days', $days));
+    }
+
+    /**
+     * Map items to render-ready view models, honouring the group's media flags.
+     * Photos/videos/transcripts absent from the returned structure are never
+     * emitted to the page.
+     *
+     * @param list<Item> $items
+     * @return list<array{item: Item, photos: list<string>, videoUrl: ?string, poster: ?string, transcript: ?string}>
+     */
+    private function buildViewItems(array $items, Group $group): array
+    {
+        $view = [];
+        foreach ($items as $item) {
+            $photos = [];
+            if ($group->isShowPhotos()) {
+                foreach ($item->getPhotoPaths() as $path) {
+                    $photos[] = $this->mediaUrl($path);
+                }
+            }
+
+            $videoUrl = null;
+            $poster = null;
+            if ($group->isShowVideos() && $item->getVideoPath() !== null) {
+                $videoUrl = $this->mediaUrl($item->getVideoPath());
+                $poster = $photos[0] ?? null;
+            }
+
+            $transcript = null;
+            if ($group->isShowTranscript() && $item->getTranscript() !== null && trim($item->getTranscript()) !== '') {
+                $transcript = $item->getTranscript();
+            }
+
+            $view[] = [
+                'item' => $item,
+                'photos' => $photos,
+                'videoUrl' => $videoUrl,
+                'poster' => $poster,
+                'transcript' => $transcript,
+            ];
+        }
+
+        return $view;
+    }
+
+    private function mediaUrl(string $relativePath): string
+    {
+        return $this->urlHelper->getAbsoluteUrl(self::MEDIA_PATH_PREFIX . ltrim($relativePath, '/'));
+    }
+}

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -144,6 +144,13 @@ class Group
     #[ApiProperty(description: 'How many days back the public page shows items. Null shows all items.', example: 30)]
     private ?int $timeWindowDays = 30;
 
+    /**
+     * Not persisted; filled at serialization time by GroupPublicUrlNormalizer.
+     */
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Absolute URL of the public page, or null when disabled. Built from publicSlug against the current host.', readable: true, writable: false)]
+    private ?string $publicUrl = null;
+
     /** @var Collection<int, Profile> */
     #[ORM\ManyToMany(targetEntity: Profile::class)]
     #[ORM\JoinTable(name: 'profile_group_profile')]
@@ -405,6 +412,11 @@ class Group
         $this->timeWindowDays = $timeWindowDays;
 
         return $this;
+    }
+
+    public function getPublicUrl(): ?string
+    {
+        return $this->publicUrl;
     }
 
     /**

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -95,6 +95,55 @@ class Group
     #[ApiProperty(description: 'Timestamp when this group was created.', readable: true, writable: false)]
     private \DateTimeImmutable $createdAt;
 
+    #[ORM\Column(name: 'public_page_enabled', type: 'boolean', options: ['default' => false])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Whether the public feed page for this group is reachable at /p/{publicSlug}. A slug is generated automatically the first time this is enabled.', example: false)]
+    private bool $publicPageEnabled = false;
+
+    #[ORM\Column(name: 'public_slug', type: 'string', length: 32, nullable: true, unique: true)]
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Unguessable URL token of the public page (path /p/{publicSlug}). Generated server-side; not writable. Use the regenerate-slug action to rotate it.', readable: true, writable: false)]
+    private ?string $publicSlug = null;
+
+    #[ORM\Column(name: 'public_password_hash', type: 'string', nullable: true)]
+    #[ApiProperty(readable: false, writable: false)]
+    private ?string $publicPasswordHash = null;
+
+    #[ORM\Column(name: 'public_title', type: 'string', length: 120, nullable: true)]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Optional heading shown on the public page. Falls back to the group name when empty.')]
+    private ?string $publicTitle = null;
+
+    #[ORM\Column(name: 'public_description', type: 'text', nullable: true)]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Optional subtitle shown on the public page.')]
+    private ?string $publicDescription = null;
+
+    #[ORM\Column(name: 'show_photos', type: 'boolean', options: ['default' => true])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Whether photos are shown on the public page.', example: true)]
+    private bool $showPhotos = true;
+
+    #[ORM\Column(name: 'show_videos', type: 'boolean', options: ['default' => true])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Whether videos are shown on the public page.', example: true)]
+    private bool $showVideos = true;
+
+    #[ORM\Column(name: 'show_transcript', type: 'boolean', options: ['default' => false])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Whether video transcripts are shown on the public page.', example: false)]
+    private bool $showTranscript = false;
+
+    #[ORM\Column(name: 'show_captions', type: 'boolean', options: ['default' => true])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'Whether the post text/caption is shown on the public page.', example: true)]
+    private bool $showCaptions = true;
+
+    #[ORM\Column(name: 'time_window_days', type: 'integer', nullable: true, options: ['default' => 30])]
+    #[Groups(['group:read', 'group:write'])]
+    #[ApiProperty(description: 'How many days back the public page shows items. Null shows all items.', example: 30)]
+    private ?int $timeWindowDays = 30;
+
     /** @var Collection<int, Profile> */
     #[ORM\ManyToMany(targetEntity: Profile::class)]
     #[ORM\JoinTable(name: 'profile_group_profile')]
@@ -202,5 +251,168 @@ class Group
     public function getProfileCount(): int
     {
         return $this->profiles->count();
+    }
+
+    public function isPublicPageEnabled(): bool
+    {
+        return $this->publicPageEnabled;
+    }
+
+    public function setPublicPageEnabled(bool $publicPageEnabled): self
+    {
+        $this->publicPageEnabled = $publicPageEnabled;
+
+        return $this;
+    }
+
+    public function getPublicSlug(): ?string
+    {
+        return $this->publicSlug;
+    }
+
+    public function setPublicSlug(?string $publicSlug): self
+    {
+        $this->publicSlug = $publicSlug;
+
+        return $this;
+    }
+
+    public function getPublicPasswordHash(): ?string
+    {
+        return $this->publicPasswordHash;
+    }
+
+    public function setPublicPasswordHash(?string $publicPasswordHash): self
+    {
+        $this->publicPasswordHash = $publicPasswordHash;
+
+        return $this;
+    }
+
+    /**
+     * Set the public-page password from a plain-text value. An empty string
+     * clears the password (page becomes freely accessible). Passing null leaves
+     * the current hash untouched — used so that "field absent" on a PATCH does
+     * not wipe an existing password.
+     */
+    #[Groups(['group:write'])]
+    #[ApiProperty(description: 'Write-only. Plain-text password protecting the public page. Send an empty string to remove the password. The stored hash is never returned.')]
+    public function setPublicPassword(?string $plain): self
+    {
+        if ($plain === null) {
+            return $this;
+        }
+
+        $this->publicPasswordHash = $plain === ''
+            ? null
+            : password_hash($plain, PASSWORD_DEFAULT);
+
+        return $this;
+    }
+
+    public function verifyPublicPassword(string $plain): bool
+    {
+        return $this->publicPasswordHash !== null
+            && password_verify($plain, $this->publicPasswordHash);
+    }
+
+    #[Groups(['group:read'])]
+    #[ApiProperty(description: 'Whether the public page is protected by a password.', readable: true, writable: false)]
+    public function isPublicPasswordProtected(): bool
+    {
+        return $this->publicPasswordHash !== null;
+    }
+
+    public function getPublicTitle(): ?string
+    {
+        return $this->publicTitle;
+    }
+
+    public function setPublicTitle(?string $publicTitle): self
+    {
+        $this->publicTitle = $publicTitle;
+
+        return $this;
+    }
+
+    public function getPublicDescription(): ?string
+    {
+        return $this->publicDescription;
+    }
+
+    public function setPublicDescription(?string $publicDescription): self
+    {
+        $this->publicDescription = $publicDescription;
+
+        return $this;
+    }
+
+    public function isShowPhotos(): bool
+    {
+        return $this->showPhotos;
+    }
+
+    public function setShowPhotos(bool $showPhotos): self
+    {
+        $this->showPhotos = $showPhotos;
+
+        return $this;
+    }
+
+    public function isShowVideos(): bool
+    {
+        return $this->showVideos;
+    }
+
+    public function setShowVideos(bool $showVideos): self
+    {
+        $this->showVideos = $showVideos;
+
+        return $this;
+    }
+
+    public function isShowTranscript(): bool
+    {
+        return $this->showTranscript;
+    }
+
+    public function setShowTranscript(bool $showTranscript): self
+    {
+        $this->showTranscript = $showTranscript;
+
+        return $this;
+    }
+
+    public function isShowCaptions(): bool
+    {
+        return $this->showCaptions;
+    }
+
+    public function setShowCaptions(bool $showCaptions): self
+    {
+        $this->showCaptions = $showCaptions;
+
+        return $this;
+    }
+
+    public function getTimeWindowDays(): ?int
+    {
+        return $this->timeWindowDays;
+    }
+
+    public function setTimeWindowDays(?int $timeWindowDays): self
+    {
+        $this->timeWindowDays = $timeWindowDays;
+
+        return $this;
+    }
+
+    /**
+     * Effective heading for the public page: the explicit public title, or the
+     * group name as a fallback.
+     */
+    public function getPublicHeading(): string
+    {
+        return $this->publicTitle ?? $this->name ?? '';
     }
 }

--- a/src/Form/GroupType.php
+++ b/src/Form/GroupType.php
@@ -8,7 +8,10 @@ use App\Entity\Profile;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -60,6 +63,59 @@ class GroupType extends AbstractType
                     ->orderBy('n.name', 'ASC')
                     ->addOrderBy('p.identifier', 'ASC'),
                 'help' => 'Profile, die zur Gruppe gehören. Profile, die nicht zum gewählten Client verknüpft sind, werden beim Speichern abgewiesen.',
+            ]);
+
+        // --- Öffentliche Seite ---
+        $builder
+            ->add('publicPageEnabled', CheckboxType::class, [
+                'label' => 'Öffentliche Seite aktivieren',
+                'required' => false,
+                'help' => 'Macht die Gruppe unter /p/{Slug} ohne Login abrufbar. Beim ersten Aktivieren wird automatisch ein Slug erzeugt.',
+            ])
+            ->add('publicTitle', TextType::class, [
+                'label' => 'Öffentlicher Titel',
+                'required' => false,
+                'help' => 'Überschrift der öffentlichen Seite. Leer = Gruppenname.',
+            ])
+            ->add('publicDescription', TextareaType::class, [
+                'label' => 'Öffentliche Beschreibung',
+                'required' => false,
+                'attr' => ['rows' => 2],
+            ])
+            ->add('showPhotos', CheckboxType::class, [
+                'label' => 'Fotos anzeigen',
+                'required' => false,
+            ])
+            ->add('showVideos', CheckboxType::class, [
+                'label' => 'Videos anzeigen',
+                'required' => false,
+            ])
+            ->add('showTranscript', CheckboxType::class, [
+                'label' => 'Video-Transkription anzeigen',
+                'required' => false,
+            ])
+            ->add('showCaptions', CheckboxType::class, [
+                'label' => 'Beitragstext anzeigen',
+                'required' => false,
+            ])
+            ->add('timeWindowDays', IntegerType::class, [
+                'label' => 'Zeitfenster (Tage)',
+                'required' => false,
+                'help' => 'Wie viele Tage zurück angezeigt werden. Leer = alle Beiträge.',
+                'attr' => ['min' => 1],
+            ])
+            ->add('publicPassword', PasswordType::class, [
+                'label' => 'Passwort',
+                'required' => false,
+                'mapped' => false,
+                'help' => 'Optionaler Passwortschutz. Leer lassen, um ein vorhandenes Passwort unverändert zu lassen.',
+                'attr' => ['autocomplete' => 'new-password'],
+            ])
+            ->add('removePublicPassword', CheckboxType::class, [
+                'label' => 'Passwort entfernen',
+                'required' => false,
+                'mapped' => false,
+                'help' => 'Entfernt einen bestehenden Passwortschutz.',
             ]);
     }
 

--- a/src/Group/PublicSlugGenerator.php
+++ b/src/Group/PublicSlugGenerator.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Group;
+
+use App\Repository\GroupRepository;
+
+/**
+ * Generates unguessable, URL-safe slugs for public group pages and guarantees
+ * uniqueness against the profile_group.public_slug column.
+ */
+class PublicSlugGenerator
+{
+    private const ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    private const LENGTH = 16;
+    private const MAX_ATTEMPTS = 10;
+
+    public function __construct(private readonly GroupRepository $groupRepository)
+    {
+    }
+
+    public function generate(): string
+    {
+        for ($attempt = 0; $attempt < self::MAX_ATTEMPTS; $attempt++) {
+            $slug = $this->randomSlug();
+            if ($this->groupRepository->findOneBy(['publicSlug' => $slug]) === null) {
+                return $slug;
+            }
+        }
+
+        throw new \RuntimeException('Could not generate a unique public slug after ' . self::MAX_ATTEMPTS . ' attempts.');
+    }
+
+    private function randomSlug(): string
+    {
+        $max = strlen(self::ALPHABET) - 1;
+        $slug = '';
+        for ($i = 0; $i < self::LENGTH; $i++) {
+            $slug .= self::ALPHABET[random_int(0, $max)];
+        }
+
+        return $slug;
+    }
+}

--- a/src/Repository/ItemRepository.php
+++ b/src/Repository/ItemRepository.php
@@ -91,6 +91,37 @@ class ItemRepository extends ServiceEntityRepository
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
+    /**
+     * Items for a group's public page: live members only, hidden / soft-deleted
+     * items excluded, optionally limited to a time window, dateTime DESC.
+     *
+     * @return list<Item>
+     */
+    public function findPaginatedForPublicGroup(\App\Entity\Group $group, int $page, int $limit, ?\DateTimeImmutable $since = null): array
+    {
+        $qb = $this->groupQueryBuilder($group)
+            ->orderBy('i.dateTime', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        if ($since !== null) {
+            $qb->andWhere('i.dateTime >= :since')->setParameter('since', $since);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function countForPublicGroup(\App\Entity\Group $group, ?\DateTimeImmutable $since = null): int
+    {
+        $qb = $this->groupQueryBuilder($group)->select('COUNT(i.id)');
+
+        if ($since !== null) {
+            $qb->andWhere('i.dateTime >= :since')->setParameter('since', $since);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
     private function groupQueryBuilder(\App\Entity\Group $group): QueryBuilder
     {
         $profileIds = [];

--- a/src/Serializer/Normalizer/GroupPublicUrlNormalizer.php
+++ b/src/Serializer/Normalizer/GroupPublicUrlNormalizer.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use App\Entity\Group;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Adds an absolute `publicUrl` to serialized groups, built from the public slug
+ * against the app router. Null when the public page is disabled or has no slug.
+ */
+class GroupPublicUrlNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const ALREADY_CALLED = 'GROUP_PUBLIC_URL_NORMALIZER_ALREADY_CALLED';
+
+    public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
+    {
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null
+    {
+        $context[self::ALREADY_CALLED] = true;
+
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        if (!is_array($data) || !$object instanceof Group) {
+            return $data;
+        }
+
+        $data['publicUrl'] = ($object->isPublicPageEnabled() && $object->getPublicSlug() !== null)
+            ? $this->urlGenerator->generate('app_public_group', ['slug' => $object->getPublicSlug()], UrlGeneratorInterface::ABSOLUTE_URL)
+            : null;
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        if (isset($context[self::ALREADY_CALLED])) {
+            return false;
+        }
+
+        return $data instanceof Group;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Group::class => false];
+    }
+}

--- a/src/State/ClientScopedGroupProcessor.php
+++ b/src/State/ClientScopedGroupProcessor.php
@@ -8,6 +8,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Client;
 use App\Entity\Group;
 use App\Entity\Profile;
+use App\Group\PublicSlugGenerator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -20,6 +21,7 @@ class ClientScopedGroupProcessor implements ProcessorInterface
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly Security $security,
+        private readonly PublicSlugGenerator $slugGenerator,
     ) {
     }
 
@@ -63,6 +65,11 @@ class ClientScopedGroupProcessor implements ProcessorInterface
 
         $this->ensureProfilesBelongToClient($client, $group);
 
+        // An enabled public page needs a slug; generate one lazily on first enable.
+        if ($group->isPublicPageEnabled() && $group->getPublicSlug() === null) {
+            $group->setPublicSlug($this->slugGenerator->generate());
+        }
+
         $this->em->persist($group);
         $this->em->flush();
 
@@ -84,6 +91,19 @@ class ClientScopedGroupProcessor implements ProcessorInterface
         $existing->setName($incoming->getName());
         $existing->setDescription($incoming->getDescription());
         $existing->setColor($incoming->getColor());
+
+        // Public-page settings (full replacement — PUT semantics). publicSlug is
+        // not writable, so the existing slug is preserved. An omitted publicPassword
+        // clears the password, consistent with PUT replacing the whole resource.
+        $existing->setPublicPageEnabled($incoming->isPublicPageEnabled());
+        $existing->setPublicTitle($incoming->getPublicTitle());
+        $existing->setPublicDescription($incoming->getPublicDescription());
+        $existing->setShowPhotos($incoming->isShowPhotos());
+        $existing->setShowVideos($incoming->isShowVideos());
+        $existing->setShowTranscript($incoming->isShowTranscript());
+        $existing->setShowCaptions($incoming->isShowCaptions());
+        $existing->setTimeWindowDays($incoming->getTimeWindowDays());
+        $existing->setPublicPasswordHash($incoming->getPublicPasswordHash());
 
         foreach ($existing->getProfiles()->toArray() as $profile) {
             $existing->removeProfile($profile);

--- a/src/Twig/PublicLinkifyExtension.php
+++ b/src/Twig/PublicLinkifyExtension.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Renders post captions for the public page: escapes the raw text, then turns
+ * URLs, #hashtags and @mentions into markup. Escaping happens first, so the
+ * result is safe to emit raw.
+ */
+class PublicLinkifyExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('public_linkify', $this->linkify(...), ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function linkify(?string $text): string
+    {
+        $escaped = htmlspecialchars($text ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        $escaped = preg_replace(
+            '#(https?://[^\s<]+)#',
+            '<a href="$1" target="_blank" rel="noopener nofollow">$1</a>',
+            $escaped,
+        ) ?? $escaped;
+
+        $escaped = preg_replace(
+            '/(^|\s)(#[\wäöüÄÖÜß]+)/u',
+            '$1<span class="hashtag">$2</span>',
+            $escaped,
+        ) ?? $escaped;
+
+        $escaped = preg_replace(
+            '/(^|\s)(@[\w.]+)/u',
+            '$1<span class="hashtag">$2</span>',
+            $escaped,
+        ) ?? $escaped;
+
+        return $escaped;
+    }
+}

--- a/templates/group/edit.html.twig
+++ b/templates/group/edit.html.twig
@@ -15,6 +15,22 @@
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
                 {{ form_row(form.profiles) }}
+
+                <hr class="my-4">
+                <h5 class="mb-3">Öffentliche Seite</h5>
+                {{ form_row(form.publicPageEnabled) }}
+                {{ form_row(form.publicTitle) }}
+                {{ form_row(form.publicDescription) }}
+                {{ form_row(form.timeWindowDays) }}
+                <div class="row">
+                    <div class="col-sm-6">{{ form_row(form.showPhotos) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showVideos) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showTranscript) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showCaptions) }}</div>
+                </div>
+                {{ form_row(form.publicPassword) }}
+                {% if group.publicPasswordProtected %}{{ form_row(form.removePublicPassword) }}{% endif %}
+
                 <div class="mt-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary">Speichern</button>
                     <a href="{{ path('app_group_show', {id: group.id}) }}" class="btn btn-outline-secondary">Abbrechen</a>

--- a/templates/group/new.html.twig
+++ b/templates/group/new.html.twig
@@ -15,6 +15,21 @@
                 {{ form_row(form.description) }}
                 {{ form_row(form.color) }}
                 {{ form_row(form.profiles) }}
+
+                <hr class="my-4">
+                <h5 class="mb-3">Öffentliche Seite</h5>
+                {{ form_row(form.publicPageEnabled) }}
+                {{ form_row(form.publicTitle) }}
+                {{ form_row(form.publicDescription) }}
+                {{ form_row(form.timeWindowDays) }}
+                <div class="row">
+                    <div class="col-sm-6">{{ form_row(form.showPhotos) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showVideos) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showTranscript) }}</div>
+                    <div class="col-sm-6">{{ form_row(form.showCaptions) }}</div>
+                </div>
+                {{ form_row(form.publicPassword) }}
+
                 <div class="mt-3 d-flex gap-2">
                     <button type="submit" class="btn btn-primary">Anlegen</button>
                     <a href="{{ path('app_group_index') }}" class="btn btn-outline-secondary">Abbrechen</a>

--- a/templates/group/show.html.twig
+++ b/templates/group/show.html.twig
@@ -35,6 +35,37 @@
                 </div>
             </div>
 
+            <div class="data-card mb-3">
+                <div class="data-card-header">Öffentliche Seite</div>
+                <div class="data-card-body">
+                    {% if group.publicPageEnabled and group.publicSlug %}
+                        <p class="mb-2">
+                            <span class="badge bg-success">aktiv</span>
+                            {% if group.publicPasswordProtected %}<span class="badge bg-secondary"><i class="fas fa-lock me-1"></i>passwortgeschützt</span>{% endif %}
+                        </p>
+                        <div class="input-group input-group-sm mb-2">
+                            <input type="text" class="form-control" readonly value="{{ url('app_public_group', {slug: group.publicSlug}) }}">
+                            <a href="{{ path('app_public_group', {slug: group.publicSlug}) }}" target="_blank" rel="noopener" class="btn btn-outline-secondary">
+                                <i class="fas fa-external-link-alt me-1"></i>Öffnen
+                            </a>
+                        </div>
+                        <form method="post" action="{{ path('app_group_regenerate_slug', {id: group.id}) }}"
+                              data-controller="confirm"
+                              data-confirm-message-value="Neuen Link erzeugen? Der bisherige Link wird ungültig.">
+                            <input type="hidden" name="_token" value="{{ csrf_token('group-regenerate-slug-' ~ group.id) }}">
+                            <button type="submit" class="btn btn-sm btn-outline-secondary">
+                                <i class="fas fa-rotate me-1"></i>Link neu erzeugen
+                            </button>
+                        </form>
+                    {% else %}
+                        <p class="text-muted mb-2">Die öffentliche Seite ist deaktiviert.</p>
+                        <a href="{{ path('app_group_edit', {id: group.id}) }}" class="btn btn-sm btn-outline-primary">
+                            <i class="fas fa-globe me-1"></i>Aktivieren
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+
             <form method="post" action="{{ path('app_group_delete', {id: group.id}) }}"
                   data-controller="confirm"
                   data-confirm-message-value="Gruppe &quot;{{ group.name }}&quot; wirklich löschen? Profile bleiben erhalten.">

--- a/templates/public/_card.html.twig
+++ b/templates/public/_card.html.twig
@@ -1,0 +1,54 @@
+{% set item = vi.item %}
+{% set profile = item.profile %}
+{% set net = profile ? profile.network : null %}
+{% set name = profile ? profile.displayName : '?' %}
+{% set initial = name|slice(0, 1)|upper %}
+{% set permalink = item.permalink ?: vi.photos|first|default('') %}
+{% set profileUrl = (profile and profile.identifier starts with 'http') ? profile.identifier : permalink %}
+<article class="post">
+    <div class="post-head">
+        <a class="avatar" style="background:hsl({{ vi.hue }}, 65%, 50%)" href="{{ profileUrl }}" target="_blank" rel="noopener nofollow">
+            {{ initial }}
+            {% if net %}<span class="net-badge" style="background:{{ net.backgroundColor }}"><i class="{{ net.icon }}"></i></span>{% endif %}
+        </a>
+        <div class="meta">
+            <a class="who" href="{{ profileUrl }}" target="_blank" rel="noopener nofollow">{{ name }}</a>
+            {% if item.dateTime %}<div class="when" title="{{ item.dateTime|date('d.m.Y H:i') }}">{{ item.dateTime|date('d.m.Y H:i') }}</div>{% endif %}
+        </div>
+    </div>
+
+    {% if vi.videoUrl %}
+        <div class="post-video">
+            <video controls preload="none"{% if vi.poster %} poster="{{ vi.poster }}"{% endif %} src="{{ vi.videoUrl }}"></video>
+        </div>
+    {% elseif vi.photos is not empty %}
+        {% if vi.photos|length == 1 %}
+            <a class="post-photo" href="{{ permalink }}" target="_blank" rel="noopener nofollow">
+                <img loading="lazy" referrerpolicy="no-referrer" src="{{ vi.photos|first }}" alt="" onerror="this.closest('.post-photo').style.display='none'">
+            </a>
+        {% else %}
+            <div class="post-photos count-{{ vi.photos|length > 4 ? 4 : vi.photos|length }}">
+                {% for p in vi.photos %}
+                    <a class="post-photo" href="{{ permalink }}" target="_blank" rel="noopener nofollow">
+                        <img loading="lazy" referrerpolicy="no-referrer" src="{{ p }}" alt="" onerror="this.closest('.post-photo').style.display='none'">
+                    </a>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endif %}
+
+    {% if (group.showCaptions and item.text) or vi.transcript %}
+        <div class="post-body">
+            {% if group.showCaptions and item.text %}
+                <div class="caption clamp"><span class="who-inline">{{ name }}</span> {{ item.text|public_linkify }}</div>
+                <span class="more" hidden>… mehr</span>
+            {% endif %}
+            {% if vi.transcript %}
+                <details class="transcript">
+                    <summary><i class="fas fa-closed-captioning"></i>Transkript</summary>
+                    <div class="transcript-text">{{ vi.transcript }}</div>
+                </details>
+            {% endif %}
+        </div>
+    {% endif %}
+</article>

--- a/templates/public/_cards.html.twig
+++ b/templates/public/_cards.html.twig
@@ -1,0 +1,19 @@
+{% set weekdays = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'] %}
+{% set months = ['', 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'] %}
+{% set today = 'now'|date('Y-m-d') %}
+{% set yesterday = '-1 day'|date('Y-m-d') %}
+{% set lastDay = null %}
+{% for vi in viewItems %}
+    {% set dk = vi.item.dateTime ? vi.item.dateTime|date('Y-m-d') : '' %}
+    {% if dk and dk != lastDay %}
+        <div class="day-heading"><span>
+            {%- if dk == today -%}Heute
+            {%- elseif dk == yesterday -%}Gestern
+            {%- else -%}{{ weekdays[vi.item.dateTime|date('w')] }}, {{ vi.item.dateTime|date('j') }}. {{ months[vi.item.dateTime|date('n')] }}
+            {%- endif -%}
+        </span></div>
+        {% set lastDay = dk %}
+    {% endif %}
+    {% include 'public/_card.html.twig' with {vi: vi, group: group} %}
+{% endfor %}
+<template data-more-meta data-has-more="{{ hasMore ? '1' : '0' }}"></template>

--- a/templates/public/base.html.twig
+++ b/templates/public/base.html.twig
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>{% block title %}{{ group.publicHeading }}{% endblock %}</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.1em%22 font-size=%22100%22>📣</text></svg>">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
+    <style>
+        :root {
+            --bg: #fafafa;
+            --bg-elev: #ffffff;
+            --fg: #18181b;
+            --fg-muted: #71717a;
+            --border: #e4e4e7;
+            --accent: {{ group.color ?: '#16a34a' }};
+            --shadow: 0 1px 2px rgba(0,0,0,.04), 0 1px 3px rgba(0,0,0,.06);
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #09090b;
+                --bg-elev: #18181b;
+                --fg: #fafafa;
+                --fg-muted: #a1a1aa;
+                --border: #27272a;
+                --shadow: 0 1px 2px rgba(0,0,0,.3);
+            }
+        }
+
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            font-size: 14px;
+            line-height: 1.5;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        header.page-head { padding: 24px 18px 8px; max-width: 470px; margin: 0 auto; }
+        header.page-head h1 { margin: 0 0 4px; font-size: 20px; font-weight: 800; letter-spacing: -.01em; }
+        header.page-head .desc { color: var(--fg-muted); font-size: 13px; margin: 0 0 4px; white-space: pre-wrap; }
+        header.page-head .sub { color: var(--fg-muted); font-size: 13px; display: flex; gap: 12px; flex-wrap: wrap; }
+        header.page-head .sub .dot { color: var(--accent); }
+
+        main { padding: 4px 12px 80px; max-width: 470px; margin: 0 auto; }
+
+        .day-heading { position: sticky; top: 8px; z-index: 10; text-align: center; margin: 14px 0 16px; pointer-events: none; }
+        .day-heading:first-child { margin-top: 4px; }
+        .day-heading span {
+            display: inline-block; background: var(--bg-elev); border: 1px solid var(--border);
+            color: var(--fg-muted); font-weight: 600; font-size: 12px; letter-spacing: .02em;
+            padding: 5px 14px; border-radius: 999px; box-shadow: var(--shadow);
+        }
+
+        .post { background: var(--bg-elev); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; margin: 0 0 16px; box-shadow: var(--shadow); }
+        .post-head { display: flex; align-items: center; gap: 10px; padding: 11px 13px; }
+        .avatar {
+            width: 34px; height: 34px; border-radius: 999px; display: inline-flex; align-items: center;
+            justify-content: center; font-weight: 700; font-size: 14px; color: white; flex-shrink: 0;
+            position: relative; text-decoration: none;
+        }
+        .avatar .net-badge {
+            position: absolute; bottom: -2px; right: -2px; width: 16px; height: 16px; border-radius: 999px;
+            display: inline-flex; align-items: center; justify-content: center; font-size: 9px; color: white;
+            border: 2px solid var(--bg-elev);
+        }
+        .post-head .meta { min-width: 0; flex: 1; }
+        .post-head .who { font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-decoration: none; color: var(--fg); display: block; }
+        .post-head .who:hover { text-decoration: underline; }
+        .post-head .when { font-size: 12px; color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+
+        .post-photo { display: block; width: 100%; background: var(--border); cursor: pointer; }
+        .post-photo img { display: block; width: 100%; height: auto; transition: opacity .15s ease; }
+        .post-photo:hover img { opacity: .94; }
+        .post-photos { display: grid; gap: 2px; }
+        .post-photos.count-2 { grid-template-columns: 1fr 1fr; }
+        .post-photos.count-3, .post-photos.count-4 { grid-template-columns: 1fr 1fr; }
+
+        .post-video { display: block; width: 100%; background: #000; }
+        .post-video video { display: block; width: 100%; height: auto; max-height: 70vh; }
+
+        .post-body { padding: 10px 14px 14px; font-size: 13px; line-height: 1.55; }
+        .post-body .caption { white-space: pre-wrap; word-wrap: break-word; overflow-wrap: anywhere; }
+        .post-body .caption.clamp { display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden; }
+        .post-body .who-inline { font-weight: 600; color: var(--fg); }
+        .post-body .more { display: inline-block; margin-top: 2px; color: var(--fg-muted); cursor: pointer; font-weight: 500; }
+        .post-body .hashtag { color: var(--accent); font-weight: 500; }
+        .post-body a { color: var(--accent); text-decoration: none; }
+        .post-body a:hover { text-decoration: underline; }
+
+        .transcript { margin-top: 10px; border-top: 1px dashed var(--border); padding-top: 8px; }
+        .transcript summary { cursor: pointer; color: var(--fg-muted); font-weight: 600; font-size: 12px; list-style: none; }
+        .transcript summary::-webkit-details-marker { display: none; }
+        .transcript summary i { margin-right: 5px; }
+        .transcript .transcript-text { margin-top: 6px; color: var(--fg-muted); white-space: pre-wrap; font-size: 12.5px; }
+
+        .empty { text-align: center; padding: 80px 24px; color: var(--fg-muted); }
+        .empty i { font-size: 28px; display: block; margin-bottom: 12px; }
+        .sentinel { height: 1px; }
+
+        /* Password gate */
+        .gate { max-width: 360px; margin: 60px auto; padding: 0 20px; text-align: center; }
+        .gate .lock { font-size: 34px; color: var(--fg-muted); margin-bottom: 16px; }
+        .gate h1 { font-size: 18px; font-weight: 700; margin: 0 0 6px; }
+        .gate p { color: var(--fg-muted); margin: 0 0 20px; }
+        .gate form { display: flex; gap: 8px; }
+        .gate input[type=password] { flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg-elev); color: var(--fg); font-size: 14px; }
+        .gate button { padding: 10px 16px; border: 0; border-radius: 10px; background: var(--accent); color: #fff; font-weight: 600; cursor: pointer; }
+        .gate .err { color: #dc2626; font-size: 13px; margin-bottom: 12px; }
+    </style>
+</head>
+<body>
+{% block body %}{% endblock %}
+{% block javascripts %}{% endblock %}
+</body>
+</html>

--- a/templates/public/group.html.twig
+++ b/templates/public/group.html.twig
@@ -1,0 +1,33 @@
+{% extends 'public/base.html.twig' %}
+
+{% block body %}
+    <header class="page-head">
+        <h1>{{ group.publicHeading }}</h1>
+        {% if group.publicDescription %}<p class="desc">{{ group.publicDescription }}</p>{% endif %}
+        <div class="sub">
+            {% if group.timeWindowDays %}<span><span class="dot">●</span> letzte {{ group.timeWindowDays }} Tage</span>{% endif %}
+            <span>{{ total }} {{ total == 1 ? 'Beitrag' : 'Beiträge' }}</span>
+        </div>
+    </header>
+
+    <main data-controller="public-feed"
+          data-public-feed-url-value="{{ path('app_public_group_more', {slug: group.publicSlug}) }}"
+          data-public-feed-page-value="{{ page }}"
+          data-public-feed-has-more-value="{{ hasMore ? 'true' : 'false' }}">
+        {% if viewItems is empty %}
+            <div class="empty">
+                <i class="fas fa-inbox"></i>
+                Noch keine Beiträge{% if group.timeWindowDays %} in den letzten {{ group.timeWindowDays }} Tagen{% endif %}.
+            </div>
+        {% else %}
+            <div data-public-feed-target="feed">
+                {% include 'public/_cards.html.twig' with {viewItems: viewItems, group: group, hasMore: hasMore} %}
+            </div>
+            <div class="sentinel" data-public-feed-target="sentinel"></div>
+        {% endif %}
+    </main>
+{% endblock %}
+
+{% block javascripts %}
+    {{ importmap('public') }}
+{% endblock %}

--- a/templates/public/password.html.twig
+++ b/templates/public/password.html.twig
@@ -1,0 +1,14 @@
+{% extends 'public/base.html.twig' %}
+
+{% block body %}
+    <div class="gate">
+        <div class="lock"><i class="fas fa-lock"></i></div>
+        <h1>{{ group.publicHeading }}</h1>
+        <p>Diese Seite ist passwortgeschützt.</p>
+        {% if error %}<div class="err">Falsches Passwort.</div>{% endif %}
+        <form method="post" action="{{ path('app_public_group_unlock', {slug: group.publicSlug}) }}">
+            <input type="password" name="password" placeholder="Passwort" autofocus required>
+            <button type="submit">Öffnen</button>
+        </form>
+    </div>
+{% endblock %}

--- a/tests/Functional/Api/GroupPublicPageApiTest.php
+++ b/tests/Functional/Api/GroupPublicPageApiTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Api;
+
+use App\Tests\Functional\AbstractApiTestCase;
+
+class GroupPublicPageApiTest extends AbstractApiTestCase
+{
+    public function testEnablingPublicPageGeneratesSlugAndUrl(): void
+    {
+        $response = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => [
+                'name' => 'Public API Group',
+                'publicPageEnabled' => true,
+                'publicTitle' => 'Mein Feed',
+                'showTranscript' => true,
+                'timeWindowDays' => 14,
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+
+        $this->assertTrue($data['publicPageEnabled']);
+        $this->assertNotEmpty($data['publicSlug']);
+        $this->assertSame('Mein Feed', $data['publicTitle']);
+        $this->assertTrue($data['showTranscript']);
+        $this->assertSame(14, $data['timeWindowDays']);
+        $this->assertStringContainsString('/p/' . $data['publicSlug'], $data['publicUrl']);
+        $this->assertFalse($data['publicPasswordProtected']);
+    }
+
+    public function testDisabledPublicPageHasNullUrl(): void
+    {
+        $response = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => ['name' => 'No Public Group'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+
+        $this->assertFalse($data['publicPageEnabled']);
+        $this->assertNull($data['publicSlug']);
+        $this->assertNull($data['publicUrl']);
+    }
+
+    public function testPasswordIsWriteOnlyAndNeverLeaksHash(): void
+    {
+        $response = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => [
+                'name' => 'Protected Group',
+                'publicPageEnabled' => true,
+                'publicPassword' => 'topsecret',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+
+        $this->assertTrue($data['publicPasswordProtected']);
+        $this->assertArrayNotHasKey('publicPassword', $data);
+        $this->assertArrayNotHasKey('publicPasswordHash', $data);
+    }
+
+    public function testPatchTogglesMediaFlag(): void
+    {
+        $created = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => ['name' => 'Toggle Group', 'showPhotos' => true],
+        ])->toArray();
+
+        $response = $this->requestWithToken('PATCH', '/api/groups/' . $created['id'], self::TOKEN_A, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'body' => json_encode(['showPhotos' => false]),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertFalse($response->toArray()['showPhotos']);
+    }
+
+    public function testSlugIsStableAcrossUpdates(): void
+    {
+        $created = $this->requestAsClientA('POST', '/api/groups', [
+            'json' => ['name' => 'Stable Slug', 'publicPageEnabled' => true],
+        ])->toArray();
+        $slug = $created['publicSlug'];
+        $this->assertNotEmpty($slug);
+
+        $updated = $this->requestAsClientA('PUT', '/api/groups/' . $created['id'], [
+            'json' => ['name' => 'Stable Slug Renamed', 'publicPageEnabled' => true, 'profiles' => []],
+        ])->toArray();
+
+        $this->assertSame($slug, $updated['publicSlug']);
+    }
+}

--- a/tests/Functional/PublicPage/PublicGroupControllerTest.php
+++ b/tests/Functional/PublicPage/PublicGroupControllerTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\PublicPage;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Item;
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client as ApiClient;
+use Doctrine\ORM\EntityManagerInterface;
+
+class PublicGroupControllerTest extends AbstractApiTestCase
+{
+    private const SHARED_PROFILE_ID = 90001;
+
+    public function testEnabledGroupShowsItems(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('showitems01', ['timeWindowDays' => null]);
+
+        $client->request('GET', '/p/showitems01');
+
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('Shared item 1', $this->body($client));
+    }
+
+    public function testDisabledGroupReturns404(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('disabled01', ['enabled' => false]);
+
+        $client->request('GET', '/p/disabled01');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownSlugReturns404(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/p/does-not-exist');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testHiddenAndDeletedItemsExcluded(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('nohidden01', ['timeWindowDays' => null]);
+
+        $client->request('GET', '/p/nohidden01');
+        $body = $this->body($client);
+
+        self::assertStringNotContainsString('Shared hidden item', $body);
+        self::assertStringNotContainsString('Shared soft-deleted item', $body);
+    }
+
+    public function testTimeWindowExcludesOldItems(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('window01', ['timeWindowDays' => 1]);
+
+        $client->request('GET', '/p/window01');
+        $body = $this->body($client);
+
+        self::assertStringContainsString('Shared item 1', $body);   // 1h ago
+        self::assertStringNotContainsString('Shared item 3', $body); // 48h ago
+    }
+
+    public function testPhotosHiddenWhenDisabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('nophoto01', [
+            'timeWindowDays' => null,
+            'showPhotos' => false,
+            'mediaItem' => ['photoPaths' => ['90001/700/photo_0.jpg']],
+        ]);
+
+        $client->request('GET', '/p/nophoto01');
+
+        self::assertStringNotContainsString('photo_0.jpg', $this->body($client));
+    }
+
+    public function testPhotosShownWhenEnabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('photo01', [
+            'timeWindowDays' => null,
+            'showPhotos' => true,
+            'mediaItem' => ['photoPaths' => ['90001/701/photo_0.jpg']],
+        ]);
+
+        $client->request('GET', '/p/photo01');
+
+        self::assertStringContainsString('photo_0.jpg', $this->body($client));
+    }
+
+    public function testVideosHiddenWhenDisabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('novideo01', [
+            'timeWindowDays' => null,
+            'showVideos' => false,
+            'mediaItem' => ['videoPath' => '90001/702/video.mp4'],
+        ]);
+
+        $client->request('GET', '/p/novideo01');
+
+        self::assertStringNotContainsString('<video', $this->body($client));
+    }
+
+    public function testVideosShownWhenEnabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('video01', [
+            'timeWindowDays' => null,
+            'showVideos' => true,
+            'mediaItem' => ['videoPath' => '90001/703/video.mp4'],
+        ]);
+
+        $client->request('GET', '/p/video01');
+
+        self::assertStringContainsString('<video', $this->body($client));
+    }
+
+    public function testTranscriptHiddenWhenDisabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('notrans01', [
+            'timeWindowDays' => null,
+            'showVideos' => true,
+            'showTranscript' => false,
+            'mediaItem' => ['videoPath' => '90001/704/video.mp4', 'transcript' => 'SECRET TRANSCRIPT'],
+        ]);
+
+        $client->request('GET', '/p/notrans01');
+
+        self::assertStringNotContainsString('SECRET TRANSCRIPT', $this->body($client));
+    }
+
+    public function testTranscriptShownWhenEnabled(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('trans01', [
+            'timeWindowDays' => null,
+            'showVideos' => true,
+            'showTranscript' => true,
+            'mediaItem' => ['videoPath' => '90001/705/video.mp4', 'transcript' => 'VISIBLE TRANSCRIPT'],
+        ]);
+
+        $client->request('GET', '/p/trans01');
+
+        self::assertStringContainsString('VISIBLE TRANSCRIPT', $this->body($client));
+    }
+
+    public function testPasswordGateBlocksThenUnlocks(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('locked01', ['timeWindowDays' => null, 'password' => 'letmein']);
+
+        // Locked: gate is shown, items are not.
+        $client->request('GET', '/p/locked01');
+        $this->assertResponseIsSuccessful();
+        self::assertStringContainsString('passwortgeschützt', $this->body($client));
+        self::assertStringNotContainsString('Shared item 1', $this->body($client));
+
+        // Wrong password keeps the gate.
+        $client->request('POST', '/p/locked01/unlock', ['extra' => ['parameters' => ['password' => 'nope']]]);
+        self::assertStringContainsString('Falsches Passwort', $this->body($client));
+
+        // Correct password unlocks; the following page load shows the feed.
+        $client->request('POST', '/p/locked01/unlock', ['extra' => ['parameters' => ['password' => 'letmein']]]);
+        $client->request('GET', '/p/locked01');
+        self::assertStringContainsString('Shared item 1', $this->body($client));
+    }
+
+    /** @param array<string, mixed> $opts */
+    private function makeGroup(string $slug, array $opts = []): void
+    {
+        $em = $this->em();
+
+        $clientA = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        $profile = $em->getRepository(Profile::class)->find(self::SHARED_PROFILE_ID);
+        self::assertInstanceOf(Client::class, $clientA);
+        self::assertInstanceOf(Profile::class, $profile);
+
+        $group = new Group();
+        $group->setName($opts['name'] ?? 'Public Test');
+        $group->setClient($clientA);
+        $group->addProfile($profile);
+        $group->setPublicPageEnabled($opts['enabled'] ?? true);
+        $group->setPublicSlug($slug);
+        $group->setShowPhotos($opts['showPhotos'] ?? true);
+        $group->setShowVideos($opts['showVideos'] ?? true);
+        $group->setShowTranscript($opts['showTranscript'] ?? false);
+        $group->setShowCaptions($opts['showCaptions'] ?? true);
+        $group->setTimeWindowDays($opts['timeWindowDays'] ?? null);
+        if (!empty($opts['password'])) {
+            $group->setPublicPassword($opts['password']);
+        }
+        $em->persist($group);
+
+        if (isset($opts['mediaItem'])) {
+            $this->addMediaItem($em, $profile, $opts['mediaItem']);
+        }
+
+        $em->flush();
+    }
+
+    /** @param array<string, mixed> $media */
+    private function addMediaItem(EntityManagerInterface $em, Profile $profile, array $media): void
+    {
+        $item = new Item();
+        $item->setProfile($profile);
+        $item->setUniqueIdentifier('media-' . bin2hex(random_bytes(4)));
+        $item->setText('Media caption');
+        $item->setPermalink('https://mastodon.social/@shared/media');
+        $item->setDateTime(new \DateTimeImmutable('-1 hour'));
+        if (isset($media['photoPaths'])) {
+            $item->setPhotoPaths($media['photoPaths']);
+        }
+        if (isset($media['videoPath'])) {
+            $item->setVideoPath($media['videoPath']);
+        }
+        if (isset($media['transcript'])) {
+            $item->setTranscript($media['transcript']);
+        }
+        $em->persist($item);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    private function body(ApiClient $client): string
+    {
+        return $client->getResponse()->getContent() ?: '';
+    }
+}

--- a/tests/Unit/Entity/GroupTest.php
+++ b/tests/Unit/Entity/GroupTest.php
@@ -64,4 +64,64 @@ class GroupTest extends TestCase
         $this->assertSame('Some description.', $group->getDescription());
         $this->assertSame('#abcdef', $group->getColor());
     }
+
+    public function testPublicPageDefaults(): void
+    {
+        $group = new Group();
+
+        $this->assertFalse($group->isPublicPageEnabled());
+        $this->assertNull($group->getPublicSlug());
+        $this->assertTrue($group->isShowPhotos());
+        $this->assertTrue($group->isShowVideos());
+        $this->assertFalse($group->isShowTranscript());
+        $this->assertTrue($group->isShowCaptions());
+        $this->assertSame(30, $group->getTimeWindowDays());
+        $this->assertFalse($group->isPublicPasswordProtected());
+    }
+
+    public function testSetPublicPasswordSetsHashesAndVerifies(): void
+    {
+        $group = new Group();
+        $group->setPublicPassword('s3cret');
+
+        $this->assertTrue($group->isPublicPasswordProtected());
+        $this->assertNotSame('s3cret', $group->getPublicPasswordHash());
+        $this->assertTrue($group->verifyPublicPassword('s3cret'));
+        $this->assertFalse($group->verifyPublicPassword('wrong'));
+    }
+
+    public function testSetPublicPasswordNullLeavesHashUntouched(): void
+    {
+        $group = new Group();
+        $group->setPublicPassword('keepme');
+        $hash = $group->getPublicPasswordHash();
+
+        $group->setPublicPassword(null);
+
+        $this->assertSame($hash, $group->getPublicPasswordHash());
+        $this->assertTrue($group->verifyPublicPassword('keepme'));
+    }
+
+    public function testSetPublicPasswordEmptyStringClears(): void
+    {
+        $group = new Group();
+        $group->setPublicPassword('gone');
+
+        $group->setPublicPassword('');
+
+        $this->assertFalse($group->isPublicPasswordProtected());
+        $this->assertNull($group->getPublicPasswordHash());
+        $this->assertFalse($group->verifyPublicPassword('gone'));
+    }
+
+    public function testPublicHeadingFallsBackToName(): void
+    {
+        $group = new Group();
+        $group->setName('Klima');
+
+        $this->assertSame('Klima', $group->getPublicHeading());
+
+        $group->setPublicTitle('Klima-Feed Lüneburg');
+        $this->assertSame('Klima-Feed Lüneburg', $group->getPublicHeading());
+    }
 }

--- a/tests/Unit/Group/PublicSlugGeneratorTest.php
+++ b/tests/Unit/Group/PublicSlugGeneratorTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Group;
+
+use App\Entity\Group;
+use App\Group\PublicSlugGenerator;
+use App\Repository\GroupRepository;
+use PHPUnit\Framework\TestCase;
+
+class PublicSlugGeneratorTest extends TestCase
+{
+    public function testGeneratesUrlSafeSlug(): void
+    {
+        $repository = $this->createStub(GroupRepository::class);
+        $repository->method('findOneBy')->willReturn(null);
+
+        $slug = (new PublicSlugGenerator($repository))->generate();
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{16}$/', $slug);
+    }
+
+    public function testRetriesOnCollisionThenSucceeds(): void
+    {
+        $existing = new Group();
+        $repository = $this->createStub(GroupRepository::class);
+        // First lookup collides, second is free.
+        $repository->method('findOneBy')->willReturnOnConsecutiveCalls($existing, null);
+
+        $slug = (new PublicSlugGenerator($repository))->generate();
+
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9]{16}$/', $slug);
+    }
+
+    public function testThrowsWhenEveryCandidateCollides(): void
+    {
+        $repository = $this->createStub(GroupRepository::class);
+        $repository->method('findOneBy')->willReturn(new Group());
+
+        $this->expectException(\RuntimeException::class);
+        (new PublicSlugGenerator($repository))->generate();
+    }
+}


### PR DESCRIPTION
## Was

Öffentliche, nicht-authentifizierte Feed-Seite pro Gruppe (Instagram-artig, einspaltig, Foto/Video + Text) unter **`/p/{slug}`**, pro Gruppe konfigurierbar.

## Inhalt

- **`Group`-Entity**: neue Public-Page-Spalten (`publicPageEnabled`, `publicSlug`, `publicPasswordHash`, `publicTitle`, `publicDescription`, `showPhotos`, `showVideos`, `showTranscript`, `showCaptions`, `timeWindowDays`) + Migration `Version20260710120000` (Schema-API, MySQL/PostgreSQL-tauglich).
- **`PublicSlugGenerator`**: 16-Zeichen base62-Slug, kollisionsgeprüft.
- **`PublicGroupController`** (`/p/{slug}`, ohne Auth): Feed-Seite, Infinite-Scroll-Fragment, Passwort-Gate (Session). Medien-/Caption-Sichtbarkeit serverseitig entschieden.
- **Security**: `/p/` als `PUBLIC_ACCESS` freigegeben.
- **Rendering**: eigenständige Twig-Templates unter `templates/public/`, eigenes `public` Importmap-Entrypoint (`assets/public.js`), Stimulus `public_feed_controller`, `public_linkify`-Filter.
- **Admin-UI**: Sektion „Öffentliche Seite" im `GroupType`, Status/URL-Karte, `POST /groups/{id}/regenerate-slug`.
- **REST-API**: Public-Page-Felder in `group:read`/`group:write`, write-only `publicPassword`, computed `publicUrl`.

## Deploy-Hinweise (Prod)

Braucht **DB-Migration** (neue Spalten), **Classmap-Dump** (neue Klassen) und **Asset-Compile** (neues JS-Entrypoint).

## Tests

Volle Suite grün (294 Tests). Enthält außerdem den zuvor auf main gemergten Pagination-Fix (#105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)