### PR TITLE
Match /reel/ and /p/ Instagram permalinks on media upload

### DIFF
--- a/src/Controller/MediaUploadController.php
+++ b/src/Controller/MediaUploadController.php
@@ -73,7 +73,7 @@ class MediaUploadController extends AbstractController
                 return new JsonResponse(['error' => sprintf('no tracked profile for account "%s"', $author)], Response::HTTP_UNPROCESSABLE_ENTITY);
             }
 
-            $item = $this->createItem($profile, rtrim($permalink, '/'), $request);
+            $item = $this->createItem($profile, $this->canonicalPermalink($permalink), $request);
             $created = true;
         }
 
@@ -155,13 +155,13 @@ class MediaUploadController extends AbstractController
     }
 
     /**
-     * Instagram permalinks differ only by a trailing slash between the page's
-     * canonical URL and what was stored, so match both forms.
+     * The page's canonical URL and the stored permalink can differ by a trailing
+     * slash and by the path segment (Instagram serves the same post under /p/,
+     * /reel/, /reels/, /tv/ while RSS.app stores /p/), so match all forms.
      */
-    private function findItemByPermalink(string $permalink): ?\App\Entity\Item
+    private function findItemByPermalink(string $permalink): ?Item
     {
-        $base = rtrim($permalink, '/');
-        foreach (array_unique([$permalink, $base, $base . '/']) as $candidate) {
+        foreach ($this->permalinkCandidates($permalink) as $candidate) {
             $item = $this->itemRepository->findOneBy(['permalink' => $candidate]);
             if ($item !== null) {
                 return $item;
@@ -169,6 +169,32 @@ class MediaUploadController extends AbstractController
         }
 
         return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function permalinkCandidates(string $permalink): array
+    {
+        $base = rtrim(trim($permalink), '/');
+        $candidates = [$base, $base . '/'];
+
+        if (preg_match('~^(https?://[^/]+)/(?:p|reel|reels|tv)/([^/?#]+)~i', $permalink, $m) === 1) {
+            foreach (['p', 'reel'] as $segment) {
+                $candidates[] = sprintf('%s/%s/%s', $m[1], $segment, $m[2]);
+                $candidates[] = sprintf('%s/%s/%s/', $m[1], $segment, $m[2]);
+            }
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    /** Normalise to the /p/ form RSS.app stores, so a created item dedupes on a later fetch. */
+    private function canonicalPermalink(string $permalink): string
+    {
+        $permalink = rtrim(trim($permalink), '/');
+
+        return preg_replace('#/(?:reel|reels|tv)/#i', '/p/', $permalink) ?? $permalink;
     }
 
     private function bearerToken(Request $request): string

--- a/tests/Functional/Web/MediaUploadWebTest.php
+++ b/tests/Functional/Web/MediaUploadWebTest.php
@@ -78,6 +78,29 @@ class MediaUploadWebTest extends AbstractWebTestCase
         self::assertResponseStatusCodeSame(404);
     }
 
+    public function testMatchesReelUrlAgainstStoredPostUrl(): void
+    {
+        $this->createItemWithTranscription(); // stored as .../p/UploadTest1/
+
+        // A video post's canonical URL is often the /reel/ form; it must still
+        // match the stored /p/ item instead of creating a duplicate.
+        $this->client->request(
+            'POST',
+            '/media-upload',
+            ['permalink' => 'https://www.instagram.com/reel/UploadTest1/'],
+            ['video' => $this->fakeUpload('clip.mp4', 'video/mp4')],
+            ['HTTP_AUTHORIZATION' => 'Bearer test-upload-token'],
+        );
+
+        self::assertResponseIsSuccessful();
+
+        $em = $this->entityManager();
+        $em->clear();
+        self::assertSame(1, $em->getRepository(Item::class)->count(['uniqueIdentifier' => 'upload-test-1']), 'no duplicate created');
+        $item = $em->getRepository(Item::class)->findOneBy(['uniqueIdentifier' => 'upload-test-1']);
+        self::assertNotNull($item->getVideoPath(), 'media attached to the existing item');
+    }
+
     public function testCreatesItemWhenMissingAndAuthorMatchesProfile(): void
     {
         $em = $this->entityManager();


### PR DESCRIPTION
Ein Video-Post hat als canonical meist die `/reel/`-Form, RSS.app speichert aber `/p/`. Dadurch fand der Upload-Endpunkt das vorhandene Item nicht und versuchte (erfolglos) anzulegen. Jetzt wird ein Post über seine `/p/`-, `/reel/`-, `/reels/`-, `/tv/`-Formen (+ Slash) gematcht; ein angelegtes Item bekommt die `/p/`-Form, damit ein späterer Fetch weiter dedupliziert. (Bonus: Regex-Delimiter-Bug behoben.) Volle Suite grün (338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)