### PR TITLE
Auto-link profiles to the group client when an admin adds them

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -81,7 +81,7 @@ class GroupController extends AbstractController
                 // Force-set again in case form data was tampered with.
                 $group->setClient($clientUser);
             }
-            if ($error = $this->ensureProfilesBelongToClient($group)) {
+            if ($error = $this->reconcileGroupProfilesWithClient($group)) {
                 $form->addError(new \Symfony\Component\Form\FormError($error));
             } else {
                 $this->applyPublicPageSettings($group, $form, $slugGenerator);
@@ -149,7 +149,7 @@ class GroupController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($error = $this->ensureProfilesBelongToClient($group)) {
+            if ($error = $this->reconcileGroupProfilesWithClient($group)) {
                 $form->addError(new \Symfony\Component\Form\FormError($error));
             } else {
                 $this->applyPublicPageSettings($group, $form, $slugGenerator);
@@ -211,9 +211,15 @@ class GroupController extends AbstractController
                 if ($profile === null) {
                     continue;
                 }
-                if (!$profile->getClients()->contains($group->getClient())) {
-                    $this->addFlash('warning', sprintf('Profil "%s" ist nicht mit dem Client der Gruppe verknüpft und wurde übersprungen.', $profile->getDisplayName()));
-                    continue;
+                $client = $group->getClient();
+                if ($client !== null && !$profile->getClients()->contains($client)) {
+                    // Client-token users may only add their own profiles; admins
+                    // pull any profile in and it is auto-linked to the client.
+                    if ($this->loggedInClient() !== null) {
+                        $this->addFlash('warning', sprintf('Profil "%s" ist nicht mit dem Client der Gruppe verknüpft und wurde übersprungen.', $profile->getDisplayName()));
+                        continue;
+                    }
+                    $client->addProfile($profile);
                 }
                 $group->addProfile($profile);
             }
@@ -278,21 +284,39 @@ class GroupController extends AbstractController
     }
 
     /** @return string|null  Error message if invalid, null if OK */
-    private function ensureProfilesBelongToClient(Group $group): ?string
+    /**
+     * Keeps the invariant that a group only contains profiles of its client.
+     * Admins may pull in any profile — it is auto-linked to the group's client
+     * on save. Client-token users stay restricted to their own profiles, so a
+     * client cannot grab a foreign profile by putting it into a group. Returns
+     * an error message for the restricted case, or null when reconciled.
+     */
+    private function reconcileGroupProfilesWithClient(Group $group): ?string
     {
         $client = $group->getClient();
         if ($client === null) {
             return null;
         }
+
+        $isAdmin = $this->loggedInClient() === null;
+
         foreach ($group->getProfiles() as $profile) {
-            if (!$profile->getClients()->contains($client)) {
-                return sprintf(
-                    'Profil "%s" ist nicht mit dem Client "%s" verknüpft. Verknüpfe es zuerst auf der Profil-Detailseite oder über die API.',
-                    $profile->getDisplayName(),
-                    $client->getName(),
-                );
+            if ($profile->getClients()->contains($client)) {
+                continue;
             }
+
+            if ($isAdmin) {
+                $client->addProfile($profile);
+                continue;
+            }
+
+            return sprintf(
+                'Profil "%s" ist nicht mit dem Client "%s" verknüpft. Verknüpfe es zuerst auf der Profil-Detailseite oder über die API.',
+                $profile->getDisplayName(),
+                $client->getName(),
+            );
         }
+
         return null;
     }
 }

--- a/tests/Functional/Group/GroupEditFormWebTest.php
+++ b/tests/Functional/Group/GroupEditFormWebTest.php
@@ -52,6 +52,50 @@ class GroupEditFormWebTest extends AbstractWebTestCase
         self::assertNotNull($option->attr('data-title'));
     }
 
+    public function testAdminAddingUnlinkedProfileAutoLinksToClientAndSaves(): void
+    {
+        $em = $this->entityManager();
+
+        /** @var Client $clientA */
+        $clientA = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+
+        $group = new Group();
+        $group->setName('Autolink Group');
+        $group->setClient($clientA);
+        $group->setCreatedAt(new \DateTimeImmutable());
+        $group->addProfile($em->getRepository(Profile::class)->find(90001)); // already linked to A
+        $em->persist($group);
+        $em->flush();
+        $groupId = $group->getId();
+
+        // Profile 90003 is linked to Client B only — not to this group's client.
+        $profileB = $em->getRepository(Profile::class)->find(90003);
+        self::assertFalse($profileB->getClients()->contains($clientA), 'precondition: 90003 not linked to A');
+
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', sprintf('/groups/%d/edit', $groupId));
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['group[profiles]'] = ['90001', '90003'];
+        $this->client->submit($form);
+
+        // Save succeeds (redirect to show) instead of being rejected.
+        self::assertResponseRedirects(sprintf('/groups/%d', $groupId));
+
+        $em->clear();
+        /** @var Group $reloaded */
+        $reloaded = $em->getRepository(Group::class)->find($groupId);
+        $ids = array_map(static fn (Profile $p): ?int => $p->getId(), $reloaded->getProfiles()->toArray());
+        self::assertContains(90003, $ids, 'newly added profile is saved into the group');
+
+        /** @var Profile $profileB */
+        $profileB = $em->getRepository(Profile::class)->find(90003);
+        /** @var Client $clientA */
+        $clientA = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        self::assertTrue($profileB->getClients()->contains($clientA), 'profile is auto-linked to the group client');
+    }
+
     private function createGroup(): Group
     {
         $em = $this->entityManager();


### PR DESCRIPTION
## Problem

Das Speichern des Gruppen-Formulars wurde **komplett abgewiesen**, sobald ein Mitglieds-Profil nicht mit dem Client der Gruppe verknüpft war (`ensureProfilesBelongToClient`). Durch die neue durchsuchbare Profil-Auswahl (die **alle** Profile listet) trat das ständig auf — hinzugefügte Profile ließen sich nicht speichern.

Konkret: Gruppe 2 gehört Client 3, an den nur die 22 bereits enthaltenen Profile verknüpft sind. Jedes weitere Profil aus der Box → Speichern abgelehnt.

## Fix

Beim Speichern wird nun **abgeglichen statt abgelehnt**:
- **Admin**: ein hinzugefügtes Profil wird automatisch mit dem Client der Gruppe verknüpft (Invariante Gruppe ⊆ Client bleibt erhalten). Speichern klappt immer.
- **Client-Token-Nutzer**: bleiben auf ihre eigenen Profile beschränkt (Fehlermeldung wie bisher), damit sie sich nicht über die Gruppenzugehörigkeit fremde Profile aneignen können.

Gilt für `new`, `edit` und die Quick-Add-Route auf der Show-Seite.

⚠️ **Nebenwirkung (gewünscht):** Fügt ein Admin ein Profil zu einer Gruppe hinzu, sieht der Client der Gruppe dieses Profil danach auch über seine API/Token.

## Tests

`GroupEditFormWebTest::testAdminAddingUnlinkedProfileAutoLinksToClientAndSaves`: Admin fügt ein nur an Client B verknüpftes Profil zu einer Client-A-Gruppe hinzu → Speichern per Redirect erfolgreich, Profil in der Gruppe und an Client A verknüpft. Volle Suite grün (307 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)