### PR TITLE
Show profile handle instead of raw URL on the public group page

### DIFF
--- a/src/Twig/PublicProfileNameExtension.php
+++ b/src/Twig/PublicProfileNameExtension.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\Profile;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Display name for a profile on the public page: the explicit title when set,
+ * otherwise the account handle derived from the identifier (the last path
+ * segment of the profile URL), falling back to the raw identifier. Keeps the
+ * public feed from showing full URLs like "https://www.instagram.com/foo/"
+ * under the post when a profile has no title configured.
+ */
+class PublicProfileNameExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('public_profile_name', $this->publicName(...)),
+        ];
+    }
+
+    public function publicName(?Profile $profile): string
+    {
+        if ($profile === null) {
+            return '?';
+        }
+
+        $title = $profile->getTitle();
+        if ($title !== null && trim($title) !== '') {
+            return trim($title);
+        }
+
+        return $this->handleFromIdentifier($profile->getIdentifier());
+    }
+
+    private function handleFromIdentifier(?string $identifier): string
+    {
+        $identifier = trim((string) $identifier);
+        if ($identifier === '') {
+            return '?';
+        }
+
+        // Prefer the URL path (drops scheme/host/query), then take the last
+        // non-empty segment — the account handle.
+        $path = parse_url($identifier, PHP_URL_PATH);
+        $candidate = is_string($path) && $path !== '' ? $path : $identifier;
+
+        $segments = array_values(array_filter(
+            explode('/', $candidate),
+            static fn (string $segment): bool => trim($segment) !== '',
+        ));
+
+        $handle = end($segments);
+
+        return $handle !== false && $handle !== '' ? $handle : $identifier;
+    }
+}

--- a/templates/public/_card.html.twig
+++ b/templates/public/_card.html.twig
@@ -1,7 +1,7 @@
 {% set item = vi.item %}
 {% set profile = item.profile %}
 {% set net = profile ? profile.network : null %}
-{% set name = profile ? profile.displayName : '?' %}
+{% set name = profile|public_profile_name %}
 {% set initial = name|slice(0, 1)|upper %}
 {% set permalink = item.permalink ?: vi.photos|first|default('') %}
 {% set profileUrl = (profile and profile.identifier starts with 'http') ? profile.identifier : permalink %}

--- a/tests/Functional/PublicPage/PublicGroupControllerTest.php
+++ b/tests/Functional/PublicPage/PublicGroupControllerTest.php
@@ -25,6 +25,20 @@ class PublicGroupControllerTest extends AbstractApiTestCase
         self::assertStringContainsString('Shared item 1', $this->body($client));
     }
 
+    public function testProfileNameShownAsHandleNotUrl(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('handle01', ['timeWindowDays' => null]);
+
+        $client->request('GET', '/p/handle01');
+        $body = $this->body($client);
+
+        // Profile 90001 has identifier "https://mastodon.social/@shared" and no
+        // title, so the displayed name must be the handle, not the full URL.
+        self::assertStringContainsString('>@shared</a>', $body);
+        self::assertStringNotContainsString('>https://mastodon.social/@shared</a>', $body);
+    }
+
     public function testDisabledGroupReturns404(): void
     {
         $client = static::createClient();

--- a/tests/Unit/Twig/PublicProfileNameExtensionTest.php
+++ b/tests/Unit/Twig/PublicProfileNameExtensionTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Twig;
+
+use App\Entity\Profile;
+use App\Twig\PublicProfileNameExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class PublicProfileNameExtensionTest extends TestCase
+{
+    private PublicProfileNameExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new PublicProfileNameExtension();
+    }
+
+    public function testPrefersExplicitTitle(): void
+    {
+        $profile = (new Profile())
+            ->setIdentifier('https://www.instagram.com/torsten.franz.lg/')
+            ->setTitle('Torsten Franz');
+
+        self::assertSame('Torsten Franz', $this->extension->publicName($profile));
+    }
+
+    public function testBlankTitleFallsBackToHandle(): void
+    {
+        $profile = (new Profile())
+            ->setIdentifier('https://www.instagram.com/torsten.franz.lg/')
+            ->setTitle('   ');
+
+        self::assertSame('torsten.franz.lg', $this->extension->publicName($profile));
+    }
+
+    #[DataProvider('identifierProvider')]
+    public function testDerivesHandleFromIdentifier(string $identifier, string $expected): void
+    {
+        $profile = (new Profile())->setIdentifier($identifier);
+
+        self::assertSame($expected, $this->extension->publicName($profile));
+    }
+
+    public static function identifierProvider(): iterable
+    {
+        yield 'instagram trailing slash' => ['https://www.instagram.com/torsten.franz.lg/', 'torsten.franz.lg'];
+        yield 'instagram no trailing slash' => ['https://www.instagram.com/cl_kalisch', 'cl_kalisch'];
+        yield 'facebook page' => ['https://www.facebook.com/GrueneLueneburg', 'GrueneLueneburg'];
+        yield 'url with query' => ['https://www.instagram.com/foo/?hl=de', 'foo'];
+        yield 'bare handle without scheme' => ['onlya.bsky.social', 'onlya.bsky.social'];
+    }
+
+    public function testNullProfileReturnsPlaceholder(): void
+    {
+        self::assertSame('?', $this->extension->publicName(null));
+    }
+
+    public function testEmptyIdentifierReturnsPlaceholder(): void
+    {
+        $profile = (new Profile())->setIdentifier('');
+
+        self::assertSame('?', $this->extension->publicName($profile));
+    }
+}


### PR DESCRIPTION
## Problem

Auf der öffentlichen Gruppen-Seite (`/p/{slug}`) wurde unter jedem Post der Profilname angezeigt — für Profile **ohne Titel** war das der Identifier, also die volle URL (z. B. `https://www.instagram.com/torsten.franz.lg/`).

## Fix

Neuer Twig-Filter `public_profile_name` (`PublicProfileNameExtension`), genutzt im Public-Card-Template:
- Ist ein **Titel** gesetzt → dieser.
- Sonst der **Handle** aus dem Identifier (letztes Pfadsegment der URL, z. B. `torsten.franz.lg`).
- Fallback: der rohe Identifier.

Der Profil-**Link** (href) bleibt unverändert die volle URL — nur der angezeigte Text ändert sich.

## Tests

- `PublicProfileNameExtensionTest` (Unit): Titel-Vorrang, Handle-Ableitung für Instagram/Facebook/URL-mit-Query/bare-Handle, Platzhalter für null/leer.
- `PublicGroupControllerTest::testProfileNameShownAsHandleNotUrl` (funktional): gerenderte Seite zeigt `@shared`, nicht die volle URL.
- Volle Suite grün (304 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)