### PR TITLE
Create the item on media upload when the post isn't fetched yet

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -23,7 +23,7 @@ async function fetchAsFile(url, fallbackName) {
     return new File([blob], name, { type: blob.type });
 }
 
-async function upload({ permalink, videoUrl, imageUrl }) {
+async function upload({ permalink, videoUrl, imageUrl, text, dateTime, author }) {
     const { appUrl, token } = await getSettings();
     if (!token) {
         throw new Error('Kein Token gesetzt — bitte in den Optionen konfigurieren.');
@@ -31,6 +31,9 @@ async function upload({ permalink, videoUrl, imageUrl }) {
 
     const form = new FormData();
     form.append('permalink', permalink);
+    if (text) form.append('text', text);
+    if (dateTime) form.append('dateTime', dateTime);
+    if (author) form.append('author', author);
 
     if (videoUrl) {
         form.append('video', await fetchAsFile(videoUrl, 'video.mp4'));
@@ -59,7 +62,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     upload(message.payload)
         .then((data) => {
-            notify('Hochgeladen', `Video: ${data.video ? 'ja' : 'nein'}, Fotos: ${data.photos}${data.transcriptQueued ? ' — Transkription eingereiht' : ''}`);
+            notify('Hochgeladen', `${data.created ? 'Item angelegt. ' : ''}Video: ${data.video ? 'ja' : 'nein'}, Fotos: ${data.photos}${data.transcriptQueued ? ' — Transkription eingereiht' : ''}`);
             sendResponse({ ok: true, data });
         })
         .catch((err) => {

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -11,7 +11,7 @@ document.getElementById('opts').addEventListener('click', (e) => {
     chrome.runtime.openOptionsPage();
 });
 
-// Injected into the page: read the post's canonical URL and media via og: tags.
+// Injected into the page: read the post's canonical URL, media and metadata.
 function extractMedia() {
     const canonical = document.querySelector('link[rel="canonical"]')?.href || location.href;
     const permalink = canonical.split('?')[0].split('#')[0];
@@ -24,8 +24,22 @@ function extractMedia() {
         if (src && !src.startsWith('blob:')) videoUrl = src;
     }
     const imageUrl = og('og:image');
+    const text = og('og:description') || '';
+    const dateTime = document.querySelector('time[datetime]')?.getAttribute('datetime') || '';
 
-    return { permalink, videoUrl: videoUrl || null, imageUrl: imageUrl || null };
+    // Author handle, so the app can create the item if it hasn't fetched the post yet.
+    let author = null;
+    const skip = ['p', 'reel', 'reels', 'explore', 'accounts', 'direct', 'stories'];
+    for (const a of document.querySelectorAll('a[href^="/"]')) {
+        const m = (a.getAttribute('href') || '').match(/^\/([A-Za-z0-9._]+)\/$/);
+        if (m && !skip.includes(m[1])) { author = m[1]; break; }
+    }
+    if (!author) {
+        const mm = document.documentElement.innerHTML.match(/"username":"([^"]+)"/);
+        if (mm) author = mm[1];
+    }
+
+    return { permalink, videoUrl: videoUrl || null, imageUrl: imageUrl || null, text, dateTime, author };
 }
 
 async function init() {
@@ -71,15 +85,24 @@ async function run(tabId) {
         const res = await chrome.runtime.sendMessage({ type: 'upload', payload: result });
 
         if (res?.ok) {
-            setStatus(`Fertig ✓ Video: ${res.data.video ? 'ja' : 'nein'}, Fotos: ${res.data.photos}` + (res.data.transcriptQueued ? '\nTranskription eingereiht.' : ''), 'ok');
+            const info = `${res.data.created ? '(Item angelegt) ' : ''}Video: ${res.data.video ? 'ja' : 'nein'}, Fotos: ${res.data.photos}`;
+            setStatus('Fertig ✓ ' + info + (res.data.transcriptQueued ? '\nTranskription eingereiht.' : ''), 'ok');
         } else {
-            setStatus('Fehler: ' + (res?.error || 'unbekannt'), 'err');
+            setStatus('Fehler: ' + friendlyError(res?.error), 'err');
             goBtn.disabled = false;
         }
     } catch (e) {
         setStatus('Fehler: ' + e.message, 'err');
         goBtn.disabled = false;
     }
+}
+
+function friendlyError(error) {
+    if (!error) return 'unbekannt';
+    if (error.includes('no item found')) return 'Post noch nicht in der App und Account nicht erkennbar.';
+    if (error.startsWith('no tracked profile')) return 'Dieser Account ist kein Profil in der App — bitte zuerst anlegen.';
+    if (error.includes('unauthorized')) return 'Token ungültig — bitte in den Einstellungen prüfen.';
+    return error;
 }
 
 function setStatus(text, cls) {

--- a/src/Controller/MediaUploadController.php
+++ b/src/Controller/MediaUploadController.php
@@ -2,7 +2,10 @@
 
 namespace App\Controller;
 
+use App\Entity\Item;
+use App\Entity\Profile;
 use App\Repository\ItemRepository;
+use App\Repository\ProfileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -25,6 +28,7 @@ class MediaUploadController extends AbstractController
 
     public function __construct(
         private readonly ItemRepository $itemRepository,
+        private readonly ProfileRepository $profileRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly FilesystemOperator $defaultStorage,
         private readonly string $mediaUploadToken,
@@ -44,8 +48,24 @@ class MediaUploadController extends AbstractController
         }
 
         $item = $this->findItemByPermalink($permalink);
+        $created = false;
+
         if ($item === null) {
-            return new JsonResponse(['error' => 'no item found for permalink'], Response::HTTP_NOT_FOUND);
+            // Post not fetched yet: create the item so media can be attached now.
+            // Using the permalink as uniqueIdentifier matches the RSS.app fetcher,
+            // so a later fetch updates this item instead of duplicating it.
+            $author = trim((string) $request->request->get('author', ''));
+            if ($author === '') {
+                return new JsonResponse(['error' => 'no item found for permalink'], Response::HTTP_NOT_FOUND);
+            }
+
+            $profile = $this->profileRepository->findOneByAccountName($author);
+            if ($profile === null) {
+                return new JsonResponse(['error' => sprintf('no tracked profile for account "%s"', $author)], Response::HTTP_UNPROCESSABLE_ENTITY);
+            }
+
+            $item = $this->createItem($profile, rtrim($permalink, '/'), $request);
+            $created = true;
         }
 
         $profile = $item->getProfile();
@@ -103,10 +123,34 @@ class MediaUploadController extends AbstractController
         return new JsonResponse([
             'status' => 'stored',
             'itemId' => $item->getId(),
+            'created' => $created,
             'video' => $stored['video'],
             'photos' => $stored['photos'],
             'transcriptQueued' => $stored['video'] && $profile->isTranscribeVideos(),
         ]);
+    }
+
+    private function createItem(Profile $profile, string $permalink, Request $request): Item
+    {
+        $dateRaw = trim((string) $request->request->get('dateTime', ''));
+        try {
+            $dateTime = $dateRaw !== '' ? new \DateTimeImmutable($dateRaw) : new \DateTimeImmutable();
+        } catch (\Exception) {
+            $dateTime = new \DateTimeImmutable();
+        }
+
+        $item = new Item();
+        $item->setProfile($profile)
+            ->setUniqueIdentifier($permalink)
+            ->setPermalink($permalink)
+            ->setText(trim((string) $request->request->get('text', '')))
+            ->setDateTime($dateTime);
+
+        $this->entityManager->persist($item);
+        // Flush now so the item has an id for the {profileId}/{itemId} media path.
+        $this->entityManager->flush();
+
+        return $item;
     }
 
     /**

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -15,6 +15,29 @@ class ProfileRepository extends ServiceEntityRepository
         parent::__construct($registry, Profile::class);
     }
 
+    /**
+     * Find a live profile whose identifier URL ends with the given account name
+     * (last path segment), e.g. "patrickpietruck" ->
+     * https://www.instagram.com/patrickpietruck/. Used to attach browser-uploaded
+     * media to the right profile when no item exists yet.
+     */
+    public function findOneByAccountName(string $account): ?Profile
+    {
+        $account = trim($account, "/ \t\n\r\0\x0B");
+        if ($account === '') {
+            return null;
+        }
+
+        return $this->createQueryBuilder('p')
+            ->andWhere('p.deleted = false')
+            ->andWhere('p.identifier LIKE :withSlash OR p.identifier LIKE :noSlash')
+            ->setParameter('withSlash', '%/' . $account . '/')
+            ->setParameter('noSlash', '%/' . $account)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findOneByNetworkAndIdentifier(Network $network, string $identifier): ?Profile
     {
         return $this->findOneBy(['network' => $network, 'identifier' => $identifier]);

--- a/tests/Functional/Web/MediaUploadWebTest.php
+++ b/tests/Functional/Web/MediaUploadWebTest.php
@@ -78,6 +78,54 @@ class MediaUploadWebTest extends AbstractWebTestCase
         self::assertResponseStatusCodeSame(404);
     }
 
+    public function testCreatesItemWhenMissingAndAuthorMatchesProfile(): void
+    {
+        $em = $this->entityManager();
+        $network = $em->getRepository(Network::class)->findOneBy(['identifier' => 'instagram_profile']);
+
+        $profile = new Profile();
+        $profile->setId(95002);
+        $profile->setIdentifier('https://www.instagram.com/uploadtest2/');
+        $profile->setNetwork($network);
+        $profile->setCreatedAt(new \DateTimeImmutable());
+        $profile->setSaveVideos(true);
+        $profile->setTranscribeVideos(true);
+        $em->persist($profile);
+        $em->flush();
+
+        $permalink = 'https://www.instagram.com/p/BrandNew1/';
+
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => $permalink, 'author' => 'uploadtest2', 'text' => 'Neuer Post', 'dateTime' => '2026-07-15T10:00:00+00:00'],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseIsSuccessful();
+
+        $em->clear();
+        // Stored without the trailing slash to match the RSS.app fetcher's uniqueIdentifier.
+        $item = $em->getRepository(Item::class)->findOneBy(['permalink' => rtrim($permalink, '/')]);
+        self::assertNotNull($item, 'item was created for the new permalink');
+        self::assertNotNull($item->getVideoPath());
+        self::assertSame('pending', $item->getTranscriptStatus());
+    }
+
+    public function testUnknownAuthorIs422(): void
+    {
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => 'https://www.instagram.com/p/Whatever/', 'author' => 'nobody_tracked'],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
     public function testRejectsUnsupportedType(): void
     {
         $this->createItemWithTranscription();


### PR DESCRIPTION
## Was

Bisher konnte die Erweiterung Medien nur an **bereits importierte** Items hängen — ein frischer Instagram-Post ergab „no item found for permalink". Jetzt legt der Endpunkt das Item an, wenn keins existiert:

- Die Erweiterung schickt zusätzlich `text`, `dateTime` und den **Autor-Handle**.
- Der Autor wird per Account-Name einem getrackten Profil zugeordnet (`ProfileRepository::findOneByAccountName`).
- Das Item wird mit dem **Permalink als `uniqueIdentifier`** gespeichert (= was der RSS.app-Fetcher nutzt), daher **aktualisiert** ein späterer Fetch dasselbe Item statt zu duplizieren.

Fallbacks: **404** ohne Autor, **422** wenn der Autor kein getracktes Profil ist. Die Erweiterung sendet die neuen Felder und zeigt verständlichere Meldungen (inkl. „Item angelegt").

## Tests

`MediaUploadWebTest`: Item wird angelegt (Autor→Profil, Video + Transkription); 422 bei unbekanntem Autor; bestehende Fälle (Anhängen, Slash-Toleranz, 401/404/415) weiter grün. Volle Suite grün (337 Tests).

## Deploy

Nur Code — `git pull` + `dump-autoload` + `cache:clear`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)