### PR TITLE
Fetch Instagram media via the private API in the extension

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -35,12 +35,16 @@ Danach `bin/console cache:clear --env=prod`. Leerer Token = Endpunkt deaktiviert
 2. Auf das Erweiterungs-Icon klicken → **Laden & hochladen**.
 3. Eine Benachrichtigung meldet Erfolg (Video/Fotos, ob Transkription eingereiht).
 
+## Wie die Medien geholt werden
+
+Die Erweiterung fragt Instagrams eigene Media-API aus deiner Browser-Session ab
+(`api/v1/media/{id}/info/`, Media-ID aus dem Shortcode berechnet) und bekommt so
+die **direkten CDN-URLs** für Video und Bild — unabhängig vom `blob:`-Player.
+Fällt die API aus, greift ein Fallback auf `og:video`/`og:image` und das
+Seiten-JSON.
+
 ## Grenzen (ehrlich)
 
-- Instagram liefert Videos teils nur als segmentierten `blob:`-Stream; solche
-  lassen sich nicht direkt herunterladen — die Erweiterung meldet dann „kein
-  ladbares Medium gefunden". Sie nutzt vorrangig die `og:video`/`og:image`-Meta-Tags
-  der Post-Seite, die meist die direkte CDN-URL enthalten.
-- Karussells (mehrere Bilder) laden aktuell nur das Hauptbild.
-- Instagram ändert seine Seiten häufig; die Extraktion kann brechen und
-  gelegentlich Anpassung brauchen.
+- Karussells (mehrere Medien) laden aktuell das erste Video bzw. das erste Bild.
+- Instagram ändert seine API/Seiten gelegentlich; dann kann die Extraktion
+  brechen und braucht Anpassung.

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -4,6 +4,51 @@
  * endpoint. Runs in the service worker so it survives the popup closing.
  */
 
+const IG_APP_ID = '936619743392459';
+const SC_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+function shortcodeToMediaId(shortcode) {
+    let id = 0n;
+    for (const ch of shortcode) {
+        const idx = SC_ALPHABET.indexOf(ch);
+        if (idx < 0) return null;
+        id = id * 64n + BigInt(idx);
+    }
+    return id.toString();
+}
+
+function mediaFromItem(item) {
+    const nodes = item.carousel_media || [item];
+    let videoUrl = null;
+    let imageUrl = null;
+    for (const n of nodes) {
+        if (!videoUrl && n.video_versions?.length) {
+            videoUrl = n.video_versions[0].url;
+        }
+        if (!imageUrl && n.image_versions2?.candidates?.length) {
+            imageUrl = n.image_versions2.candidates[0].url;
+        }
+    }
+    return { videoUrl, imageUrl };
+}
+
+// Reliable path: ask Instagram's own media API (from the browser session) for
+// the direct CDN video/image URLs, instead of scraping the DOM/og: tags.
+async function fetchViaApi(shortcode) {
+    const mediaId = shortcodeToMediaId(shortcode);
+    if (!mediaId) return {};
+
+    const res = await fetch(`https://www.instagram.com/api/v1/media/${mediaId}/info/`, {
+        headers: { 'X-IG-App-ID': IG_APP_ID, 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'include',
+    });
+    if (!res.ok) return {};
+
+    const data = await res.json().catch(() => null);
+    const item = data?.items?.[0];
+    return item ? mediaFromItem(item) : {};
+}
+
 async function getSettings() {
     const { appUrl, token } = await chrome.storage.sync.get(['appUrl', 'token']);
     return {
@@ -23,10 +68,25 @@ async function fetchAsFile(url, fallbackName) {
     return new File([blob], name, { type: blob.type });
 }
 
-async function upload({ permalink, videoUrl, imageUrl, text, dateTime, author }) {
+async function upload({ permalink, shortcode, videoUrl, imageUrl, text, dateTime, author }) {
     const { appUrl, token } = await getSettings();
     if (!token) {
         throw new Error('Kein Token gesetzt — bitte in den Optionen konfigurieren.');
+    }
+
+    // Prefer Instagram's API for direct CDN URLs; fall back to page-extracted ones.
+    if (shortcode) {
+        try {
+            const api = await fetchViaApi(shortcode);
+            if (api.videoUrl) videoUrl = api.videoUrl;
+            if (api.imageUrl) imageUrl = api.imageUrl;
+        } catch (e) {
+            // keep the page-extracted URLs
+        }
+    }
+
+    if (!videoUrl && !imageUrl) {
+        throw new Error('Kein Medium gefunden (Instagram-API lieferte nichts).');
     }
 
     const form = new FormData();

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -48,7 +48,10 @@ function extractMedia() {
         if (mm) author = mm[1];
     }
 
-    return { permalink, videoUrl: videoUrl || null, imageUrl: imageUrl || null, text, dateTime, author };
+    const scMatch = permalink.match(/\/(?:p|reel|reels|tv)\/([^/?#]+)/);
+    const shortcode = scMatch ? scMatch[1] : null;
+
+    return { permalink, shortcode, videoUrl: videoUrl || null, imageUrl: imageUrl || null, text, dateTime, author };
 }
 
 async function init() {
@@ -84,8 +87,8 @@ async function run(tabId) {
             func: extractMedia,
         });
 
-        if (!result || (!result.videoUrl && !result.imageUrl)) {
-            setStatus('Kein ladbares Medium gefunden. Instagram liefert das Video evtl. nur als Stream (blob:).', 'err');
+        if (!result || (!result.shortcode && !result.videoUrl && !result.imageUrl)) {
+            setStatus('Kein Post erkannt. Öffne die Instagram-Einzelpost-Seite (…/p/… oder …/reel/…).', 'err');
             goBtn.disabled = false;
             return;
         }


### PR DESCRIPTION
DOM/`og:`-Extraktion kam nicht an Videos (Instagram spielt sie aus einem `blob:`-MediaSource; kein `og:video`, keine `video_url` im SPA-HTML). Die Erweiterung fragt jetzt Instagrams eigene Media-API aus der Browser-Session ab: Media-ID aus dem Shortcode berechnen, dann `GET api/v1/media/{id}/info/` mit dem Web-`X-IG-App-ID` → direkte CDN-Video-/Bild-URLs. Fallback auf die Seiten-Extraktion, falls die API scheitert. (Reine Extension-Änderung.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)