### PR TITLE
Punkte in Instagram-Usernamen erlauben (instagram_profile profileUrlPattern)

### DIFF
--- a/migrations/Version20260713120000.php
+++ b/migrations/Version20260713120000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Allow dots in Instagram usernames in the instagram_profile URL validation
+ * pattern. Instagram handles may contain periods (e.g. "torsten.franz.lg");
+ * the previous username character class [A-Za-z0-9\-_] rejected them, which
+ * blocked POST /profiles and change-identifier for such handles even though
+ * dotted profiles already existed in the DB via import.
+ */
+final class Version20260713120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow dots in Instagram usernames (instagram_profile profileUrlPattern)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE network
+            SET profile_url_pattern = '#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9._\-]{5,}/?$#i'
+            WHERE identifier = 'instagram_profile'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE network
+            SET profile_url_pattern = '#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9\-_]{5,}/?$#i'
+            WHERE identifier = 'instagram_profile'
+        SQL);
+    }
+}

--- a/src/DataFixtures/NetworkFixtures.php
+++ b/src/DataFixtures/NetworkFixtures.php
@@ -102,7 +102,7 @@ class NetworkFixtures extends Fixture
                 'icon' => 'fab fa-instagram',
                 'backgroundColor' => 'rgb(203, 44, 128)',
                 'textColor' => 'white',
-                'profileUrlPattern' => '#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9\-_]{5,}/?$#i',
+                'profileUrlPattern' => '#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9._\-]{5,}/?$#i',
             ],
             self::NETWORK_INSTAGRAM_PHOTO => [
                 'identifier' => 'instagram_photo',


### PR DESCRIPTION
## Problem
Die Zeichenklasse `[A-Za-z0-9\-_]` im `instagram_profile`-`profileUrlPattern` verbot **Punkte** im Usernamen. Handles mit Punkt (z. B. `torsten.franz.lg`) wurden bei `POST /profiles` und `POST /profiles/{id}/change-identifier` mit „… ist kein gültiger Identifier für das Netzwerk Instagram-Profil" abgelehnt — obwohl solche Profile (z. B. `criticalmass.duisburg`, `alexander.schwake`) via Import längst in der DB existieren.

## Fix
- `NetworkFixtures`: Zeichenklasse um `.` erweitert → `[A-Za-z0-9._\-]`.
- Migration `Version20260713120000`: `UPDATE` der bestehenden `network`-Zeile (`identifier='instagram_profile'`), damit vorhandene DBs mitgezogen werden. `down()` stellt das alte Muster wieder her.

## Kontext / nötig für
Die `instagram-block`-`ensure_media_saving`-PUT sendet den `identifier` mit und validiert ihn erneut — ohne diesen Fix schlägt das für gepunktete Handles fehl.

## Hinweis
Die Prod-DB von feeds.maltehuebner.dev wurde bereits per direktem `UPDATE` gehotfixt (Profil 2179 `toddyfranz` → `torsten.franz.lg`, Beiträge erhalten). Diese Migration bildet den Hotfix reproduzierbar für andere Umgebungen ab. (Prod meldet zusätzlich eine nicht-registrierte Migration in der DB — davon unabhängig, separat zu reconcilen.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)