### PR TITLE
Retry RSS.app requests on HTTP 429 with bounded backoff

### DIFF
--- a/src/RssApp/RssApp.php
+++ b/src/RssApp/RssApp.php
@@ -3,9 +3,16 @@
 namespace App\RssApp;
 
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class RssApp implements RssAppInterface
 {
+    /** Total attempts (1 initial + retries) for a rate-limited (429) request. */
+    private const MAX_ATTEMPTS = 4;
+
+    /** Never block a request longer than this per wait — surface the 429 instead. */
+    private const MAX_RETRY_WAIT_SECONDS = 8.0;
+
     private readonly string $bearer;
 
     public function __construct(
@@ -16,11 +23,55 @@ class RssApp implements RssAppInterface
         $this->bearer = sprintf('Bearer %s:%s', $rssAppApiKey, $rssAppApiSecret);
     }
 
+    /**
+     * RSS.app enforces a per-window API rate limit; registering a profile alone
+     * fans out into several calls (paginated feed listing + create), so a burst
+     * can trip a 429. Retry a rate-limited request a few times with backoff,
+     * honouring a numeric Retry-After when present, but give up (returning the
+     * 429 response) rather than blocking the caller for too long.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function requestWithRetry(string $method, string $url, array $options): ResponseInterface
+    {
+        for ($attempt = 1; ; ++$attempt) {
+            $response = $this->httpClient->request($method, $url, $options);
+
+            // getStatusCode() forces the transfer, so a 429 is detectable here.
+            if ($response->getStatusCode() !== 429 || $attempt >= self::MAX_ATTEMPTS) {
+                return $response;
+            }
+
+            $wait = $this->retryDelaySeconds($response, $attempt);
+            if ($wait > self::MAX_RETRY_WAIT_SECONDS) {
+                // Would block the caller too long — surface the 429 instead.
+                return $response;
+            }
+
+            if ($wait > 0.0) {
+                usleep((int) ($wait * 1_000_000));
+            }
+        }
+    }
+
+    private function retryDelaySeconds(ResponseInterface $response, int $attempt): float
+    {
+        $headers = $response->getHeaders(throw: false);
+        $retryAfter = $headers['retry-after'][0] ?? null;
+
+        if ($retryAfter !== null && is_numeric($retryAfter)) {
+            return (float) $retryAfter;
+        }
+
+        // Exponential backoff: 1s, 2s, 4s, ...
+        return (float) (2 ** ($attempt - 1));
+    }
+
     public function getItems(string $feedId, int $count = 100): array
     {
         $url = sprintf('https://api.rss.app/v1/feeds/%s?limit=%d', $feedId, $count);
 
-        $response = $this->httpClient->request('GET', $url, [
+        $response = $this->requestWithRetry('GET', $url, [
             'headers' => ['Authorization' => $this->bearer]
         ]);
 
@@ -34,7 +85,7 @@ class RssApp implements RssAppInterface
         $url = sprintf('https://api.rss.app/v1/feeds/%s', $feedId);
 
         try {
-            $response = $this->httpClient->request('GET', $url, [
+            $response = $this->requestWithRetry('GET', $url, [
                 'headers' => ['Authorization' => $this->bearer]
             ]);
 
@@ -51,7 +102,7 @@ class RssApp implements RssAppInterface
         $limit = 100;
 
         do {
-            $response = $this->httpClient->request('GET', "https://api.rss.app/v1/feeds?limit=$limit&offset=$offset", [
+            $response = $this->requestWithRetry('GET', "https://api.rss.app/v1/feeds?limit=$limit&offset=$offset", [
                 'headers' => ['Authorization' => $this->bearer]
             ]);
 
@@ -81,7 +132,7 @@ class RssApp implements RssAppInterface
 
     public function createFeed(string $url): array
     {
-        $response = $this->httpClient->request('POST', 'https://api.rss.app/v1/feeds', [
+        $response = $this->requestWithRetry('POST', 'https://api.rss.app/v1/feeds', [
             'headers' => [
                 'Authorization' => $this->bearer,
                 'Content-Type' => 'application/json',
@@ -128,7 +179,7 @@ class RssApp implements RssAppInterface
 
     public function deleteFeed(string $feedId): void
     {
-        $this->httpClient->request('DELETE', sprintf('https://api.rss.app/v1/feeds/%s', $feedId), [
+        $this->requestWithRetry('DELETE', sprintf('https://api.rss.app/v1/feeds/%s', $feedId), [
             'headers' => ['Authorization' => $this->bearer],
         ]);
     }

--- a/tests/Unit/RssApp/RssAppRetryTest.php
+++ b/tests/Unit/RssApp/RssAppRetryTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\RssApp;
+
+use App\RssApp\RssApp;
+use App\RssApp\RssAppException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class RssAppRetryTest extends TestCase
+{
+    public function testCreateFeedRetriesAfterRateLimitThenSucceeds(): void
+    {
+        $client = new MockHttpClient([
+            $this->rateLimited(retryAfter: '0'),
+            new MockResponse(json_encode(['id' => 'feed-123', 'source_url' => 'https://example.com']), ['http_code' => 200]),
+        ]);
+
+        $rssApp = new RssApp($client, 'key', 'secret');
+        $feed = $rssApp->createFeed('https://example.com');
+
+        self::assertSame('feed-123', $feed['id']);
+        self::assertSame(2, $client->getRequestsCount(), 'one retry after the 429');
+    }
+
+    public function testCreateFeedGivesUpAfterMaxAttempts(): void
+    {
+        $client = new MockHttpClient(array_fill(0, 6, $this->rateLimited(retryAfter: '0')));
+
+        $rssApp = new RssApp($client, 'key', 'secret');
+
+        try {
+            $rssApp->createFeed('https://example.com');
+            self::fail('expected RssAppException');
+        } catch (RssAppException $e) {
+            self::assertStringContainsString('429', $e->getMessage());
+        }
+
+        // 1 initial + 3 retries = 4 attempts, then it gives up.
+        self::assertSame(4, $client->getRequestsCount());
+    }
+
+    public function testDoesNotBlockWhenRetryAfterIsTooLong(): void
+    {
+        $client = new MockHttpClient([
+            $this->rateLimited(retryAfter: '3600'),
+            new MockResponse(json_encode(['id' => 'never-reached']), ['http_code' => 200]),
+        ]);
+
+        $rssApp = new RssApp($client, 'key', 'secret');
+
+        $this->expectException(RssAppException::class);
+        try {
+            $rssApp->createFeed('https://example.com');
+        } finally {
+            // Surfaces the 429 immediately instead of sleeping an hour / retrying.
+            self::assertSame(1, $client->getRequestsCount());
+        }
+    }
+
+    private function rateLimited(string $retryAfter): MockResponse
+    {
+        return new MockResponse(
+            json_encode(['message' => 'API rate limit exceeded']),
+            ['http_code' => 429, 'response_headers' => ['retry-after' => $retryAfter]],
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Beim Klick auf „RSS.app registrieren" schlägt die Registrierung mit **HTTP 429 (API rate limit exceeded)** fehl. Eine Registrierung löst mehrere RSS.app-Aufrufe aus (paginiertes Auflisten aller Feeds via `findRssAppFeedIdBySourceUrl`, dann `createFeed`) — dieser Burst reißt RSS.apps Rate-Limit pro Zeitfenster.

## Fix

Alle RSS.app-Requests laufen jetzt über einen kleinen Retry-Helper:
- Bei **429** wird begrenzt erneut versucht (insgesamt 4 Versuche).
- Ein numerischer **`Retry-After`**-Header wird respektiert; sonst exponentielles Backoff (1s, 2s, 4s).
- **Abbruch** (429 wird wie bisher als Fehler durchgereicht), wenn die Wartezeit einen synchronen Web-Request zu lange blockieren würde (> 8s) — kein Hängen.

## Grenzen

Das behebt **transiente** Rate-Limits (Bursts). Ein hartes Konto-/Plan-Kontingent bei RSS.app kann weiterhin fehlschlagen — dann hilft nur warten bzw. der RSS.app-Plan.

## Tests

`RssAppRetryTest` (Unit, `MockHttpClient`): Retry nach 429 → Erfolg; Aufgabe nach 4 Versuchen; kein Blockieren bei zu langem `Retry-After` (nur 1 Request). Volle Suite grün (319 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)