### PR TITLE
Extract Instagram video URL from page JSON in the extension

### DIFF
--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -19,6 +19,15 @@ function extractMedia() {
 
     let videoUrl = og('og:video:secure_url') || og('og:video');
     if (!videoUrl) {
+        // Instagram usually plays the video from a blob: MediaSource, but embeds
+        // the direct CDN mp4 URL in the page's JSON ("video_url":"https:\/\/…").
+        const html = document.documentElement.innerHTML;
+        const m = html.match(/"video_url":"(https:[^"]+)"/);
+        if (m) {
+            videoUrl = m[1].replace(/\\u0026/g, '&').replace(/\\\//g, '/');
+        }
+    }
+    if (!videoUrl) {
         const v = document.querySelector('video');
         const src = v && (v.currentSrc || v.src);
         if (src && !src.startsWith('blob:')) videoUrl = src;


### PR DESCRIPTION
Instagram spielt Feed-Videos/Reels aus einem `blob:`-MediaSource ab, daher fehlt `og:video` oft und es kam nur das Thumbnail durch. Die Erweiterung durchsucht jetzt zusätzlich das eingebettete Seiten-JSON nach der direkten CDN-`video_url`, sodass das echte Video erfasst und hochgeladen wird. (Reine Extension-Änderung.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)