### PR TITLE
Search profiles by title and identifier in the group form

### DIFF
--- a/assets/controllers/searchable_select_controller.js
+++ b/assets/controllers/searchable_select_controller.js
@@ -12,6 +12,7 @@ import 'tom-select/dist/css/tom-select.bootstrap5.min.css';
 export default class extends Controller {
     static values = {
         placeholder: { type: String, default: 'Tippen zum Suchen …' },
+        searchFields: { type: Array, default: ['text'] },
     };
 
     connect() {
@@ -23,8 +24,9 @@ export default class extends Controller {
             maxOptions: null,
             maxItems: isMultiple ? null : 1,
             hidePlaceholder: false,
-            // Match against the visible label as well as the option value.
-            searchField: ['text'],
+            // Match against the visible label plus any per-option data-*
+            // fields (e.g. title, identifier) exposed as Tom Select option data.
+            searchField: this.searchFieldsValue,
             sortField: [{ field: 'text', direction: 'asc' }],
         });
     }

--- a/src/Form/GroupType.php
+++ b/src/Form/GroupType.php
@@ -58,8 +58,13 @@ class GroupType extends AbstractType
                 'attr' => [
                     'data-controller' => 'searchable-select',
                     'data-searchable-select-placeholder-value' => 'Profil suchen und hinzufügen …',
+                    'data-searchable-select-search-fields-value' => json_encode(['text', 'title', 'identifier']),
                 ],
                 'choice_label' => fn(Profile $p) => sprintf('%s — %s', $p->getNetwork()?->getName() ?? '?', $p->getDisplayName()),
+                'choice_attr' => fn(Profile $p) => [
+                    'data-title' => (string) $p->getTitle(),
+                    'data-identifier' => (string) $p->getIdentifier(),
+                ],
                 'query_builder' => fn(EntityRepository $repository) => $repository->createQueryBuilder('p')
                     ->leftJoin('p.network', 'n')
                     ->addSelect('n')

--- a/tests/Functional/Group/GroupEditFormWebTest.php
+++ b/tests/Functional/Group/GroupEditFormWebTest.php
@@ -27,6 +27,29 @@ class GroupEditFormWebTest extends AbstractWebTestCase
         self::assertCount(1, $profilesSelect, 'profiles select is rendered');
         self::assertSame('searchable-select', $profilesSelect->attr('data-controller'));
         self::assertNotNull($profilesSelect->attr('multiple'));
+
+        // Search must cover the label plus the profile title and identifier.
+        $searchFields = $profilesSelect->attr('data-searchable-select-search-fields-value');
+        self::assertNotNull($searchFields);
+        self::assertStringContainsString('title', $searchFields);
+        self::assertStringContainsString('identifier', $searchFields);
+    }
+
+    public function testProfileOptionsExposeTitleAndIdentifierForSearch(): void
+    {
+        $group = $this->createGroup();
+
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', sprintf('/groups/%d/edit', $group->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        // Profile 90001 (identifier https://mastodon.social/@shared, no title)
+        // must carry data attributes so Tom Select can match on them.
+        $option = $crawler->filter('select[name="group[profiles][]"] option[value="90001"]');
+        self::assertCount(1, $option);
+        self::assertSame('https://mastodon.social/@shared', $option->attr('data-identifier'));
+        self::assertNotNull($option->attr('data-title'));
     }
 
     private function createGroup(): Group


### PR DESCRIPTION
## Was

Erweitert die durchsuchbare Profil-Auswahl (Tom Select) im Gruppen-Formular so, dass sie **Titel und Identifier/Handle** matcht — nicht nur das sichtbare Label.

## Warum

Das Label zeigt „Netzwerk — Anzeigename", wobei der Anzeigename der Titel *oder* (falls leer) der Identifier ist. Dadurch war ein Profil mit gesetztem Titel nicht mehr über seinen Handle auffindbar (und umgekehrt).

## Wie

- `GroupType`: pro Option `data-title` und `data-identifier` (via `choice_attr`); Suchfelder gesetzt über `data-searchable-select-search-fields-value` = `["text","title","identifier"]`.
- Stimulus-Controller `searchable-select`: Suchfelder jetzt konfigurierbar (`searchFields`-Value, Default `["text"]`). Tom Select übernimmt `data-*` automatisch in die Optionsdaten (per `Object.assign({}, option.dataset)`, im vendored Source verifiziert).

Hinweis: Das Profil hat kein `description`-Feld — daher wird der Handle/Identifier durchsuchbar gemacht statt einer nicht existierenden Beschreibung (mit dem Nutzer abgestimmt).

## Tests

`GroupEditFormWebTest`: Suchfelder enthalten `title`/`identifier`; Optionen tragen `data-identifier`/`data-title`. Volle Suite grün (306 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)