### PR TITLE
Surface video download failures on completed items

### DIFF
--- a/templates/item/show.html.twig
+++ b/templates/item/show.html.twig
@@ -53,8 +53,11 @@
                             <p class="text-muted mb-0">Keine Medien heruntergeladen.</p>
                         {% endif %}
                     </div>
-                    {% if item.mediaStatus == 'failed' and item.mediaError %}
-                        <div class="alert alert-danger mt-3 mb-0">
+                    {% if item.mediaError %}
+                        {# Video-only failures keep mediaStatus "completed" (photos were
+                           saved) but must still surface the video/Instagram error so a
+                           missing video isn't mistaken for a fully successful download. #}
+                        <div class="alert {{ item.mediaStatus == 'failed' ? 'alert-danger' : 'alert-warning' }} mt-3 mb-0">
                             <i class="fas fa-exclamation-triangle me-1"></i>{{ item.mediaError }}
                         </div>
                     {% endif %}
@@ -63,6 +66,9 @@
                             <small class="text-muted">Status: </small>
                             {% if item.mediaStatus == 'completed' %}
                                 <span class="badge bg-success">{{ item.mediaStatus }}</span>
+                                {% if item.mediaError %}
+                                    <span class="badge bg-warning text-dark">Video fehlgeschlagen</span>
+                                {% endif %}
                             {% elseif item.mediaStatus == 'failed' %}
                                 <span class="badge bg-danger">{{ item.mediaStatus }}</span>
                             {% elseif item.mediaStatus == 'downloading' %}

--- a/tests/Functional/Web/ItemMediaFailureWebTest.php
+++ b/tests/Functional/Web/ItemMediaFailureWebTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Entity\Item;
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * A video download that fails while photos succeed keeps mediaStatus
+ * "completed"; the item detail page must still surface the video error so the
+ * missing video is visible, not mistaken for a full success.
+ */
+class ItemMediaFailureWebTest extends AbstractWebTestCase
+{
+    public function testCompletedItemWithVideoFailureShowsWarning(): void
+    {
+        $id = $this->createItem('completed', 'Video: yt-dlp failed: HTTP Error 404: Not Found', ['90001/1/photo_0.jpg']);
+
+        $this->loginAsAdmin();
+        $this->client->request('GET', sprintf('/items/%d', $id));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.alert-warning');
+        self::assertSelectorTextContains('.alert-warning', 'HTTP Error 404');
+        self::assertSelectorTextContains('.badge.bg-warning', 'Video fehlgeschlagen');
+    }
+
+    public function testFailedItemShowsDangerError(): void
+    {
+        $id = $this->createItem('failed', 'Photo: HTTP 403; Video: yt-dlp failed', []);
+
+        $this->loginAsAdmin();
+        $this->client->request('GET', sprintf('/items/%d', $id));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.alert-danger');
+    }
+
+    /**
+     * @param list<string> $photoPaths
+     */
+    private function createItem(string $mediaStatus, string $mediaError, array $photoPaths): int
+    {
+        $em = $this->entityManager();
+        /** @var Profile $profile */
+        $profile = $em->getRepository(Profile::class)->find(90001);
+
+        $item = new Item();
+        $item->setProfile($profile);
+        $item->setUniqueIdentifier('media-failure-' . $mediaStatus);
+        $item->setPermalink('https://www.instagram.com/p/DavbOT2kxtJ');
+        $item->setText('Media failure test');
+        $item->setDateTime(new \DateTimeImmutable('-1 hour'));
+        $item->setMediaStatus($mediaStatus);
+        $item->setMediaError($mediaError);
+        $item->setPhotoPaths($photoPaths);
+        $em->persist($item);
+        $em->flush();
+
+        return $item->getId();
+    }
+}


### PR DESCRIPTION
## Problem

Scheitert nur der **Video**-Download (Fotos ok), bleibt `mediaStatus = completed` und der Video-Fehler landet nur still in `mediaError`. Die Item-Detailseite zeigte `mediaError` aber **nur** bei `failed` — ein fehlendes Video sah aus wie ein voller Erfolg (grünes „completed"). Besonders relevant, da yt-dlp Instagram-Medien serverseitig derzeit nicht laden kann.

## Fix

- `mediaError` wird jetzt **immer** angezeigt (gelb/`alert-warning` bei „completed", rot/`alert-danger` bei „failed").
- Zusätzliches Badge **„Video fehlgeschlagen"** neben dem „completed"-Status, wenn ein `mediaError` vorliegt.

## Tests

`ItemMediaFailureWebTest`: „completed" + Video-Fehler → Warnung + Badge sichtbar; „failed" → roter Fehler. Volle Suite grün (328 Tests).
🤖 Generated with [Claude Code](https://claude.com/claude-code)