### PR TITLE
Create profiles from just an identifier (auto-detect network, assign id)

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Client;
 use App\Entity\Group;
+use App\Entity\Network;
 use App\Entity\Profile;
 use App\Form\ProfileType;
 use App\FeedFetcher\FeedFetcher;
@@ -14,6 +15,7 @@ use App\Model\Profile as ModelProfile;
 use App\Profile\IdentifierChangeException;
 use App\Profile\IdentifierChangeResult;
 use App\Profile\IdentifierChanger;
+use App\Profile\NetworkDetector;
 use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
 use App\Repository\NetworkRepository;
@@ -23,6 +25,7 @@ use App\RssApp\RegistrationResult;
 use App\RssApp\RssAppInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -84,8 +87,13 @@ class ProfileController extends AbstractController
     }
 
     #[Route('/new', name: 'app_profile_new')]
-    public function new(Request $request, EntityManagerInterface $em, FeedRegistrar $feedRegistrar): Response
-    {
+    public function new(
+        Request $request,
+        EntityManagerInterface $em,
+        FeedRegistrar $feedRegistrar,
+        ProfileRepository $profileRepository,
+        NetworkDetector $networkDetector,
+    ): Response {
         $profile = new Profile();
         $profile->setCreatedAt(new \DateTimeImmutable());
 
@@ -93,16 +101,40 @@ class ProfileController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em->persist($profile);
-            $em->flush();
+            $networkError = false;
 
-            $result = $feedRegistrar->registerIfNeeded($profile);
+            // Network is optional in the form: derive it from the identifier
+            // unless the user picked one manually.
+            if ($profile->getNetwork() === null) {
+                $detection = $networkDetector->detect((string) $profile->getIdentifier());
 
-            $em->flush();
+                if ($detection->isDetected()) {
+                    $profile->setNetwork($detection->network);
+                } else {
+                    $form->get('network')->addError(new FormError($detection->isAmbiguous()
+                        ? sprintf(
+                            'Der Identifier passt auf mehrere Netzwerke (%s). Bitte wähle das Netzwerk manuell.',
+                            implode(', ', array_map(static fn (Network $n): string => (string) $n->getName(), $detection->candidates)),
+                        )
+                        : 'Das Netzwerk konnte nicht aus dem Identifier ermittelt werden. Bitte prüfe die URL oder wähle das Netzwerk manuell.'));
+                    $networkError = true;
+                }
+            }
 
-            $this->addFlash('success', $this->buildCreationFlashMessage($result));
+            if (!$networkError) {
+                // The id column is not auto-generated (profiles imported from
+                // criticalmass.in keep their id), so assign the next free one.
+                $profile->setId($profileRepository->findNextFreeId());
+                $em->persist($profile);
+                $em->flush();
 
-            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+                $result = $feedRegistrar->registerIfNeeded($profile);
+                $em->flush();
+
+                $this->addFlash('success', $this->buildCreationFlashMessage($result));
+
+                return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+            }
         }
 
         return $this->render('profile/new.html.twig', [

--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -8,7 +8,6 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,24 +17,21 @@ class ProfileType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        if ($options['is_new']) {
-            $builder->add('id', IntegerType::class, [
-                'label' => 'ID',
-                'help' => 'Eindeutige numerische ID für dieses Profil',
-            ]);
-        }
-
         $builder
             ->add('network', EntityType::class, [
                 'class' => Network::class,
                 'choice_label' => 'name',
-                'placeholder' => 'Netzwerk wählen...',
+                'required' => !$options['is_new'],
+                'placeholder' => $options['is_new'] ? 'Automatisch aus Identifier erkennen' : 'Netzwerk wählen...',
                 'label' => 'Netzwerk',
+                'help' => $options['is_new']
+                    ? 'Leer lassen — wird beim Speichern aus dem Identifier ermittelt. Nur bei Bedarf manuell wählen.'
+                    : null,
                 'query_builder' => fn (\Doctrine\ORM\EntityRepository $er) => $er->createQueryBuilder('n')->orderBy('n.name', 'ASC'),
             ])
             ->add('identifier', TextType::class, [
                 'label' => 'Identifier',
-                'help' => 'URL oder Benutzername im Netzwerk',
+                'help' => 'Vollständige URL des Profils (z. B. https://www.instagram.com/name/). Das Netzwerk wird daraus erkannt.',
             ])
             ->add('title', TextType::class, [
                 'label' => 'Titel',

--- a/src/Profile/NetworkDetectionResult.php
+++ b/src/Profile/NetworkDetectionResult.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\Profile;
+
+use App\Entity\Network;
+
+/**
+ * Outcome of resolving a network from a profile identifier: either a single
+ * detected network, an ambiguous set of candidates, or nothing matched.
+ */
+final class NetworkDetectionResult
+{
+    /** @param list<Network> $candidates */
+    private function __construct(
+        public readonly ?Network $network,
+        public readonly array $candidates,
+    ) {
+    }
+
+    public static function detected(Network $network): self
+    {
+        return new self($network, [$network]);
+    }
+
+    /** @param list<Network> $candidates */
+    public static function ambiguous(array $candidates): self
+    {
+        return new self(null, $candidates);
+    }
+
+    public static function none(): self
+    {
+        return new self(null, []);
+    }
+
+    public function isDetected(): bool
+    {
+        return $this->network !== null;
+    }
+
+    public function isAmbiguous(): bool
+    {
+        return $this->network === null && count($this->candidates) > 1;
+    }
+}

--- a/src/Profile/NetworkDetector.php
+++ b/src/Profile/NetworkDetector.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Profile;
+
+use App\Entity\Network;
+use App\Repository\NetworkRepository;
+
+/**
+ * Determines a profile's network from its identifier by matching it against
+ * each network's profileUrlPattern. The catch-all "homepage" network (which
+ * matches any URL) is only used as a fallback when no more specific network
+ * matches, so a real Instagram/Facebook/... URL resolves to its actual
+ * network rather than to Homepage.
+ */
+class NetworkDetector
+{
+    private const FALLBACK_IDENTIFIER = 'homepage';
+
+    public function __construct(private readonly NetworkRepository $networkRepository)
+    {
+    }
+
+    public function detect(string $identifier): NetworkDetectionResult
+    {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            return NetworkDetectionResult::none();
+        }
+
+        $matches = array_values(array_filter(
+            $this->networkRepository->findAll(),
+            static fn (Network $network): bool => $network->isValidProfileUrl($identifier),
+        ));
+
+        $specific = array_values(array_filter(
+            $matches,
+            static fn (Network $network): bool => $network->getIdentifier() !== self::FALLBACK_IDENTIFIER,
+        ));
+
+        if (count($specific) === 1) {
+            return NetworkDetectionResult::detected($specific[0]);
+        }
+
+        if (count($specific) > 1) {
+            return NetworkDetectionResult::ambiguous($specific);
+        }
+
+        foreach ($matches as $match) {
+            if ($match->getIdentifier() === self::FALLBACK_IDENTIFIER) {
+                return NetworkDetectionResult::detected($match);
+            }
+        }
+
+        return NetworkDetectionResult::none();
+    }
+}

--- a/tests/Functional/Web/ProfileNewWebTest.php
+++ b/tests/Functional/Web/ProfileNewWebTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Entity\Profile;
+use App\Repository\ProfileRepository;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * The "new profile" form only needs an identifier: the network is detected
+ * from it and the (non auto-increment) id is assigned on save.
+ */
+class ProfileNewWebTest extends AbstractWebTestCase
+{
+    public function testCreatingProfileDetectsNetworkAndAssignsId(): void
+    {
+        $identifier = 'https://mastodon.social/@brandnewprofile';
+
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', '/profiles/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['profile[identifier]'] = $identifier;
+        // network left empty on purpose — it must be auto-detected.
+        $this->client->submit($form);
+
+        self::assertResponseRedirects();
+
+        /** @var ProfileRepository $profiles */
+        $profiles = $this->entityManager()->getRepository(Profile::class);
+        $profile = $profiles->findOneBy(['identifier' => $identifier]);
+
+        self::assertNotNull($profile, 'profile was created');
+        self::assertNotNull($profile->getId(), 'id was assigned');
+        self::assertNotNull($profile->getNetwork());
+        self::assertSame('mastodon', $profile->getNetwork()->getIdentifier(), 'network detected from identifier');
+    }
+
+    public function testUndetectableIdentifierShowsErrorAndDoesNotSave(): void
+    {
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', '/profiles/new');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['profile[identifier]'] = 'not-a-recognisable-url';
+        $this->client->submit($form);
+
+        // Re-renders the form with an error (422) instead of saving/redirecting.
+        self::assertResponseStatusCodeSame(422);
+
+        $profile = $this->entityManager()->getRepository(Profile::class)
+            ->findOneBy(['identifier' => 'not-a-recognisable-url']);
+        self::assertNull($profile, 'nothing is persisted when the network cannot be resolved');
+    }
+}

--- a/tests/Unit/Profile/NetworkDetectorTest.php
+++ b/tests/Unit/Profile/NetworkDetectorTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Profile;
+
+use App\Entity\Network;
+use App\Profile\NetworkDetector;
+use App\Repository\NetworkRepository;
+use PHPUnit\Framework\TestCase;
+
+class NetworkDetectorTest extends TestCase
+{
+    private NetworkDetector $detector;
+
+    protected function setUp(): void
+    {
+        $networks = [
+            $this->network('instagram_profile', '#^https?://(www\.)?instagram\.[A-Za-z]{2,3}/[A-Za-z0-9._\-]{5,}/?$#i'),
+            $this->network('facebook_page', '#^https?://(www\.)?facebook\.com/(?!groups/|events/|profile\.php)([A-Za-z0-9.\-]+)/?$#i'),
+            $this->network('bluesky_profile', '#^(https?://bsky\.app/profile/(did:plc:[a-z0-9]+|[a-z0-9.\-]+\.[a-z]{2,})/?|[a-z0-9.\-]+\.[a-z]{2,})$#i'),
+            $this->network('youtube_channel', '#^https?://(www\.)?youtube\.com/channel/.+$#i'),
+            $this->network('youtube_video', '#^((?:https?:)?//)?((?:www|m)\.)?((?:youtube\.com|youtu\.be))(\/(?:watch+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$#i'),
+            $this->network('homepage', '#^https?://.+$#i'),
+        ];
+
+        $repository = $this->createMock(NetworkRepository::class);
+        $repository->method('findAll')->willReturn($networks);
+
+        $this->detector = new NetworkDetector($repository);
+    }
+
+    public function testDetectsInstagramProfile(): void
+    {
+        $result = $this->detector->detect('https://www.instagram.com/torsten.franz.lg/');
+
+        self::assertTrue($result->isDetected());
+        self::assertSame('instagram_profile', $result->network->getIdentifier());
+    }
+
+    public function testDetectsFacebookPage(): void
+    {
+        $result = $this->detector->detect('https://www.facebook.com/GrueneLueneburg');
+
+        self::assertTrue($result->isDetected());
+        self::assertSame('facebook_page', $result->network->getIdentifier());
+    }
+
+    public function testDetectsBlueskyFromBareHandle(): void
+    {
+        $result = $this->detector->detect('someone.bsky.social');
+
+        self::assertTrue($result->isDetected());
+        self::assertSame('bluesky_profile', $result->network->getIdentifier());
+    }
+
+    public function testFallsBackToHomepageWhenOnlyGenericMatch(): void
+    {
+        $result = $this->detector->detect('https://example.org/blog');
+
+        self::assertTrue($result->isDetected());
+        self::assertSame('homepage', $result->network->getIdentifier());
+    }
+
+    public function testAmbiguousWhenMultipleSpecificNetworksMatch(): void
+    {
+        // A channel URL matches both youtube_channel and the broad youtube_video.
+        $result = $this->detector->detect('https://www.youtube.com/channel/UCabc123');
+
+        self::assertFalse($result->isDetected());
+        self::assertTrue($result->isAmbiguous());
+        self::assertCount(2, $result->candidates);
+    }
+
+    public function testNoneWhenNothingMatches(): void
+    {
+        $result = $this->detector->detect('not a url at all');
+
+        self::assertFalse($result->isDetected());
+        self::assertFalse($result->isAmbiguous());
+    }
+
+    public function testNoneForEmptyIdentifier(): void
+    {
+        $result = $this->detector->detect('   ');
+
+        self::assertFalse($result->isDetected());
+    }
+
+    private function network(string $identifier, string $pattern): Network
+    {
+        $network = new Network();
+        $network->setIdentifier($identifier);
+        $network->setName($identifier);
+        $network->setProfileUrlPattern($pattern);
+
+        return $network;
+    }
+}


### PR DESCRIPTION
## Problem

Das Formular „Neues Profil" (`/profiles/new`) verlangte eine **manuelle numerische ID** (die man nicht kennt) und eine **manuelle Netzwerk-Auswahl**.

## Lösung

Nur noch den **Identifier** (Profil-URL) eingeben:
- **ID**: Feld entfernt; beim Speichern wird die nächste freie ID vergeben (`ProfileRepository::findNextFreeId()` — wie der API-Processor es bereits tut). Die Spalte ist bewusst nicht auto-increment, weil importierte criticalmass.in-Profile ihre ID behalten.
- **Netzwerk**: im Neu-Formular optional (Default „Automatisch aus Identifier erkennen"). Neuer `NetworkDetector` matcht den Identifier gegen die `profileUrlPattern` jedes Netzwerks. Das Catch-all-Netzwerk `homepage` (matcht jede URL) dient nur als Fallback, damit echte Instagram-/Facebook-/…-URLs ihrem tatsächlichen Netzwerk zugeordnet werden.
- Ist der Identifier mehrdeutig oder unbekannt, erscheint eine Formular-Fehlermeldung mit Bitte um manuelle Netzwerk-Wahl (das Dropdown bleibt als optionaler Override erhalten).

## Tests

- `NetworkDetectorTest` (Unit): Instagram/Facebook/Bluesky-Erkennung, Homepage-Fallback, Mehrdeutigkeit (YouTube channel vs. video), kein Treffer, leer.
- `ProfileNewWebTest` (funktional): Anlegen nur mit Identifier → Netzwerk erkannt + ID gesetzt (Redirect); unerkennbarer Identifier → 422 mit Fehler, nichts gespeichert.
- Volle Suite grün (316 Tests).

## Deploy-Hinweis

Neue PHP-Klassen → `composer dump-autoload` (classmap-authoritative) nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)