### PR TITLE
Add "Angemeldet bleiben" (remember-me) to the admin login

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -9,3 +9,7 @@ VAPID_PRIVATE_KEY=kBQ4Vybnbs_QyXwkCbad-_oHG9P9Kp7iYmpuXUxkMGg
 VAPID_SUBJECT=mailto:test@example.com
 DEFAULT_URI=http://localhost
 MEDIA_UPLOAD_TOKEN=test-upload-token
+
+# Known admin credentials for form-login tests (password: adminpass).
+WEB_ADMIN_USERNAME=admin
+WEB_ADMIN_PASSWORD_HASH='$2y$04$js.IYLKuePJbtC/z7e44Z.yS.RsWNbv6ktHeDQDGL2fo3hCpC7IDa'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,12 @@ security:
                 check_path: app_login
                 default_target_path: app_dashboard
                 enable_csrf: true
+            # "Angemeldet bleiben": signature-based (no DB table), only issued when
+            # the login form sends the _remember_me checkbox.
+            remember_me:
+                secret: '%kernel.secret%'
+                lifetime: 2592000 # 30 days
+                path: /
             custom_authenticators:
                 - App\Security\WebTokenAuthenticator
             logout:

--- a/templates/login/login.html.twig
+++ b/templates/login/login.html.twig
@@ -49,6 +49,11 @@
                                    class="form-control" required autocomplete="current-password">
                         </div>
 
+                        <div class="form-check mb-3">
+                            <input type="checkbox" class="form-check-input" id="remember_me" name="_remember_me" value="1" checked>
+                            <label class="form-check-label" for="remember_me">Angemeldet bleiben</label>
+                        </div>
+
                         <button type="submit" class="btn-primary-custom w-100">
                             <i class="fas fa-sign-in-alt me-1"></i>Sign in
                         </button>

--- a/tests/Functional/Web/RememberMeWebTest.php
+++ b/tests/Functional/Web/RememberMeWebTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * The admin form login offers "Angemeldet bleiben"; when checked, the firewall
+ * must issue a persistent REMEMBERME cookie so the session survives a browser
+ * restart.
+ */
+class RememberMeWebTest extends AbstractWebTestCase
+{
+    public function testLoginWithRememberMeSetsCookie(): void
+    {
+        $this->submitLogin(rememberMe: true);
+
+        self::assertResponseRedirects();
+        self::assertNotNull(
+            $this->client->getCookieJar()->get('REMEMBERME'),
+            'a remember-me cookie is issued when the box is checked',
+        );
+    }
+
+    public function testLoginWithoutRememberMeSetsNoCookie(): void
+    {
+        $this->submitLogin(rememberMe: false);
+
+        self::assertResponseRedirects();
+        self::assertNull($this->client->getCookieJar()->get('REMEMBERME'));
+    }
+
+    private function submitLogin(bool $rememberMe): void
+    {
+        $crawler = $this->client->request('GET', '/login');
+        $form = $crawler->selectButton('Sign in')->form([
+            '_username' => 'admin',
+            '_password' => 'adminpass',
+        ]);
+
+        if ($rememberMe) {
+            $form['_remember_me']->tick();
+        } else {
+            $form['_remember_me']->untick();
+        }
+
+        $this->client->submit($form);
+    }
+}


### PR DESCRIPTION
## Was

„Angemeldet bleiben" beim Admin-Login: Symfonys signaturbasiertes `remember_me` an der `main`-Firewall (30 Tage, **kein DB-Table**) + eine standardmäßig angehakte `_remember_me`-Checkbox im Admin-Login-Formular. Admins bleiben so über Browser-Neustarts eingeloggt. Client-Token-Login bleibt unberührt.

## Tests

`RememberMeWebTest`: Formular-Login **mit** Haken → `REMEMBERME`-Cookie gesetzt; **ohne** → kein Cookie. (Test-Admin-Credentials in `.env.test`.) Volle Suite grün (335 Tests).

## Deploy

Nur Config + Template — `git pull` + `cache:clear`. Nutzt `APP_SECRET` (bereits gesetzt).
🤖 Generated with [Claude Code](https://claude.com/claude-code)