### PR TITLE
Add admin-only view/click statistics for public group pages

### DIFF
--- a/assets/controllers/public_feed_controller.js
+++ b/assets/controllers/public_feed_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
         url: String,
         page: Number,
         hasMore: Boolean,
+        clickUrl: String,
     };
 
     connect() {
@@ -24,10 +25,25 @@ export default class extends Controller {
             );
             this.observer.observe(this.sentinelTarget);
         }
+
+        if (this.clickUrlValue) {
+            this.trackClick = this.trackClick.bind(this);
+            this.element.addEventListener('click', this.trackClick);
+        }
     }
 
     disconnect() {
         if (this.observer) this.observer.disconnect();
+        if (this.clickUrlValue) this.element.removeEventListener('click', this.trackClick);
+    }
+
+    // Count clicks on outbound links without blocking the navigation.
+    trackClick(event) {
+        const link = event.target.closest('a[href^="http"]');
+        if (!link || !navigator.sendBeacon) return;
+
+        const body = new URLSearchParams({ url: link.href });
+        navigator.sendBeacon(this.clickUrlValue, body);
     }
 
     async loadMore() {

--- a/migrations/Version20260715120000.php
+++ b/migrations/Version20260715120000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260715120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add public_page_event table for public group page view/click statistics';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable('public_page_event');
+        $table->addColumn('id', 'integer', ['autoincrement' => true]);
+        $table->addColumn('group_id', 'integer', ['notnull' => true]);
+        $table->addColumn('type', 'string', ['length' => 16, 'notnull' => true]);
+        $table->addColumn('url', 'string', ['length' => 500, 'notnull' => false]);
+        $table->addColumn('occurred_at', 'datetime_immutable', ['notnull' => true]);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['group_id', 'type', 'occurred_at'], 'idx_ppe_group_type_time');
+        $table->addForeignKeyConstraint(
+            'profile_group',
+            ['group_id'],
+            ['id'],
+            ['onDelete' => 'CASCADE'],
+            'fk_ppe_group',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable('public_page_event');
+    }
+}

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -105,6 +105,7 @@ class GroupController extends AbstractController
         Request $request,
         ItemRepository $itemRepository,
         NetworkRepository $networkRepository,
+        \App\PublicPage\PublicPageAnalytics $analytics,
     ): Response {
         $this->denyForeignClient($group);
         $page = max(1, $request->query->getInt('page', 1));
@@ -127,6 +128,9 @@ class GroupController extends AbstractController
         }
         usort($networks, static fn ($a, $b): int => strcasecmp($a->getName() ?? '', $b->getName() ?? ''));
 
+        // Public-page statistics are admin-only.
+        $stats = $this->isGranted('ROLE_ADMIN') ? $analytics->summary($group) : null;
+
         return $this->render('group/show.html.twig', [
             'group' => $group,
             'items' => $items,
@@ -135,6 +139,7 @@ class GroupController extends AbstractController
             'pages' => $pages,
             'networks' => array_values($networks),
             'selectedNetworkId' => $networkId,
+            'stats' => $stats,
         ]);
     }
 

--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -38,6 +38,7 @@ class PublicGroupController extends AbstractController
         private readonly UrlHelper $urlHelper,
         private readonly PushSubscriptionRepository $pushSubscriptionRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly \App\PublicPage\PublicPageAnalytics $analytics,
         private readonly string $vapidPublicKey,
     ) {
     }
@@ -46,6 +47,7 @@ class PublicGroupController extends AbstractController
     public function page(string $slug, Request $request): Response
     {
         $group = $this->requirePublicGroup($slug);
+        $this->analytics->recordView($group);
 
         if ($this->isLocked($group, $request)) {
             return $this->render('public/password.html.twig', [
@@ -67,6 +69,19 @@ class PublicGroupController extends AbstractController
             'pushEnabled' => $this->vapidPublicKey !== '',
             'vapidPublicKey' => $this->vapidPublicKey,
         ]);
+    }
+
+    #[Route('/{slug}/click', name: 'app_public_group_click', methods: ['POST'])]
+    public function trackClick(string $slug, Request $request): Response
+    {
+        $group = $this->requirePublicGroup($slug);
+
+        $url = (string) $request->request->get('url', '');
+        if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
+            $this->analytics->recordClick($group, $url);
+        }
+
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 
     #[Route('/{slug}/push/subscribe', name: 'app_public_group_push_subscribe', methods: ['POST'])]

--- a/src/Entity/PublicPageEvent.php
+++ b/src/Entity/PublicPageEvent.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\PublicPageEventRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A single tracked event on a group's public page: either a page view or a
+ * click on an outbound link. One row per event with its timestamp, so
+ * admin-only statistics can be aggregated over time.
+ */
+#[ORM\Table(name: 'public_page_event')]
+#[ORM\Index(name: 'idx_ppe_group_type_time', columns: ['group_id', 'type', 'occurred_at'])]
+#[ORM\Entity(repositoryClass: PublicPageEventRepository::class)]
+class PublicPageEvent
+{
+    public const TYPE_VIEW = 'view';
+    public const TYPE_CLICK = 'click';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Group::class)]
+    #[ORM\JoinColumn(name: 'group_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Group $group = null;
+
+    #[ORM\Column(type: 'string', length: 16)]
+    private ?string $type = null;
+
+    #[ORM\Column(type: 'string', length: 500, nullable: true)]
+    private ?string $url = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private ?\DateTimeImmutable $occurredAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getGroup(): ?Group
+    {
+        return $this->group;
+    }
+
+    public function setGroup(Group $group): self
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(?string $url): self
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getOccurredAt(): ?\DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+
+    public function setOccurredAt(\DateTimeImmutable $occurredAt): self
+    {
+        $this->occurredAt = $occurredAt;
+
+        return $this;
+    }
+}

--- a/src/PublicPage/PublicPageAnalytics.php
+++ b/src/PublicPage/PublicPageAnalytics.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace App\PublicPage;
+
+use App\Entity\Group;
+use App\Entity\PublicPageEvent;
+use App\Repository\PublicPageEventRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Records public-page views and outbound-link clicks (one timestamped row each)
+ * and aggregates them into the admin-only statistics summary.
+ */
+class PublicPageAnalytics
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly PublicPageEventRepository $repository,
+    ) {
+    }
+
+    public function recordView(Group $group): void
+    {
+        $this->record($group, PublicPageEvent::TYPE_VIEW, null);
+    }
+
+    public function recordClick(Group $group, ?string $url): void
+    {
+        $url = $url !== null ? mb_substr(trim($url), 0, 500) : null;
+        $this->record($group, PublicPageEvent::TYPE_CLICK, $url !== '' ? $url : null);
+    }
+
+    /**
+     * @return array{views: int, clicks: int, views7: int, views30: int, topLinks: list<array{url: string, count: int}>}
+     */
+    public function summary(Group $group): array
+    {
+        return [
+            'views' => $this->repository->countByGroupAndType($group, PublicPageEvent::TYPE_VIEW),
+            'clicks' => $this->repository->countByGroupAndType($group, PublicPageEvent::TYPE_CLICK),
+            'views7' => $this->repository->countByGroupAndType($group, PublicPageEvent::TYPE_VIEW, new \DateTimeImmutable('-7 days')),
+            'views30' => $this->repository->countByGroupAndType($group, PublicPageEvent::TYPE_VIEW, new \DateTimeImmutable('-30 days')),
+            'topLinks' => $this->repository->topClickedUrls($group, 10),
+        ];
+    }
+
+    private function record(Group $group, string $type, ?string $url): void
+    {
+        $event = (new PublicPageEvent())
+            ->setGroup($group)
+            ->setType($type)
+            ->setUrl($url)
+            ->setOccurredAt(new \DateTimeImmutable());
+
+        $this->entityManager->persist($event);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Repository/PublicPageEventRepository.php
+++ b/src/Repository/PublicPageEventRepository.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Group;
+use App\Entity\PublicPageEvent;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PublicPageEvent>
+ */
+class PublicPageEventRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PublicPageEvent::class);
+    }
+
+    public function countByGroupAndType(Group $group, string $type, ?\DateTimeImmutable $since = null): int
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->select('COUNT(e.id)')
+            ->andWhere('e.group = :group')
+            ->andWhere('e.type = :type')
+            ->setParameter('group', $group)
+            ->setParameter('type', $type);
+
+        if ($since !== null) {
+            $qb->andWhere('e.occurredAt >= :since')->setParameter('since', $since);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return list<array{url: string, count: int}>
+     */
+    public function topClickedUrls(Group $group, int $limit = 10): array
+    {
+        $rows = $this->createQueryBuilder('e')
+            ->select('e.url AS url', 'COUNT(e.id) AS cnt')
+            ->andWhere('e.group = :group')
+            ->andWhere('e.type = :type')
+            ->andWhere('e.url IS NOT NULL')
+            ->setParameter('group', $group)
+            ->setParameter('type', PublicPageEvent::TYPE_CLICK)
+            ->groupBy('e.url')
+            ->orderBy('cnt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return array_map(
+            static fn (array $row): array => ['url' => (string) $row['url'], 'count' => (int) $row['cnt']],
+            $rows,
+        );
+    }
+}

--- a/templates/group/show.html.twig
+++ b/templates/group/show.html.twig
@@ -66,6 +66,38 @@
                 </div>
             </div>
 
+            {% if stats is not null %}
+                <div class="data-card mb-3">
+                    <div class="data-card-header"><i class="fas fa-chart-simple me-1"></i>Statistik (nur Admin)</div>
+                    <div class="data-card-body">
+                        <div class="row text-center g-2 mb-2">
+                            <div class="col-6">
+                                <div class="fs-4 fw-bold">{{ stats.views }}</div>
+                                <div class="small text-muted">Aufrufe gesamt</div>
+                            </div>
+                            <div class="col-6">
+                                <div class="fs-4 fw-bold">{{ stats.clicks }}</div>
+                                <div class="small text-muted">Link-Klicks</div>
+                            </div>
+                        </div>
+                        <div class="small text-muted mb-3">
+                            Aufrufe: {{ stats.views7 }} (7 Tage) · {{ stats.views30 }} (30 Tage)
+                        </div>
+                        {% if stats.topLinks is not empty %}
+                            <div class="small fw-semibold mb-1">Meistgeklickte Links</div>
+                            <ul class="list-unstyled small mb-0">
+                                {% for link in stats.topLinks %}
+                                    <li class="d-flex justify-content-between gap-2">
+                                        <a href="{{ link.url }}" target="_blank" rel="noopener" class="text-truncate">{{ link.url }}</a>
+                                        <span class="badge bg-secondary">{{ link.count }}</span>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
             <form method="post" action="{{ path('app_group_delete', {id: group.id}) }}"
                   data-controller="confirm"
                   data-confirm-message-value="Gruppe &quot;{{ group.name }}&quot; wirklich löschen? Profile bleiben erhalten.">

--- a/templates/public/group.html.twig
+++ b/templates/public/group.html.twig
@@ -22,7 +22,8 @@
     <main data-controller="public-feed"
           data-public-feed-url-value="{{ path('app_public_group_more', {slug: group.publicSlug}) }}"
           data-public-feed-page-value="{{ page }}"
-          data-public-feed-has-more-value="{{ hasMore ? 'true' : 'false' }}">
+          data-public-feed-has-more-value="{{ hasMore ? 'true' : 'false' }}"
+          data-public-feed-click-url-value="{{ path('app_public_group_click', {slug: group.publicSlug}) }}">
         {% if viewItems is empty %}
             <div class="empty">
                 <i class="fas fa-inbox"></i>

--- a/tests/Functional/PublicPage/PublicPageAnalyticsWebTest.php
+++ b/tests/Functional/PublicPage/PublicPageAnalyticsWebTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\PublicPage;
+
+use App\Entity\Client;
+use App\Entity\Group;
+use App\Entity\Profile;
+use App\Entity\PublicPageEvent;
+use App\Tests\Functional\AbstractWebTestCase;
+
+class PublicPageAnalyticsWebTest extends AbstractWebTestCase
+{
+    public function testPageViewIsRecorded(): void
+    {
+        $group = $this->makePublicGroup('statsview01');
+
+        $this->client->request('GET', '/p/statsview01');
+        self::assertResponseIsSuccessful();
+
+        self::assertSame(1, $this->countEvents($group, PublicPageEvent::TYPE_VIEW));
+    }
+
+    public function testClickIsRecorded(): void
+    {
+        $group = $this->makePublicGroup('statsclick01');
+
+        $this->client->request('POST', '/p/statsclick01/click', ['url' => 'https://www.instagram.com/p/Abc/']);
+        self::assertResponseStatusCodeSame(204);
+
+        self::assertSame(1, $this->countEvents($group, PublicPageEvent::TYPE_CLICK));
+    }
+
+    public function testClickWithNonHttpUrlIsIgnored(): void
+    {
+        $group = $this->makePublicGroup('statsclick02');
+
+        $this->client->request('POST', '/p/statsclick02/click', ['url' => 'javascript:alert(1)']);
+        self::assertResponseStatusCodeSame(204);
+
+        self::assertSame(0, $this->countEvents($group, PublicPageEvent::TYPE_CLICK));
+    }
+
+    public function testAdminGroupPageShowsStats(): void
+    {
+        $group = $this->makePublicGroup('statsadmin01');
+        // Two views, one click.
+        $this->client->request('GET', '/p/statsadmin01');
+        $this->client->request('GET', '/p/statsadmin01');
+        $this->client->request('POST', '/p/statsadmin01/click', ['url' => 'https://example.com/x']);
+
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', sprintf('/groups/%d', $group->getId()));
+
+        self::assertResponseIsSuccessful();
+        $body = $crawler->filter('body')->text();
+        self::assertStringContainsString('Statistik (nur Admin)', $body);
+        self::assertStringContainsString('Aufrufe gesamt', $body);
+    }
+
+    private function makePublicGroup(string $slug): Group
+    {
+        $em = $this->entityManager();
+        $clientA = $em->getRepository(Client::class)->findOneBy(['name' => 'Client A']);
+        $profile = $em->getRepository(Profile::class)->find(90001);
+
+        $group = new Group();
+        $group->setName('Stats Group');
+        $group->setClient($clientA);
+        $group->addProfile($profile);
+        $group->setPublicPageEnabled(true);
+        $group->setPublicSlug($slug);
+        $em->persist($group);
+        $em->flush();
+
+        return $group;
+    }
+
+    private function countEvents(Group $group, string $type): int
+    {
+        $em = $this->entityManager();
+        $em->clear();
+
+        return (int) $em->getRepository(PublicPageEvent::class)->count([
+            'group' => $em->getRepository(Group::class)->find($group->getId()),
+            'type' => $type,
+        ]);
+    }
+}


### PR DESCRIPTION
## Was

Statistiken für die öffentlichen Gruppen-Seiten, **nur für Admins sichtbar**:
- **Aufrufe**: jeder `GET /p/{slug}` wird serverseitig als Event mit Zeitstempel gezählt.
- **Link-Klicks**: Klicks auf externe Links werden per `navigator.sendBeacon` an `POST /p/{slug}/click` gemeldet (Links bleiben direkt, kein Redirect/Open-Redirect). Nur http(s)-URLs werden gezählt.
- Jedes Event = eine Zeile in `public_page_event` (Gruppe, Typ, URL, Zeitpunkt) → Zeit-Auswertungen möglich.

## Anzeige

Statistik-Karte auf der Admin-Gruppenseite (`/groups/{id}`), **nur bei `ROLE_ADMIN`**: Aufrufe gesamt, Link-Klicks, Aufrufe der letzten 7/30 Tage, meistgeklickte Links. Client-Token-Nutzer sehen sie nicht.

## Tests

`PublicPageAnalyticsWebTest`: View wird gezählt; Klick wird gezählt; nicht-http-URL ignoriert; Admin sieht die Statistik-Karte. Volle Suite grün (342 Tests).

## Deploy

Migration `public_page_event` + `dump-autoload` + `asset-map:compile` (geänderter Feed-Controller) + `cache:clear`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)