### PR TITLE
Browser push notifications for public group pages

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,22 @@ WEB_ADMIN_USERNAME=admin
 WEB_ADMIN_PASSWORD_HASH='$2y$13$changeme'
 ###< app/web-auth ###
 
+###> app/base-url ###
+# Absolute base URL used to generate links in non-HTTP contexts (CLI/cron),
+# e.g. the public-page link inside push notifications. Set to the site's public
+# origin in production, e.g. https://feeds.maltehuebner.dev
+DEFAULT_URI=http://localhost
+###< app/base-url ###
+
+###> app/web-push ###
+# Web Push (browser push notifications). Generate a key pair once with:
+#   php -r 'require "vendor/autoload.php"; var_export(Minishlink\WebPush\VAPID::createVapidKeys());'
+# The private key is secret — keep it in .env.local, never commit it. Empty keys disable push.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:admin@example.com
+###< app/web-push ###
+
 ###> doctrine/doctrine-bundle ###
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,9 @@
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
 DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_test.db"
+
+# Dummy VAPID keys for tests (valid format, not secret).
+VAPID_PUBLIC_KEY=BMT5_U4QEeMM_XQA3vRfvj-KZyNDpkJ4mkSnw0w-MqKSxuof5sm3_qPdmHWGDgaJZhuxlyHYv3z_Zs9QMhftNYw
+VAPID_PRIVATE_KEY=kBQ4Vybnbs_QyXwkCbad-_oHG9P9Kp7iYmpuXUxkMGg
+VAPID_SUBJECT=mailto:test@example.com
+DEFAULT_URI=http://localhost

--- a/assets/controllers/push_subscribe_controller.js
+++ b/assets/controllers/push_subscribe_controller.js
@@ -1,0 +1,136 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+ * Subscribe/unsubscribe the browser to Web Push notifications for a public
+ * group page. Registers the root-scoped service worker (/push-sw.js), manages
+ * the PushManager subscription and syncs it with the backend.
+ */
+export default class extends Controller {
+    static targets = ['button'];
+    static values = {
+        vapidPublicKey: String,
+        subscribeUrl: String,
+        unsubscribeUrl: String,
+    };
+
+    async connect() {
+        this.subscription = null;
+
+        if (!this.isSupported()) {
+            this.element.hidden = true;
+            return;
+        }
+
+        if (Notification.permission === 'denied') {
+            this.element.hidden = false;
+            this.render('blocked');
+            return;
+        }
+
+        try {
+            this.registration = await navigator.serviceWorker.register('/push-sw.js');
+            this.subscription = await this.registration.pushManager.getSubscription();
+        } catch (e) {
+            this.element.hidden = true;
+            return;
+        }
+
+        this.element.hidden = false;
+        this.render(this.subscription ? 'on' : 'off');
+    }
+
+    isSupported() {
+        return (
+            'serviceWorker' in navigator &&
+            'PushManager' in window &&
+            'Notification' in window &&
+            Boolean(this.vapidPublicKeyValue)
+        );
+    }
+
+    async toggle() {
+        if (this.busy) return;
+        this.busy = true;
+        this.render('working');
+
+        try {
+            if (this.subscription) {
+                await this.unsubscribe();
+            } else {
+                await this.subscribe();
+            }
+        } catch (e) {
+            this.render(this.subscription ? 'on' : 'off');
+        } finally {
+            this.busy = false;
+        }
+    }
+
+    async subscribe() {
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') {
+            this.render(permission === 'denied' ? 'blocked' : 'off');
+            return;
+        }
+
+        this.subscription = await this.registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: this.urlBase64ToUint8Array(this.vapidPublicKeyValue),
+        });
+
+        const res = await fetch(this.subscribeUrlValue, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(this.subscription.toJSON()),
+        });
+
+        if (!res.ok) {
+            await this.subscription.unsubscribe();
+            this.subscription = null;
+            this.render('off');
+            return;
+        }
+
+        this.render('on');
+    }
+
+    async unsubscribe() {
+        const endpoint = this.subscription.endpoint;
+
+        await fetch(this.unsubscribeUrlValue, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ endpoint }),
+        });
+
+        await this.subscription.unsubscribe();
+        this.subscription = null;
+        this.render('off');
+    }
+
+    render(state) {
+        if (!this.hasButtonTarget) return;
+        const btn = this.buttonTarget;
+        btn.disabled = state === 'working' || state === 'blocked';
+
+        const labels = {
+            on: '🔕 Benachrichtigungen aus',
+            off: '🔔 Benachrichtigungen an',
+            working: '…',
+            blocked: '🔔 Benachrichtigungen blockiert',
+        };
+        btn.textContent = labels[state] || labels.off;
+        btn.classList.toggle('is-on', state === 'on');
+    }
+
+    urlBase64ToUint8Array(base64String) {
+        const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const raw = window.atob(base64);
+        const output = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; ++i) {
+            output[i] = raw.charCodeAt(i);
+        }
+        return output;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laminas/laminas-feed": "^2.12",
         "laminas/laminas-http": "^2.11",
         "league/flysystem-bundle": "^3.6",
+        "minishlink/web-push": "^9",
         "nelmio/api-doc-bundle": "^5.9",
         "symfony/apache-pack": "*",
         "symfony/asset": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dee7aa5ca1ff585547e21c647129d924",
+    "content-hash": "085f2f57428fd44748533fcf9add3c88",
     "packages": [
         {
             "name": "api-platform/core",
@@ -224,6 +224,65 @@
                 "source": "https://github.com/api-platform/core/tree/v4.2.19"
             },
             "time": "2026-02-27T16:05:25+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.17.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.17.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-25T20:34:43+00:00"
         },
         {
             "name": "brick/varexporter",
@@ -1529,6 +1588,337 @@
             "time": "2025-10-31T18:51:33+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.5",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-13T01:32:54+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-08T15:48:39+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.12.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-13T01:27:20+00:00"
+        },
+        {
             "name": "halaxa/json-machine",
             "version": "1.2.6",
             "source": {
@@ -2446,6 +2836,73 @@
             "time": "2024-09-21T08:32:55+00:00"
         },
         {
+            "name": "minishlink/web-push",
+            "version": "v9.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-push-libs/web-push-php.git",
+                "reference": "f979f40b0017d2f86d82b9f21edbc515d031cc23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-push-libs/web-push-php/zipball/f979f40b0017d2f86d82b9f21edbc515d031cc23",
+                "reference": "f979f40b0017d2f86d82b9f21edbc515d031cc23",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "php": ">=8.1",
+                "spomky-labs/base64url": "^2.0.4",
+                "symfony/polyfill-php82": "^v1.31.0",
+                "web-token/jwt-library": "^3.3.0|^4.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.91.3",
+                "phpstan/phpstan": "^2.1.2",
+                "phpunit/phpunit": "^10.5.44|^11.5.6",
+                "symfony/polyfill-iconv": "^1.33"
+            },
+            "suggest": {
+                "ext-bcmath": "Optional for performance.",
+                "ext-gmp": "Optional for performance."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Minishlink\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Louis Lagrange",
+                    "email": "lagrange.louis@gmail.com",
+                    "homepage": "https://github.com/Minishlink"
+                }
+            ],
+            "description": "Web Push library for PHP",
+            "homepage": "https://github.com/web-push-libs/web-push-php",
+            "keywords": [
+                "Push API",
+                "WebPush",
+                "notifications",
+                "push",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/web-push-libs/web-push-php/issues",
+                "source": "https://github.com/web-push-libs/web-push-php/tree/v9.0.4"
+            },
+            "time": "2025-12-10T14:00:12+00:00"
+        },
+        {
             "name": "nelmio/api-doc-bundle",
             "version": "v5.9.5",
             "source": {
@@ -3314,6 +3771,225 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "symfony/apache-pack",
@@ -5934,6 +6610,170 @@
             "time": "2024-12-23T08:48:59+00:00"
         },
         {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
+        },
+        {
             "name": "symfony/polyfill-php84",
             "version": "v1.33.0",
             "source": {
@@ -8011,6 +8851,95 @@
                 }
             ],
             "time": "2026-01-23T21:00:41+00:00"
+        },
+        {
+            "name": "web-token/jwt-library",
+            "version": "4.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-token/jwt-library.git",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "spomky-labs/pki-framework": "^1.2.1"
+            },
+            "conflict": {
+                "spomky-labs/jose": "*"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-gmp": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-openssl": "For key management (creation, optimization, etc.) and some algorithms (AES, RSA, ECDSA, etc.)",
+                "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "paragonie/sodium_compat": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "spomky-labs/aes-key-wrap": "For all Key Wrapping algorithms (AxxxKW, AxxxGCMKW, PBES2-HSxxx+AyyyKW...)",
+                "symfony/console": "Needed to use console commands",
+                "symfony/http-client": "To enable JKU/X5U support."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jose\\Component\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-token/jwt-framework/contributors"
+                }
+            ],
+            "description": "JWT library",
+            "homepage": "https://github.com/web-token",
+            "keywords": [
+                "JOSE",
+                "JWE",
+                "JWK",
+                "JWKSet",
+                "JWS",
+                "Jot",
+                "RFC7515",
+                "RFC7516",
+                "RFC7517",
+                "RFC7518",
+                "RFC7519",
+                "RFC7520",
+                "bundle",
+                "jwa",
+                "jwt",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/web-token/jwt-library/issues",
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-06-06T18:12:39+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -2,6 +2,7 @@ framework:
     router:
         utf8: true
 
-        # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
+        # Configure how to generate URLs in non-HTTP contexts, such as CLI commands
+        # (e.g. absolute public-page URLs in push notifications sent from the fetch cron).
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(DEFAULT_URI)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,6 +21,9 @@ services:
             $whisperCliPath: '%env(WHISPER_CLI_PATH)%'
             $whisperModelPath: '%env(WHISPER_MODEL_PATH)%'
             $whisperLanguage: '%env(WHISPER_LANGUAGE)%'
+            $vapidPublicKey: '%env(VAPID_PUBLIC_KEY)%'
+            $vapidPrivateKey: '%env(VAPID_PRIVATE_KEY)%'
+            $vapidSubject: '%env(VAPID_SUBJECT)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/migrations/Version20260714120000.php
+++ b/migrations/Version20260714120000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260714120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add push_subscription table for browser Web Push subscriptions per group';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('push_subscription');
+        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('group_id', 'integer', ['notnull' => true]);
+        $table->addColumn('endpoint', 'string', ['length' => 500, 'notnull' => true]);
+        $table->addColumn('p256dh', 'string', ['length' => 255, 'notnull' => true]);
+        $table->addColumn('auth', 'string', ['length' => 255, 'notnull' => true]);
+        $table->addColumn('created_at', 'datetime_immutable', ['notnull' => true]);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['group_id'], 'idx_push_subscription_group');
+        $table->addForeignKeyConstraint(
+            'profile_group',
+            ['group_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE'],
+            'fk_push_subscription_group',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('push_subscription');
+    }
+}

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,0 +1,42 @@
+/*
+ * Service worker for public group page push notifications.
+ * Served from the site root so its scope covers /p/*.
+ */
+
+self.addEventListener('push', (event) => {
+    let data = {};
+    try {
+        data = event.data ? event.data.json() : {};
+    } catch (e) {
+        data = { body: event.data ? event.data.text() : '' };
+    }
+
+    const title = data.title || 'Neue Beiträge';
+    const options = {
+        body: data.body || '',
+        data: { url: data.url || '/' },
+        tag: data.tag || undefined,
+        renotify: Boolean(data.tag),
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    const url = (event.notification.data && event.notification.data.url) || '/';
+
+    event.waitUntil(
+        self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+            for (const client of clientList) {
+                if (client.url === url && 'focus' in client) {
+                    return client.focus();
+                }
+            }
+            if (self.clients.openWindow) {
+                return self.clients.openWindow(url);
+            }
+            return undefined;
+        }),
+    );
+});

--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -4,9 +4,13 @@ namespace App\Controller;
 
 use App\Entity\Group;
 use App\Entity\Item;
+use App\Entity\PushSubscription;
 use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
+use App\Repository\PushSubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\UrlHelper;
@@ -32,6 +36,9 @@ class PublicGroupController extends AbstractController
         private readonly GroupRepository $groupRepository,
         private readonly ItemRepository $itemRepository,
         private readonly UrlHelper $urlHelper,
+        private readonly PushSubscriptionRepository $pushSubscriptionRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly string $vapidPublicKey,
     ) {
     }
 
@@ -57,7 +64,57 @@ class PublicGroupController extends AbstractController
             'total' => $total,
             'page' => 1,
             'hasMore' => $total > self::ITEMS_PER_PAGE,
+            'pushEnabled' => $this->vapidPublicKey !== '',
+            'vapidPublicKey' => $this->vapidPublicKey,
         ]);
+    }
+
+    #[Route('/{slug}/push/subscribe', name: 'app_public_group_push_subscribe', methods: ['POST'])]
+    public function pushSubscribe(string $slug, Request $request): JsonResponse
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        if ($this->isLocked($group, $request)) {
+            return new JsonResponse(['error' => 'locked'], Response::HTTP_FORBIDDEN);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $endpoint = is_array($data) ? ($data['endpoint'] ?? null) : null;
+        $p256dh = is_array($data) ? ($data['keys']['p256dh'] ?? null) : null;
+        $auth = is_array($data) ? ($data['keys']['auth'] ?? null) : null;
+
+        if (!is_string($endpoint) || !is_string($p256dh) || !is_string($auth) || $endpoint === '') {
+            return new JsonResponse(['error' => 'invalid subscription'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $subscription = $this->pushSubscriptionRepository->findOneByGroupAndEndpoint($group, $endpoint)
+            ?? (new PushSubscription())->setGroup($group)->setEndpoint($endpoint)->setCreatedAt(new \DateTimeImmutable());
+
+        $subscription->setP256dh($p256dh)->setAuth($auth);
+
+        $this->entityManager->persist($subscription);
+        $this->entityManager->flush();
+
+        return new JsonResponse(['status' => 'subscribed'], Response::HTTP_CREATED);
+    }
+
+    #[Route('/{slug}/push/unsubscribe', name: 'app_public_group_push_unsubscribe', methods: ['POST'])]
+    public function pushUnsubscribe(string $slug, Request $request): JsonResponse
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        $data = json_decode($request->getContent(), true);
+        $endpoint = is_array($data) ? ($data['endpoint'] ?? null) : null;
+
+        if (is_string($endpoint) && $endpoint !== '') {
+            $subscription = $this->pushSubscriptionRepository->findOneByGroupAndEndpoint($group, $endpoint);
+            if ($subscription !== null) {
+                $this->entityManager->remove($subscription);
+                $this->entityManager->flush();
+            }
+        }
+
+        return new JsonResponse(['status' => 'unsubscribed']);
     }
 
     #[Route('/{slug}/more', name: 'app_public_group_more', methods: ['GET'])]

--- a/src/Entity/PushSubscription.php
+++ b/src/Entity/PushSubscription.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\PushSubscriptionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A browser Web Push subscription for a group's public page. Anonymous visitors
+ * of /p/{slug} subscribe to be notified when the group gets new posts. Keyed by
+ * the push endpoint; the p256dh/auth keys authenticate the encrypted payload.
+ */
+#[ORM\Table(name: 'push_subscription')]
+#[ORM\Index(name: 'idx_push_subscription_group', columns: ['group_id'])]
+#[ORM\Entity(repositoryClass: PushSubscriptionRepository::class)]
+class PushSubscription
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Group::class)]
+    #[ORM\JoinColumn(name: 'group_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Group $group = null;
+
+    #[ORM\Column(type: 'string', length: 500)]
+    private ?string $endpoint = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private ?string $p256dh = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private ?string $auth = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroup(): ?Group
+    {
+        return $this->group;
+    }
+
+    public function setGroup(Group $group): self
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    public function getEndpoint(): ?string
+    {
+        return $this->endpoint;
+    }
+
+    public function setEndpoint(string $endpoint): self
+    {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    public function getP256dh(): ?string
+    {
+        return $this->p256dh;
+    }
+
+    public function setP256dh(string $p256dh): self
+    {
+        $this->p256dh = $p256dh;
+
+        return $this;
+    }
+
+    public function getAuth(): ?string
+    {
+        return $this->auth;
+    }
+
+    public function setAuth(string $auth): self
+    {
+        $this->auth = $auth;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+}

--- a/src/FeedFetcher/FeedFetcher.php
+++ b/src/FeedFetcher/FeedFetcher.php
@@ -8,6 +8,7 @@ use App\NetworkFeedFetcher\NetworkFeedFetcherInterface;
 use App\Model\Profile;
 use App\ProfileFetcher\ProfileFetcherInterface;
 use App\ProfilePersister\ProfilePersisterInterface;
+use App\Push\GroupPushNotifier;
 use App\Repository\ProfileRepository;
 use App\SourceFetcher\SourceFetcher;
 
@@ -15,6 +16,7 @@ class FeedFetcher extends AbstractFeedFetcher
 {
     private MediaDownloadService $mediaDownloadService;
     private ProfileRepository $profileRepository;
+    private GroupPushNotifier $groupPushNotifier;
 
     public function __construct(
         FeedItemPersisterInterface $feedItemPersister,
@@ -23,10 +25,12 @@ class FeedFetcher extends AbstractFeedFetcher
         SourceFetcher $sourceFetcher,
         MediaDownloadService $mediaDownloadService,
         ProfileRepository $profileRepository,
+        GroupPushNotifier $groupPushNotifier,
     ) {
         parent::__construct($feedItemPersister, $profileFetcher, $profilePersister, $sourceFetcher);
         $this->mediaDownloadService = $mediaDownloadService;
         $this->profileRepository = $profileRepository;
+        $this->groupPushNotifier = $groupPushNotifier;
     }
     protected function getFeedFetcherForProfile(Profile $profile): ?NetworkFeedFetcherInterface
     {
@@ -68,7 +72,9 @@ class FeedFetcher extends AbstractFeedFetcher
                         ->setProfile($profile)
                         ->setCounterFetched(count($feedItemList));
 
+                    $newCountBefore = $this->feedItemPersister->getNewCount();
                     $this->feedItemPersister->persistFeedItemList($feedItemList, $fetchResult)->flush();
+                    $newItemsForProfile = $this->feedItemPersister->getNewCount() - $newCountBefore;
 
                     if (!$fetcherMarkedAsFailed) {
                         $profile->setLastFetchSuccessDateTime(new \DateTimeImmutable());
@@ -85,6 +91,11 @@ class FeedFetcher extends AbstractFeedFetcher
                         $this->mediaDownloadService->downloadNewItemsForProfile($entityProfile);
                     }
 
+                    if ($entityProfile) {
+                        // Accumulate per group; bundled notifications go out after the run.
+                        $this->groupPushNotifier->recordNewItems($entityProfile, $newItemsForProfile);
+                    }
+
                     $callback($fetchResult);
                 } catch (\Throwable $e) {
                     $profile->setLastFetchFailureDateTime(new \DateTimeImmutable());
@@ -93,6 +104,9 @@ class FeedFetcher extends AbstractFeedFetcher
                 }
             }
         }
+
+        // Send bundled push notifications for all groups that gained new items.
+        $this->groupPushNotifier->dispatch();
 
         return $this;
     }

--- a/src/FeedItemPersister/FeedItemPersisterInterface.php
+++ b/src/FeedItemPersister/FeedItemPersisterInterface.php
@@ -12,4 +12,7 @@ interface FeedItemPersisterInterface
     public function persistFeedItem(Item $item, ?FetchResult $fetchResult): FeedItemPersisterInterface;
 
     public function flush(): FeedItemPersisterInterface;
+
+    /** Running total of newly inserted items (not duplicates) since construction/reset. */
+    public function getNewCount(): int;
 }

--- a/src/Push/GroupPushNotifier.php
+++ b/src/Push/GroupPushNotifier.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace App\Push;
+
+use App\Entity\Group;
+use App\Entity\Profile;
+use App\Repository\GroupRepository;
+use App\Repository\PushSubscriptionRepository;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Collects new-item counts per group during a fetch run and, once dispatched,
+ * sends one bundled Web Push notification per group ("3 neue Beiträge …") to
+ * its public-page subscribers. Only public-page-enabled groups are notified,
+ * since that is where visitors subscribe and where the notification links to.
+ */
+class GroupPushNotifier
+{
+    /** @var array<int, array{group: Group, count: int}> */
+    private array $pending = [];
+
+    public function __construct(
+        private readonly GroupRepository $groupRepository,
+        private readonly PushSubscriptionRepository $subscriptionRepository,
+        private readonly WebPushSenderInterface $sender,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function recordNewItems(Profile $profile, int $count): void
+    {
+        if ($count <= 0 || !$this->sender->isEnabled()) {
+            return;
+        }
+
+        foreach ($this->groupRepository->findByProfile($profile) as $group) {
+            if (!$group->isPublicPageEnabled() || $group->getPublicSlug() === null) {
+                continue;
+            }
+
+            $id = $group->getId();
+            if (!isset($this->pending[$id])) {
+                $this->pending[$id] = ['group' => $group, 'count' => 0];
+            }
+            $this->pending[$id]['count'] += $count;
+        }
+    }
+
+    public function dispatch(): void
+    {
+        $pending = $this->pending;
+        $this->pending = [];
+
+        foreach ($pending as $entry) {
+            $this->notifyGroup($entry['group'], $entry['count']);
+        }
+    }
+
+    private function notifyGroup(Group $group, int $count): void
+    {
+        if ($count <= 0) {
+            return;
+        }
+
+        $subscriptions = $this->subscriptionRepository->findByGroup($group);
+        if ($subscriptions === []) {
+            return;
+        }
+
+        $this->sender->send($subscriptions, [
+            'title' => $group->getPublicTitle() ?: ($group->getName() ?? 'Neue Beiträge'),
+            'body' => $count === 1 ? '1 neuer Beitrag' : sprintf('%d neue Beiträge', $count),
+            'url' => $this->urlGenerator->generate(
+                'app_public_group',
+                ['slug' => $group->getPublicSlug()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            ),
+        ]);
+    }
+}

--- a/src/Push/WebPushSender.php
+++ b/src/Push/WebPushSender.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace App\Push;
+
+use App\Entity\PushSubscription;
+use Doctrine\ORM\EntityManagerInterface;
+use Minishlink\WebPush\Subscription;
+use Minishlink\WebPush\WebPush;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Sends Web Push notifications via VAPID and prunes subscriptions the push
+ * service reports as expired/gone. No-ops when no VAPID keys are configured,
+ * so the app runs fine without push set up.
+ */
+class WebPushSender implements WebPushSenderInterface
+{
+    private readonly bool $enabled;
+    private ?WebPush $webPush = null;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+        string $vapidPublicKey,
+        string $vapidPrivateKey,
+        string $vapidSubject,
+    ) {
+        $this->enabled = $vapidPublicKey !== '' && $vapidPrivateKey !== '';
+
+        if ($this->enabled) {
+            $this->webPush = new WebPush([
+                'VAPID' => [
+                    'subject' => $vapidSubject !== '' ? $vapidSubject : 'mailto:admin@localhost',
+                    'publicKey' => $vapidPublicKey,
+                    'privateKey' => $vapidPrivateKey,
+                ],
+            ]);
+        }
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function send(iterable $subscriptions, array $payload): void
+    {
+        if (!$this->enabled || $this->webPush === null) {
+            return;
+        }
+
+        $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        /** @var array<string, PushSubscription> $byEndpoint */
+        $byEndpoint = [];
+        $queued = 0;
+
+        foreach ($subscriptions as $subscription) {
+            $byEndpoint[$subscription->getEndpoint()] = $subscription;
+
+            $this->webPush->queueNotification(
+                Subscription::create([
+                    'endpoint' => $subscription->getEndpoint(),
+                    'keys' => [
+                        'p256dh' => $subscription->getP256dh(),
+                        'auth' => $subscription->getAuth(),
+                    ],
+                    'contentEncoding' => 'aes128gcm',
+                ]),
+                $json,
+            );
+            ++$queued;
+        }
+
+        if ($queued === 0) {
+            return;
+        }
+
+        $pruned = false;
+
+        foreach ($this->webPush->flush() as $report) {
+            if ($report->isSuccess()) {
+                continue;
+            }
+
+            $endpoint = $report->getEndpoint();
+
+            if ($report->isSubscriptionExpired() && isset($byEndpoint[$endpoint])) {
+                $this->entityManager->remove($byEndpoint[$endpoint]);
+                $pruned = true;
+
+                continue;
+            }
+
+            $this->logger->warning('Web push delivery failed for {endpoint}: {reason}', [
+                'endpoint' => $endpoint,
+                'reason' => $report->getReason(),
+            ]);
+        }
+
+        if ($pruned) {
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/src/Push/WebPushSenderInterface.php
+++ b/src/Push/WebPushSenderInterface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace App\Push;
+
+use App\Entity\PushSubscription;
+
+interface WebPushSenderInterface
+{
+    /**
+     * Send a notification payload to the given subscriptions. Subscriptions the
+     * push service reports as gone (expired/unsubscribed) are pruned.
+     *
+     * @param iterable<PushSubscription> $subscriptions
+     * @param array<string, mixed>       $payload       decoded into JSON for the service worker
+     */
+    public function send(iterable $subscriptions, array $payload): void;
+
+    /** Web push is only usable when VAPID keys are configured. */
+    public function isEnabled(): bool;
+}

--- a/src/Repository/PushSubscriptionRepository.php
+++ b/src/Repository/PushSubscriptionRepository.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Group;
+use App\Entity\PushSubscription;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PushSubscription>
+ */
+class PushSubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PushSubscription::class);
+    }
+
+    /**
+     * @return list<PushSubscription>
+     */
+    public function findByGroup(Group $group): array
+    {
+        return $this->findBy(['group' => $group]);
+    }
+
+    public function findOneByGroupAndEndpoint(Group $group, string $endpoint): ?PushSubscription
+    {
+        return $this->findOneBy(['group' => $group, 'endpoint' => $endpoint]);
+    }
+
+    public function countByGroup(Group $group): int
+    {
+        return $this->count(['group' => $group]);
+    }
+}

--- a/templates/public/base.html.twig
+++ b/templates/public/base.html.twig
@@ -44,6 +44,11 @@
         header.page-head .desc { color: var(--fg-muted); font-size: 13px; margin: 0 0 4px; white-space: pre-wrap; }
         header.page-head .sub { color: var(--fg-muted); font-size: 13px; display: flex; gap: 12px; flex-wrap: wrap; }
         header.page-head .sub .dot { color: var(--accent); }
+        header.page-head .push-subscribe { margin-top: 12px; }
+        .push-btn { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border, #d0d0d0); background: transparent; color: var(--fg, inherit); transition: background .15s, border-color .15s; }
+        .push-btn:hover:not(:disabled) { border-color: var(--accent); }
+        .push-btn:disabled { opacity: .6; cursor: default; }
+        .push-btn.is-on { background: var(--accent); border-color: var(--accent); color: #fff; }
 
         main { padding: 4px 12px 80px; max-width: 470px; margin: 0 auto; }
 

--- a/templates/public/group.html.twig
+++ b/templates/public/group.html.twig
@@ -8,6 +8,15 @@
             {% if group.timeWindowDays %}<span><span class="dot">●</span> letzte {{ group.timeWindowDays }} Tage</span>{% endif %}
             <span>{{ total }} {{ total == 1 ? 'Beitrag' : 'Beiträge' }}</span>
         </div>
+        {% if pushEnabled %}
+            <div class="push-subscribe" hidden
+                 data-controller="push-subscribe"
+                 data-push-subscribe-vapid-public-key-value="{{ vapidPublicKey }}"
+                 data-push-subscribe-subscribe-url-value="{{ path('app_public_group_push_subscribe', {slug: group.publicSlug}) }}"
+                 data-push-subscribe-unsubscribe-url-value="{{ path('app_public_group_push_unsubscribe', {slug: group.publicSlug}) }}">
+                <button type="button" class="push-btn" data-push-subscribe-target="button" data-action="push-subscribe#toggle">🔔 Benachrichtigungen an</button>
+            </div>
+        {% endif %}
     </header>
 
     <main data-controller="public-feed"

--- a/tests/Functional/PublicPage/PublicGroupPushTest.php
+++ b/tests/Functional/PublicPage/PublicGroupPushTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\PublicPage;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Profile;
+use App\Entity\PushSubscription;
+use App\Tests\Functional\AbstractApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+class PublicGroupPushTest extends AbstractApiTestCase
+{
+    private const SUBSCRIPTION = [
+        'endpoint' => 'https://push.example.com/endpoint/abc123',
+        'keys' => ['p256dh' => 'BPublicKeyValue', 'auth' => 'authSecret'],
+    ];
+
+    public function testSubscribeThenUnsubscribe(): void
+    {
+        $client = static::createClient();
+        $group = $this->makePublicGroup('pushslug01');
+
+        // Subscribe.
+        $client->request('POST', '/p/pushslug01/push/subscribe', ['json' => self::SUBSCRIPTION]);
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(1, $this->subscriptionCount($group));
+
+        // Subscribing again with the same endpoint is idempotent (upsert).
+        $client->request('POST', '/p/pushslug01/push/subscribe', ['json' => self::SUBSCRIPTION]);
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame(1, $this->subscriptionCount($group));
+
+        // Unsubscribe removes it.
+        $client->request('POST', '/p/pushslug01/push/unsubscribe', ['json' => ['endpoint' => self::SUBSCRIPTION['endpoint']]]);
+        self::assertResponseIsSuccessful();
+        self::assertSame(0, $this->subscriptionCount($group));
+    }
+
+    public function testSubscribeRejectsInvalidPayload(): void
+    {
+        $client = static::createClient();
+        $group = $this->makePublicGroup('pushslug02');
+
+        $client->request('POST', '/p/pushslug02/push/subscribe', ['json' => ['endpoint' => '']]);
+        self::assertResponseStatusCodeSame(400);
+        self::assertSame(0, $this->subscriptionCount($group));
+    }
+
+    public function testSubscribeOnUnknownGroupIs404(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/p/does-not-exist/push/subscribe', ['json' => self::SUBSCRIPTION]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function makePublicGroup(string $slug): Group
+    {
+        $em = $this->em();
+        $clientA = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        $profile = $em->getRepository(Profile::class)->find(90001);
+
+        $group = new Group();
+        $group->setName('Push Group');
+        $group->setClient($clientA);
+        $group->addProfile($profile);
+        $group->setPublicPageEnabled(true);
+        $group->setPublicSlug($slug);
+        $em->persist($group);
+        $em->flush();
+
+        return $group;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get('doctrine.orm.entity_manager');
+    }
+
+    private function subscriptionCount(Group $group): int
+    {
+        $em = $this->em();
+        $em->clear();
+
+        return (int) $em->getRepository(PushSubscription::class)->count([
+            'group' => $em->getRepository(Group::class)->find($group->getId()),
+        ]);
+    }
+}

--- a/tests/Unit/Push/GroupPushNotifierTest.php
+++ b/tests/Unit/Push/GroupPushNotifierTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\Push;
+
+use App\Entity\Group;
+use App\Entity\Profile;
+use App\Entity\PushSubscription;
+use App\Push\GroupPushNotifier;
+use App\Push\WebPushSenderInterface;
+use App\Repository\GroupRepository;
+use App\Repository\PushSubscriptionRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class GroupPushNotifierTest extends TestCase
+{
+    public function testBundlesNewItemsPerGroupAndSendsOnce(): void
+    {
+        $group = $this->group(1, 'Wahlkampf', 'slug-1');
+        $subscription = (new PushSubscription())->setGroup($group)->setEndpoint('e')->setP256dh('p')->setAuth('a');
+
+        $groupRepo = $this->createMock(GroupRepository::class);
+        $groupRepo->method('findByProfile')->willReturn([$group]);
+
+        $subRepo = $this->createMock(PushSubscriptionRepository::class);
+        $subRepo->method('findByGroup')->with($group)->willReturn([$subscription]);
+
+        $sender = $this->createMock(WebPushSenderInterface::class);
+        $sender->method('isEnabled')->willReturn(true);
+        $sender->expects(self::once())
+            ->method('send')
+            ->with(
+                [$subscription],
+                self::callback(fn (array $p): bool => $p['body'] === '3 neue Beiträge'
+                    && $p['title'] === 'Wahlkampf'
+                    && str_contains($p['url'], 'slug-1')),
+            );
+
+        $notifier = new GroupPushNotifier($groupRepo, $subRepo, $sender, $this->urlGenerator());
+
+        // Two profiles of the same group in one run: 2 + 1 = 3 bundled.
+        $notifier->recordNewItems(new Profile(), 2);
+        $notifier->recordNewItems(new Profile(), 1);
+        $notifier->dispatch();
+    }
+
+    public function testSingularBody(): void
+    {
+        $group = $this->group(1, 'G', 's');
+        $sub = (new PushSubscription())->setGroup($group)->setEndpoint('e')->setP256dh('p')->setAuth('a');
+
+        $groupRepo = $this->createMock(GroupRepository::class);
+        $groupRepo->method('findByProfile')->willReturn([$group]);
+        $subRepo = $this->createMock(PushSubscriptionRepository::class);
+        $subRepo->method('findByGroup')->willReturn([$sub]);
+
+        $sender = $this->createMock(WebPushSenderInterface::class);
+        $sender->method('isEnabled')->willReturn(true);
+        $sender->expects(self::once())->method('send')
+            ->with(self::anything(), self::callback(fn (array $p): bool => $p['body'] === '1 neuer Beitrag'));
+
+        $notifier = new GroupPushNotifier($groupRepo, $subRepo, $sender, $this->urlGenerator());
+        $notifier->recordNewItems(new Profile(), 1);
+        $notifier->dispatch();
+    }
+
+    public function testSkipsGroupsWithoutPublicPage(): void
+    {
+        $group = $this->group(1, 'G', 's');
+        $group->setPublicPageEnabled(false);
+
+        $groupRepo = $this->createMock(GroupRepository::class);
+        $groupRepo->method('findByProfile')->willReturn([$group]);
+        $subRepo = $this->createMock(PushSubscriptionRepository::class);
+
+        $sender = $this->createMock(WebPushSenderInterface::class);
+        $sender->method('isEnabled')->willReturn(true);
+        $sender->expects(self::never())->method('send');
+
+        $notifier = new GroupPushNotifier($groupRepo, $subRepo, $sender, $this->urlGenerator());
+        $notifier->recordNewItems(new Profile(), 5);
+        $notifier->dispatch();
+    }
+
+    public function testDoesNothingWhenSenderDisabled(): void
+    {
+        $groupRepo = $this->createMock(GroupRepository::class);
+        $groupRepo->expects(self::never())->method('findByProfile');
+        $subRepo = $this->createMock(PushSubscriptionRepository::class);
+
+        $sender = $this->createMock(WebPushSenderInterface::class);
+        $sender->method('isEnabled')->willReturn(false);
+        $sender->expects(self::never())->method('send');
+
+        $notifier = new GroupPushNotifier($groupRepo, $subRepo, $sender, $this->urlGenerator());
+        $notifier->recordNewItems(new Profile(), 5);
+        $notifier->dispatch();
+    }
+
+    private function group(int $id, string $name, string $slug): Group
+    {
+        $group = new Group();
+        $group->setName($name);
+        $group->setPublicPageEnabled(true);
+        $group->setPublicSlug($slug);
+
+        $ref = new \ReflectionProperty(Group::class, 'id');
+        $ref->setValue($group, $id);
+
+        return $group;
+    }
+
+    private function urlGenerator(): UrlGeneratorInterface
+    {
+        $generator = $this->createMock(UrlGeneratorInterface::class);
+        $generator->method('generate')->willReturnCallback(
+            static fn (string $route, array $params = []): string => 'https://example.test/p/' . ($params['slug'] ?? ''),
+        );
+
+        return $generator;
+    }
+}


### PR DESCRIPTION
## Was

Besucher der öffentlichen Gruppen-Seite (`/p/{slug}`) können **Web-Push-Benachrichtigungen abonnieren** und bekommen **pro Fetch-Zyklus eine gebündelte Benachrichtigung je Gruppe** („3 neue Beiträge …"), wenn Profile der Gruppe neue Beiträge haben. Ein Klick öffnet die öffentliche Gruppen-Seite. (Design mit dem Nutzer abgestimmt: öffentliche Seite, gebündelt pro Fetch, Klick → Gruppenseite.)

## Backend

- `PushSubscription`-Entity/Repository/Migration (eine Zeile je Browser-Endpoint je Gruppe, FK mit `ON DELETE CASCADE`).
- `WebPushSender` (minishlink/web-push + VAPID; entfernt abgelaufene Endpoints bei 404/410) + Interface; No-Op ohne VAPID-Keys.
- `GroupPushNotifier`: sammelt neue-Item-Zähler je öffentlich-aktiver Gruppe während eines Fetch-Laufs und versendet am Ende gebündelt.
- `FeedFetcher` erfasst pro Profil das Neu-Item-Delta (`getNewCount()` im Persister-Interface) und dispatcht am Laufende.
- Öffentliche `POST /p/{slug}/push/subscribe` + `/unsubscribe` (unter `/p/` → bereits `PUBLIC_ACCESS`).

## Frontend

- Root-scoped Service Worker `public/push-sw.js` (`push` + `notificationclick`).
- Stimulus `push_subscribe`-Controller (Permission, SW-Registrierung, Subscribe/Unsubscribe, Sync mit Backend) + Abo-Button auf der öffentlichen Seite (nur sichtbar bei Support/konfigurierten Keys).

## Config / Deploy

- VAPID-Keys via `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY`/`VAPID_SUBJECT` (leer = deaktiviert). `DEFAULT_URI` für absolute Links aus dem Fetch-Cron.
- **Deploy braucht:** `composer install` (neue Dependency), Migration `push_subscription`, VAPID-Keys + `DEFAULT_URI` in Prod-`.env.local`, `dump-autoload`, `asset-map:compile`, `cache:clear`.

## Tests

`GroupPushNotifierTest` (Bündelung, Singular/Plural, Skip nicht-öffentlicher Gruppen, No-Op ohne Keys), `PublicGroupPushTest` (Subscribe idempotent/Unsubscribe/400/404). Volle Suite grün (326 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)