### PR TITLE
Searchable profile selection in the group form (Tom Select)

### DIFF
--- a/assets/controllers/searchable_select_controller.js
+++ b/assets/controllers/searchable_select_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from '@hotwired/stimulus';
+import TomSelect from 'tom-select';
+import 'tom-select/dist/css/tom-select.bootstrap5.min.css';
+
+/*
+ * Turns a native (multi-)select into a searchable, tag-based widget.
+ * Attach with data-controller="searchable-select" on a <select> element;
+ * the underlying select keeps its value, so normal form submission is
+ * unchanged. Optional data-searchable-select-placeholder-value overrides
+ * the placeholder text.
+ */
+export default class extends Controller {
+    static values = {
+        placeholder: { type: String, default: 'Tippen zum Suchen …' },
+    };
+
+    connect() {
+        const isMultiple = this.element.multiple;
+
+        this.select = new TomSelect(this.element, {
+            plugins: isMultiple ? ['remove_button'] : [],
+            placeholder: this.placeholderValue,
+            maxOptions: null,
+            maxItems: isMultiple ? null : 1,
+            hidePlaceholder: false,
+            // Match against the visible label as well as the option value.
+            searchField: ['text'],
+            sortField: [{ field: 'text', direction: 'asc' }],
+        });
+    }
+
+    disconnect() {
+        if (this.select) {
+            this.select.destroy();
+            this.select = null;
+        }
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -52,4 +52,17 @@ return [
         'version' => '2.3.7',
         'type' => 'css',
     ],
+    'tom-select' => [
+        'version' => '2.6.2',
+    ],
+    '@orchidjs/sifter' => [
+        'version' => '1.1.0',
+    ],
+    '@orchidjs/unicode-variants' => [
+        'version' => '1.1.2',
+    ],
+    'tom-select/dist/css/tom-select.bootstrap5.min.css' => [
+        'version' => '2.6.2',
+        'type' => 'css',
+    ],
 ];

--- a/src/Form/GroupType.php
+++ b/src/Form/GroupType.php
@@ -34,6 +34,7 @@ class GroupType extends AbstractType
                 'label' => 'Client',
                 'placeholder' => 'Client wählen...',
                 'help' => 'Eigentümer-Client der Gruppe. Bestimmt, wer sie über die API sieht.',
+                'attr' => ['data-controller' => 'searchable-select'],
             ]);
         }
 
@@ -54,7 +55,10 @@ class GroupType extends AbstractType
                 'expanded' => false,
                 'label' => 'Profile',
                 'required' => false,
-                'attr' => ['size' => 15],
+                'attr' => [
+                    'data-controller' => 'searchable-select',
+                    'data-searchable-select-placeholder-value' => 'Profil suchen und hinzufügen …',
+                ],
                 'choice_label' => fn(Profile $p) => sprintf('%s — %s', $p->getNetwork()?->getName() ?? '?', $p->getDisplayName()),
                 'query_builder' => fn(EntityRepository $repository) => $repository->createQueryBuilder('p')
                     ->leftJoin('p.network', 'n')

--- a/tests/Functional/Group/GroupEditFormWebTest.php
+++ b/tests/Functional/Group/GroupEditFormWebTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Group;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * The group edit form must wire the profiles select to the searchable-select
+ * Stimulus controller (Tom Select) instead of rendering a plain oversized
+ * multi-select.
+ */
+class GroupEditFormWebTest extends AbstractWebTestCase
+{
+    public function testProfilesFieldUsesSearchableSelect(): void
+    {
+        $group = $this->createGroup();
+
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', sprintf('/groups/%d/edit', $group->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $profilesSelect = $crawler->filter('select[name="group[profiles][]"]');
+        self::assertCount(1, $profilesSelect, 'profiles select is rendered');
+        self::assertSame('searchable-select', $profilesSelect->attr('data-controller'));
+        self::assertNotNull($profilesSelect->attr('multiple'));
+    }
+
+    private function createGroup(): Group
+    {
+        $em = $this->entityManager();
+
+        /** @var Client $client */
+        $client = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        /** @var Profile $profile */
+        $profile = $em->getRepository(Profile::class)->find(90001);
+
+        $group = new Group();
+        $group->setName('Editable Group');
+        $group->setClient($client);
+        $group->setCreatedAt(new \DateTimeImmutable());
+        $group->addProfile($profile);
+        $em->persist($group);
+        $em->flush();
+
+        return $group;
+    }
+}


### PR DESCRIPTION
## Problem

Im Gruppen-Formular (`/groups/{id}/edit`) war das Profil-Feld eine native `<select multiple>` über **alle** Profile (tausende) — unpraktikabel.

## Lösung

Durchsuchbares, tag-basiertes Widget via **Tom Select**:
- Neuer Stimulus-Controller `searchable-select`, der Tom Select auf jedem `<select>` mit `data-controller="searchable-select"` initialisiert (Chips mit Entfernen-Button, Suche, Platzhalter).
- Das darunterliegende `<select>` behält seinen Wert → Formular-Handling unverändert, kein neuer Endpoint.
- Verdrahtet am `profiles`-Feld und am kleinen `client`-Select in `GroupType`.
- `tom-select` (+ Abhängigkeiten `@orchidjs/sifter`, `@orchidjs/unicode-variants`, Bootstrap-5-Theme) zur Importmap hinzugefügt.

## Tests

- `GroupEditFormWebTest`: Profil-Select ist als `multiple` gerendert und mit `data-controller="searchable-select"` verdrahtet.
- Volle Suite grün (305 Tests). `asset-map:compile` löst alle Imports auf.

## Deploy-Hinweis

Braucht `importmap:install` (vendored Tom-Select-Dateien) + `asset-map:compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)