### PR TITLE
Browser media-upload endpoint + Chrome extension for Instagram media

### DIFF
--- a/.env
+++ b/.env
@@ -55,6 +55,13 @@ WEB_ADMIN_PASSWORD_HASH='$2y$13$changeme'
 DEFAULT_URI=http://localhost
 ###< app/base-url ###
 
+###> app/media-upload ###
+# Bearer token for the browser media-upload endpoint (POST /media-upload), used by
+# the Chrome extension to push Instagram media the server can't fetch itself.
+# Empty disables the endpoint. Generate a strong random value for production.
+MEDIA_UPLOAD_TOKEN=
+###< app/media-upload ###
+
 ###> app/web-push ###
 # Web Push (browser push notifications). Generate a key pair once with:
 #   php -r 'require "vendor/autoload.php"; var_export(Minishlink\WebPush\VAPID::createVapidKeys());'

--- a/.env.test
+++ b/.env.test
@@ -8,3 +8,4 @@ VAPID_PUBLIC_KEY=BMT5_U4QEeMM_XQA3vRfvj-KZyNDpkJ4mkSnw0w-MqKSxuof5sm3_qPdmHWGDga
 VAPID_PRIVATE_KEY=kBQ4Vybnbs_QyXwkCbad-_oHG9P9Kp7iYmpuXUxkMGg
 VAPID_SUBJECT=mailto:test@example.com
 DEFAULT_URI=http://localhost
+MEDIA_UPLOAD_TOKEN=test-upload-token

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,0 +1,46 @@
+# Feed Media Uploader (Chrome-Erweiterung)
+
+Lädt Video/Fotos eines offenen Instagram-Posts in die Social-Network-Fetcher-App.
+Der Server kann Instagram-Medien selbst nicht laden (Instagram blockt
+Rechenzentrums-IPs); dein Browser hat eine Wohn-IP + eingeloggte Session und kommt
+dran. Die Erweiterung greift das Medium ab und schickt es an den
+`/media-upload`-Endpunkt der App, der es dem passenden Item (per Permalink)
+zuordnet und – bei Videos – die Transkription anstößt.
+
+## Voraussetzung: Token auf dem Server
+
+In der Server-`.env.local` einen `MEDIA_UPLOAD_TOKEN` setzen (starker Zufallswert),
+z. B.:
+
+```
+MEDIA_UPLOAD_TOKEN=<langer-zufallswert>
+```
+
+Danach `bin/console cache:clear --env=prod`. Leerer Token = Endpunkt deaktiviert.
+
+## Installation
+
+1. `chrome://extensions` öffnen.
+2. **Entwicklermodus** oben rechts aktivieren.
+3. **Entpackte Erweiterung laden** → diesen `browser-extension/`-Ordner wählen.
+4. Auf das Erweiterungs-Icon → **Optionen** (bzw. Rechtsklick → Optionen):
+   - **App-URL**: `https://feeds.maltehuebner.dev`
+   - **Upload-Token**: derselbe Wert wie `MEDIA_UPLOAD_TOKEN` auf dem Server.
+   - Speichern.
+
+## Nutzung
+
+1. Instagram-Post im Browser öffnen (URL der Form `…/p/…` oder `…/reel/…`).
+   Wichtig: die **Einzelpost-Seite**, nicht der Feed.
+2. Auf das Erweiterungs-Icon klicken → **Laden & hochladen**.
+3. Eine Benachrichtigung meldet Erfolg (Video/Fotos, ob Transkription eingereiht).
+
+## Grenzen (ehrlich)
+
+- Instagram liefert Videos teils nur als segmentierten `blob:`-Stream; solche
+  lassen sich nicht direkt herunterladen — die Erweiterung meldet dann „kein
+  ladbares Medium gefunden". Sie nutzt vorrangig die `og:video`/`og:image`-Meta-Tags
+  der Post-Seite, die meist die direkte CDN-URL enthalten.
+- Karussells (mehrere Bilder) laden aktuell nur das Hauptbild.
+- Instagram ändert seine Seiten häufig; die Extraktion kann brechen und
+  gelegentlich Anpassung brauchen.

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,0 +1,83 @@
+/*
+ * Fetches the media bytes (using the browser's residential IP + Instagram
+ * session via host permissions) and uploads them to the app's /media-upload
+ * endpoint. Runs in the service worker so it survives the popup closing.
+ */
+
+async function getSettings() {
+    const { appUrl, token } = await chrome.storage.sync.get(['appUrl', 'token']);
+    return {
+        appUrl: (appUrl || 'https://feeds.maltehuebner.dev').replace(/\/+$/, ''),
+        token: token || '',
+    };
+}
+
+async function fetchAsFile(url, fallbackName) {
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) {
+        throw new Error(`Download fehlgeschlagen (${res.status})`);
+    }
+    const blob = await res.blob();
+    const ext = (blob.type.split('/')[1] || '').split(';')[0] || fallbackName.split('.').pop();
+    const name = fallbackName.replace(/\.[^.]*$/, '') + '.' + ext;
+    return new File([blob], name, { type: blob.type });
+}
+
+async function upload({ permalink, videoUrl, imageUrl }) {
+    const { appUrl, token } = await getSettings();
+    if (!token) {
+        throw new Error('Kein Token gesetzt — bitte in den Optionen konfigurieren.');
+    }
+
+    const form = new FormData();
+    form.append('permalink', permalink);
+
+    if (videoUrl) {
+        form.append('video', await fetchAsFile(videoUrl, 'video.mp4'));
+    }
+    if (imageUrl) {
+        form.append('photos[]', await fetchAsFile(imageUrl, 'photo.jpg'));
+    }
+
+    const res = await fetch(`${appUrl}/media-upload`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        throw new Error(data.error || `Upload fehlgeschlagen (${res.status})`);
+    }
+    return data;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.type !== 'upload') {
+        return false;
+    }
+
+    upload(message.payload)
+        .then((data) => {
+            notify('Hochgeladen', `Video: ${data.video ? 'ja' : 'nein'}, Fotos: ${data.photos}${data.transcriptQueued ? ' — Transkription eingereiht' : ''}`);
+            sendResponse({ ok: true, data });
+        })
+        .catch((err) => {
+            notify('Fehler', err.message);
+            sendResponse({ ok: false, error: err.message });
+        });
+
+    return true; // keep the message channel open for the async response
+});
+
+// 1x1 transparent PNG — avoids shipping a binary icon asset just for notifications.
+const ICON = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+function notify(title, message) {
+    chrome.notifications.create({
+        type: 'basic',
+        iconUrl: ICON,
+        title,
+        message,
+    });
+}

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+    "manifest_version": 3,
+    "name": "Feed Media Uploader",
+    "version": "1.0.0",
+    "description": "Lädt Video/Fotos eines offenen Instagram-Posts in die Social-Network-Fetcher-App (die der Server selbst nicht laden kann).",
+    "permissions": ["scripting", "storage", "activeTab", "notifications"],
+    "host_permissions": [
+        "https://www.instagram.com/*",
+        "https://*.cdninstagram.com/*",
+        "https://*.fbcdn.net/*",
+        "https://feeds.maltehuebner.dev/*"
+    ],
+    "action": {
+        "default_popup": "popup.html",
+        "default_title": "Instagram-Post in die App laden"
+    },
+    "options_page": "options.html",
+    "background": {
+        "service_worker": "background.js"
+    }
+}

--- a/browser-extension/options.html
+++ b/browser-extension/options.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font: 14px/1.5 system-ui, sans-serif; max-width: 460px; margin: 30px auto; padding: 0 16px; }
+        label { display: block; font-weight: 600; margin: 16px 0 4px; }
+        input { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 6px; box-sizing: border-box; font: inherit; }
+        button { margin-top: 18px; font: inherit; font-weight: 600; padding: 9px 16px; border: 0; border-radius: 7px; background: #2f6feb; color: #fff; cursor: pointer; }
+        .hint { color: #666; font-size: 12px; margin-top: 4px; }
+        #saved { color: #1e824c; margin-left: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Feed Media Uploader — Einstellungen</h1>
+
+    <label for="appUrl">App-URL</label>
+    <input id="appUrl" type="url" placeholder="https://feeds.maltehuebner.dev">
+    <div class="hint">Basis-URL der App (ohne /media-upload).</div>
+
+    <label for="token">Upload-Token</label>
+    <input id="token" type="password" placeholder="MEDIA_UPLOAD_TOKEN">
+    <div class="hint">Der auf dem Server gesetzte MEDIA_UPLOAD_TOKEN.</div>
+
+    <button id="save">Speichern</button><span id="saved" hidden>Gespeichert ✓</span>
+
+    <script src="options.js"></script>
+</body>
+</html>

--- a/browser-extension/options.js
+++ b/browser-extension/options.js
@@ -1,0 +1,17 @@
+const appUrlEl = document.getElementById('appUrl');
+const tokenEl = document.getElementById('token');
+const savedEl = document.getElementById('saved');
+
+chrome.storage.sync.get(['appUrl', 'token']).then(({ appUrl, token }) => {
+    appUrlEl.value = appUrl || 'https://feeds.maltehuebner.dev';
+    tokenEl.value = token || '';
+});
+
+document.getElementById('save').addEventListener('click', async () => {
+    await chrome.storage.sync.set({
+        appUrl: appUrlEl.value.trim().replace(/\/+$/, ''),
+        token: tokenEl.value.trim(),
+    });
+    savedEl.hidden = false;
+    setTimeout(() => { savedEl.hidden = true; }, 2000);
+});

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font: 13px/1.4 system-ui, sans-serif; width: 300px; margin: 0; padding: 14px; }
+        h1 { font-size: 14px; margin: 0 0 10px; }
+        button { font: inherit; font-weight: 600; width: 100%; padding: 9px; border: 0; border-radius: 7px; background: #2f6feb; color: #fff; cursor: pointer; }
+        button:disabled { opacity: .6; cursor: default; }
+        .muted { color: #666; }
+        .permalink { word-break: break-all; font-size: 12px; margin: 6px 0 12px; color: #444; }
+        #status { margin-top: 12px; white-space: pre-wrap; }
+        .err { color: #c0392b; }
+        .ok { color: #1e824c; }
+        a { color: #2f6feb; }
+    </style>
+</head>
+<body>
+    <h1>Instagram-Post in die App laden</h1>
+    <div id="notReady" class="muted" hidden></div>
+    <div class="permalink" id="permalink"></div>
+    <button id="go" disabled>Laden &amp; hochladen</button>
+    <div id="status" class="muted"></div>
+    <div style="margin-top:12px"><a href="#" id="opts">Einstellungen</a></div>
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -1,0 +1,90 @@
+/* Popup: detect the Instagram post in the active tab, extract its media URLs
+ * in-page, and hand them to the background worker for download + upload. */
+
+const goBtn = document.getElementById('go');
+const statusEl = document.getElementById('status');
+const permalinkEl = document.getElementById('permalink');
+const notReadyEl = document.getElementById('notReady');
+
+document.getElementById('opts').addEventListener('click', (e) => {
+    e.preventDefault();
+    chrome.runtime.openOptionsPage();
+});
+
+// Injected into the page: read the post's canonical URL and media via og: tags.
+function extractMedia() {
+    const canonical = document.querySelector('link[rel="canonical"]')?.href || location.href;
+    const permalink = canonical.split('?')[0].split('#')[0];
+    const og = (p) => document.querySelector(`meta[property="${p}"]`)?.content || null;
+
+    let videoUrl = og('og:video:secure_url') || og('og:video');
+    if (!videoUrl) {
+        const v = document.querySelector('video');
+        const src = v && (v.currentSrc || v.src);
+        if (src && !src.startsWith('blob:')) videoUrl = src;
+    }
+    const imageUrl = og('og:image');
+
+    return { permalink, videoUrl: videoUrl || null, imageUrl: imageUrl || null };
+}
+
+async function init() {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const isPost = tab?.url && /^https:\/\/www\.instagram\.com\/(p|reel)\//.test(tab.url);
+
+    const { token } = await chrome.storage.sync.get(['token']);
+    if (!token) {
+        notReadyEl.hidden = false;
+        notReadyEl.innerHTML = 'Kein Token gesetzt. Bitte zuerst in den <a href="#" id="o2">Einstellungen</a> hinterlegen.';
+        document.getElementById('o2').addEventListener('click', (e) => { e.preventDefault(); chrome.runtime.openOptionsPage(); });
+        return;
+    }
+
+    if (!isPost) {
+        notReadyEl.hidden = false;
+        notReadyEl.textContent = 'Öffne einen Instagram-Post (…/p/… oder …/reel/…) und klicke dann hier.';
+        return;
+    }
+
+    permalinkEl.textContent = tab.url.split('?')[0];
+    goBtn.disabled = false;
+    goBtn.addEventListener('click', () => run(tab.id));
+}
+
+async function run(tabId) {
+    goBtn.disabled = true;
+    setStatus('Medien werden ausgelesen …', 'muted');
+
+    try {
+        const [{ result }] = await chrome.scripting.executeScript({
+            target: { tabId },
+            func: extractMedia,
+        });
+
+        if (!result || (!result.videoUrl && !result.imageUrl)) {
+            setStatus('Kein ladbares Medium gefunden. Instagram liefert das Video evtl. nur als Stream (blob:).', 'err');
+            goBtn.disabled = false;
+            return;
+        }
+
+        setStatus('Hochladen …', 'muted');
+        const res = await chrome.runtime.sendMessage({ type: 'upload', payload: result });
+
+        if (res?.ok) {
+            setStatus(`Fertig ✓ Video: ${res.data.video ? 'ja' : 'nein'}, Fotos: ${res.data.photos}` + (res.data.transcriptQueued ? '\nTranskription eingereiht.' : ''), 'ok');
+        } else {
+            setStatus('Fehler: ' + (res?.error || 'unbekannt'), 'err');
+            goBtn.disabled = false;
+        }
+    } catch (e) {
+        setStatus('Fehler: ' + e.message, 'err');
+        goBtn.disabled = false;
+    }
+}
+
+function setStatus(text, cls) {
+    statusEl.textContent = text;
+    statusEl.className = cls;
+}
+
+init();

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -47,6 +47,9 @@ security:
         - { path: ^/login, roles: PUBLIC_ACCESS }
         # Public per-group feed pages are reachable without authentication.
         - { path: ^/p/, roles: PUBLIC_ACCESS }
+        # Browser media-upload endpoint: authenticated by its own bearer token in
+        # the controller, so it is opened here (the admin catch-all would 302 it).
+        - { path: ^/media-upload, roles: PUBLIC_ACCESS }
         # Group management is available to both admins and client-token users.
         - { path: ^/groups, roles: [ROLE_ADMIN, ROLE_API_CLIENT] }
         - { path: ^/, roles: ROLE_ADMIN }

--- a/config/packages/test/flysystem.yaml
+++ b/config/packages/test/flysystem.yaml
@@ -1,0 +1,6 @@
+flysystem:
+    storages:
+        default.storage:
+            adapter: 'local'
+            options:
+                directory: '%kernel.cache_dir%/test-media'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,7 @@ services:
             $vapidPublicKey: '%env(VAPID_PUBLIC_KEY)%'
             $vapidPrivateKey: '%env(VAPID_PRIVATE_KEY)%'
             $vapidSubject: '%env(VAPID_SUBJECT)%'
+            $mediaUploadToken: '%env(MEDIA_UPLOAD_TOKEN)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Controller/MediaUploadController.php
+++ b/src/Controller/MediaUploadController.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Repository\ItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Receives media (video/photos) that the browser extension grabbed from an
+ * Instagram post — media the server itself cannot download — and attaches it to
+ * the matching item (by permalink), then queues transcription. Authenticated by
+ * its own bearer token (MEDIA_UPLOAD_TOKEN), opened as PUBLIC_ACCESS.
+ */
+class MediaUploadController extends AbstractController
+{
+    private const VIDEO_EXTENSIONS = ['mp4', 'mov', 'webm', 'm4v'];
+    private const PHOTO_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+
+    public function __construct(
+        private readonly ItemRepository $itemRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FilesystemOperator $defaultStorage,
+        private readonly string $mediaUploadToken,
+    ) {
+    }
+
+    #[Route('/media-upload', name: 'app_media_upload', methods: ['POST'])]
+    public function upload(Request $request): JsonResponse
+    {
+        if ($this->mediaUploadToken === '' || !hash_equals($this->mediaUploadToken, $this->bearerToken($request))) {
+            return new JsonResponse(['error' => 'unauthorized'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $permalink = trim((string) $request->request->get('permalink', ''));
+        if ($permalink === '') {
+            return new JsonResponse(['error' => 'permalink is required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $item = $this->findItemByPermalink($permalink);
+        if ($item === null) {
+            return new JsonResponse(['error' => 'no item found for permalink'], Response::HTTP_NOT_FOUND);
+        }
+
+        $profile = $item->getProfile();
+        if ($profile === null) {
+            return new JsonResponse(['error' => 'item has no profile'], Response::HTTP_CONFLICT);
+        }
+
+        $video = $request->files->get('video');
+        /** @var list<UploadedFile> $photos */
+        $photos = array_values(array_filter($request->files->all('photos')));
+
+        if (!$video instanceof UploadedFile && $photos === []) {
+            return new JsonResponse(['error' => 'no media provided'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $prefix = sprintf('%d/%d', $profile->getId(), $item->getId());
+        $stored = ['photos' => 0, 'video' => false];
+
+        if ($video instanceof UploadedFile) {
+            $ext = $this->safeExtension($video, self::VIDEO_EXTENSIONS);
+            if ($ext === null) {
+                return new JsonResponse(['error' => 'unsupported video type'], Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
+            }
+            $path = sprintf('%s/video.%s', $prefix, $ext);
+            $this->defaultStorage->write($path, (string) file_get_contents($video->getPathname()));
+            $item->setVideoPath($path);
+            $stored['video'] = true;
+        }
+
+        if ($photos !== []) {
+            $paths = [];
+            foreach ($photos as $i => $photo) {
+                $ext = $this->safeExtension($photo, self::PHOTO_EXTENSIONS);
+                if ($ext === null) {
+                    return new JsonResponse(['error' => 'unsupported photo type'], Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
+                }
+                $path = sprintf('%s/photo_%d.%s', $prefix, $i, $ext);
+                $this->defaultStorage->write($path, (string) file_get_contents($photo->getPathname()));
+                $paths[] = $path;
+            }
+            $item->setPhotoPaths($paths);
+            $stored['photos'] = count($paths);
+        }
+
+        $item->setMediaStatus('completed');
+        $item->setMediaError(null);
+
+        if ($stored['video'] && $profile->isTranscribeVideos()) {
+            $item->setTranscriptStatus('pending');
+            $item->setTranscriptError(null);
+        }
+
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'status' => 'stored',
+            'itemId' => $item->getId(),
+            'video' => $stored['video'],
+            'photos' => $stored['photos'],
+            'transcriptQueued' => $stored['video'] && $profile->isTranscribeVideos(),
+        ]);
+    }
+
+    /**
+     * Instagram permalinks differ only by a trailing slash between the page's
+     * canonical URL and what was stored, so match both forms.
+     */
+    private function findItemByPermalink(string $permalink): ?\App\Entity\Item
+    {
+        $base = rtrim($permalink, '/');
+        foreach (array_unique([$permalink, $base, $base . '/']) as $candidate) {
+            $item = $this->itemRepository->findOneBy(['permalink' => $candidate]);
+            if ($item !== null) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function bearerToken(Request $request): string
+    {
+        $header = $request->headers->get('Authorization', '');
+
+        return str_starts_with($header, 'Bearer ') ? substr($header, 7) : '';
+    }
+
+    /**
+     * @param list<string> $allowed
+     */
+    private function safeExtension(UploadedFile $file, array $allowed): ?string
+    {
+        $ext = strtolower($file->getClientOriginalExtension() ?: (string) $file->guessExtension());
+
+        return in_array($ext, $allowed, true) ? $ext : null;
+    }
+}

--- a/tests/Functional/Web/MediaUploadWebTest.php
+++ b/tests/Functional/Web/MediaUploadWebTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Entity\Item;
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class MediaUploadWebTest extends AbstractWebTestCase
+{
+    private const PERMALINK = 'https://www.instagram.com/p/UploadTest1/';
+
+    public function testUploadAttachesVideoAndQueuesTranscription(): void
+    {
+        $this->createItemWithTranscription();
+
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => self::PERMALINK],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseIsSuccessful();
+
+        $em = $this->entityManager();
+        $em->clear();
+        $item = $em->getRepository(Item::class)->findOneBy(['permalink' => self::PERMALINK]);
+
+        self::assertNotNull($item->getVideoPath());
+        self::assertSame('completed', $item->getMediaStatus());
+        self::assertSame('pending', $item->getTranscriptStatus(), 'transcription queued for a video on a transcribe-enabled profile');
+    }
+
+    public function testMatchesPermalinkDespiteTrailingSlashMismatch(): void
+    {
+        $this->createItemWithTranscription(); // stored with a trailing slash
+
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => rtrim(self::PERMALINK, '/')], // sent without one
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testRejectsWrongToken(): void
+    {
+        $this->createItemWithTranscription();
+
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => self::PERMALINK],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer wrong'],
+        );
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testUnknownPermalinkIs404(): void
+    {
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => 'https://www.instagram.com/p/DoesNotExist/'],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testRejectsUnsupportedType(): void
+    {
+        $this->createItemWithTranscription();
+
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => self::PERMALINK],
+            ['video' => $this->fakeUpload('clip.exe', 'application/octet-stream')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseStatusCodeSame(415);
+    }
+
+    private function createItemWithTranscription(): void
+    {
+        $em = $this->entityManager();
+        $network = $em->getRepository(Network::class)->findOneBy(['identifier' => 'instagram_profile']);
+
+        $profile = new Profile();
+        $profile->setId(95001);
+        $profile->setIdentifier('https://www.instagram.com/uploadtest/');
+        $profile->setNetwork($network);
+        $profile->setCreatedAt(new \DateTimeImmutable());
+        $profile->setSaveVideos(true);
+        $profile->setTranscribeVideos(true);
+        $em->persist($profile);
+
+        $item = new Item();
+        $item->setProfile($profile);
+        $item->setUniqueIdentifier('upload-test-1');
+        $item->setPermalink(self::PERMALINK);
+        $item->setText('Upload test');
+        $item->setDateTime(new \DateTimeImmutable('-1 hour'));
+        $item->setMediaStatus('completed');
+        $item->setMediaError('Video: yt-dlp failed');
+        $em->persist($item);
+        $em->flush();
+    }
+
+    private function fakeUpload(string $name, string $mime): UploadedFile
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'up');
+        file_put_contents($tmp, 'dummy-media-bytes');
+
+        return new UploadedFile($tmp, $name, $mime, null, true);
+    }
+}


### PR DESCRIPTION
## Warum

Der Server kann Instagram-Medien nicht laden (Instagram blockt Rechenzentrums-IPs). Ein eingeloggter Browser auf Wohn-IP kommt aber dran. Dieses Feature schleust die Medien aus dem Browser in die App.

## Backend

`POST /media-upload` (Bearer `MEDIA_UPLOAD_TOKEN`, als `PUBLIC_ACCESS` freigegeben, Token-Check im Controller):
- Ordnet hochgeladenes Video/Fotos dem Item mit passendem **Permalink** zu (tolerant gegen abschließenden Slash).
- Speichert Dateien über den bestehenden Flysystem-Media-Store (`{profileId}/{itemId}/…`).
- Setzt `mediaStatus=completed`, löscht `mediaError`, und reiht bei Videos auf Transkriptions-Profilen `transcriptStatus=pending` ein.
- Typ-Whitelist (mp4/mov/webm/m4v, jpg/png/webp), 401/404/415/400.

## Erweiterung (`browser-extension/`, Manifest V3)

Auf einer Instagram-Post-Seite: liest `og:video`/`og:image`, lädt die Bytes mit der Browser-Session und lädt sie zum Endpunkt hoch. Token/App-URL in der Options-Seite. README mit Installations- und Nutzungsanleitung inkl. ehrlicher Grenzen (blob:-Videos, Karussells).

## Deploy

`MEDIA_UPLOAD_TOKEN` in Prod-`.env.local` setzen + `cache:clear`. Kein Migrationsbedarf.

## Tests

`MediaUploadWebTest`: Upload hängt Video an + reiht Transkription ein; Permalink-Slash-Toleranz; 401 (falscher Token), 404 (unbekannt), 415 (falscher Typ). Volle Suite grün (333 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)