### PR TITLE
Track clicks via a signed redirect; make videos link to Instagram

### DIFF
--- a/assets/controllers/public_feed_controller.js
+++ b/assets/controllers/public_feed_controller.js
@@ -11,7 +11,6 @@ export default class extends Controller {
         url: String,
         page: Number,
         hasMore: Boolean,
-        clickUrl: String,
     };
 
     connect() {
@@ -25,25 +24,29 @@ export default class extends Controller {
             );
             this.observer.observe(this.sentinelTarget);
         }
-
-        if (this.clickUrlValue) {
-            this.trackClick = this.trackClick.bind(this);
-            this.element.addEventListener('click', this.trackClick);
-        }
     }
 
     disconnect() {
         if (this.observer) this.observer.disconnect();
-        if (this.clickUrlValue) this.element.removeEventListener('click', this.trackClick);
     }
 
-    // Count clicks on outbound links without blocking the navigation.
-    trackClick(event) {
-        const link = event.target.closest('a[href^="http"]');
-        if (!link || !navigator.sendBeacon) return;
+    // Reveal and play the local <video> in place of the Instagram cover link.
+    playVideo(event) {
+        event.preventDefault();
+        const wrap = event.currentTarget.closest('.post-video');
+        if (!wrap) return;
 
-        const body = new URLSearchParams({ url: link.href });
-        navigator.sendBeacon(this.clickUrlValue, body);
+        const cover = wrap.querySelector('.video-cover');
+        const button = wrap.querySelector('.video-play');
+        const video = wrap.querySelector('video');
+
+        if (cover) cover.hidden = true;
+        if (button) button.hidden = true;
+        if (video) {
+            video.hidden = false;
+            const play = video.play();
+            if (play && typeof play.catch === 'function') play.catch(() => {});
+        }
     }
 
     async loadMore() {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,7 @@ services:
             $vapidPrivateKey: '%env(VAPID_PRIVATE_KEY)%'
             $vapidSubject: '%env(VAPID_SUBJECT)%'
             $mediaUploadToken: '%env(MEDIA_UPLOAD_TOKEN)%'
+            $appSecret: '%kernel.secret%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -39,6 +39,7 @@ class PublicGroupController extends AbstractController
         private readonly PushSubscriptionRepository $pushSubscriptionRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly \App\PublicPage\PublicPageAnalytics $analytics,
+        private readonly \App\PublicPage\OutboundLinkSigner $outboundLinkSigner,
         private readonly string $vapidPublicKey,
     ) {
     }
@@ -71,17 +72,23 @@ class PublicGroupController extends AbstractController
         ]);
     }
 
-    #[Route('/{slug}/click', name: 'app_public_group_click', methods: ['POST'])]
-    public function trackClick(string $slug, Request $request): Response
+    #[Route('/{slug}/go', name: 'app_public_group_go', methods: ['GET'])]
+    public function trackOutbound(string $slug, Request $request): Response
     {
         $group = $this->requirePublicGroup($slug);
 
-        $url = (string) $request->request->get('url', '');
-        if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
-            $this->analytics->recordClick($group, $url);
+        $url = (string) $request->query->get('u', '');
+        $signature = (string) $request->query->get('s', '');
+        $isHttp = str_starts_with($url, 'http://') || str_starts_with($url, 'https://');
+
+        // A tampered/unsigned target must not turn this into an open redirect.
+        if (!$isHttp || !$this->outboundLinkSigner->verify($url, $signature)) {
+            return $this->redirectToRoute('app_public_group', ['slug' => $slug]);
         }
 
-        return new Response('', Response::HTTP_NO_CONTENT);
+        $this->analytics->recordClick($group, $url);
+
+        return $this->redirect($url);
     }
 
     #[Route('/{slug}/push/subscribe', name: 'app_public_group_push_subscribe', methods: ['POST'])]

--- a/src/PublicPage/OutboundLinkSigner.php
+++ b/src/PublicPage/OutboundLinkSigner.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace App\PublicPage;
+
+/**
+ * Signs outbound public-page links so the click-tracking redirect can only be
+ * used for URLs the page itself generated — preventing it from becoming an open
+ * redirect.
+ */
+class OutboundLinkSigner
+{
+    public function __construct(private readonly string $appSecret)
+    {
+    }
+
+    public function sign(string $url): string
+    {
+        return substr(hash_hmac('sha256', $url, $this->appSecret), 0, 16);
+    }
+
+    public function verify(string $url, string $signature): bool
+    {
+        return $signature !== '' && hash_equals($this->sign($url), $signature);
+    }
+}

--- a/src/Twig/PublicOutboundExtension.php
+++ b/src/Twig/PublicOutboundExtension.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Entity\Group;
+use App\PublicPage\OutboundLinkSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * public_out(group, url): rewrites an outbound public-page link to the signed
+ * click-tracking redirect (/p/{slug}/go), so every click is counted. Non-http
+ * URLs are returned unchanged.
+ */
+class PublicOutboundExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly OutboundLinkSigner $signer,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('public_out', $this->outbound(...)),
+        ];
+    }
+
+    public function outbound(Group $group, ?string $url): string
+    {
+        $url = (string) $url;
+        if (!str_starts_with($url, 'http://') && !str_starts_with($url, 'https://')) {
+            return $url;
+        }
+
+        if ($group->getPublicSlug() === null) {
+            return $url;
+        }
+
+        return $this->urlGenerator->generate('app_public_group_go', [
+            'slug' => $group->getPublicSlug(),
+            'u' => $url,
+            's' => $this->signer->sign($url),
+        ]);
+    }
+}

--- a/templates/public/_card.html.twig
+++ b/templates/public/_card.html.twig
@@ -7,29 +7,38 @@
 {% set profileUrl = (profile and profile.identifier starts with 'http') ? profile.identifier : permalink %}
 <article class="post">
     <div class="post-head">
-        <a class="avatar" style="background:hsl({{ vi.hue }}, 65%, 50%)" href="{{ profileUrl }}" target="_blank" rel="noopener nofollow">
+        <a class="avatar" style="background:hsl({{ vi.hue }}, 65%, 50%)" href="{{ public_out(group, profileUrl) }}" target="_blank" rel="noopener nofollow">
             {{ initial }}
             {% if net %}<span class="net-badge" style="background:{{ net.backgroundColor }}"><i class="{{ net.icon }}"></i></span>{% endif %}
         </a>
         <div class="meta">
-            <a class="who" href="{{ profileUrl }}" target="_blank" rel="noopener nofollow">{{ name }}</a>
+            <a class="who" href="{{ public_out(group, profileUrl) }}" target="_blank" rel="noopener nofollow">{{ name }}</a>
             {% if item.dateTime %}<div class="when" title="{{ item.dateTime|date('d.m.Y H:i') }}">{{ item.dateTime|date('d.m.Y H:i') }}</div>{% endif %}
         </div>
     </div>
 
     {% if vi.videoUrl %}
         <div class="post-video">
-            <video controls preload="none"{% if vi.poster %} poster="{{ vi.poster }}"{% endif %} src="{{ vi.videoUrl }}"></video>
+            {# Default: the cover links to the original Instagram post (counted).
+               The play button reveals the local <video> for in-page playback. #}
+            <a class="video-cover" href="{{ public_out(group, permalink) }}" target="_blank" rel="noopener nofollow">
+                {% if vi.poster %}<img loading="lazy" referrerpolicy="no-referrer" src="{{ vi.poster }}" alt="">{% endif %}
+                <span class="video-hint"><i class="fab fa-instagram"></i> auf Instagram ansehen</span>
+            </a>
+            <button type="button" class="video-play" data-action="public-feed#playVideo">
+                <i class="fas fa-play"></i> Video hier abspielen
+            </button>
+            <video controls preload="none"{% if vi.poster %} poster="{{ vi.poster }}"{% endif %} src="{{ vi.videoUrl }}" hidden></video>
         </div>
     {% elseif vi.photos is not empty %}
         {% if vi.photos|length == 1 %}
-            <a class="post-photo" href="{{ permalink }}" target="_blank" rel="noopener nofollow">
+            <a class="post-photo" href="{{ public_out(group, permalink) }}" target="_blank" rel="noopener nofollow">
                 <img loading="lazy" referrerpolicy="no-referrer" src="{{ vi.photos|first }}" alt="" onerror="this.closest('.post-photo').style.display='none'">
             </a>
         {% else %}
             <div class="post-photos count-{{ vi.photos|length > 4 ? 4 : vi.photos|length }}">
                 {% for p in vi.photos %}
-                    <a class="post-photo" href="{{ permalink }}" target="_blank" rel="noopener nofollow">
+                    <a class="post-photo" href="{{ public_out(group, permalink) }}" target="_blank" rel="noopener nofollow">
                         <img loading="lazy" referrerpolicy="no-referrer" src="{{ p }}" alt="" onerror="this.closest('.post-photo').style.display='none'">
                     </a>
                 {% endfor %}

--- a/templates/public/base.html.twig
+++ b/templates/public/base.html.twig
@@ -84,8 +84,13 @@
         .post-photos.count-2 { grid-template-columns: 1fr 1fr; }
         .post-photos.count-3, .post-photos.count-4 { grid-template-columns: 1fr 1fr; }
 
-        .post-video { display: block; width: 100%; background: #000; }
+        .post-video { position: relative; width: 100%; background: #000; }
         .post-video video { display: block; width: 100%; height: auto; max-height: 70vh; }
+        .video-cover { display: block; position: relative; }
+        .video-cover img { display: block; width: 100%; height: auto; }
+        .video-cover .video-hint { position: absolute; left: 10px; bottom: 10px; background: rgba(0,0,0,.65); color: #fff; font-size: 12px; font-weight: 600; padding: 5px 9px; border-radius: 999px; }
+        .video-play { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; border: 0; padding: 10px; background: var(--accent); color: #fff; }
+        .video-play:hover { filter: brightness(1.08); }
 
         .post-body { padding: 10px 14px 14px; font-size: 13px; line-height: 1.55; }
         .post-body .caption { white-space: pre-wrap; word-wrap: break-word; overflow-wrap: anywhere; }

--- a/templates/public/group.html.twig
+++ b/templates/public/group.html.twig
@@ -22,8 +22,7 @@
     <main data-controller="public-feed"
           data-public-feed-url-value="{{ path('app_public_group_more', {slug: group.publicSlug}) }}"
           data-public-feed-page-value="{{ page }}"
-          data-public-feed-has-more-value="{{ hasMore ? 'true' : 'false' }}"
-          data-public-feed-click-url-value="{{ path('app_public_group_click', {slug: group.publicSlug}) }}">
+          data-public-feed-has-more-value="{{ hasMore ? 'true' : 'false' }}">
         {% if viewItems is empty %}
             <div class="empty">
                 <i class="fas fa-inbox"></i>

--- a/tests/Functional/PublicPage/PublicPageAnalyticsWebTest.php
+++ b/tests/Functional/PublicPage/PublicPageAnalyticsWebTest.php
@@ -6,6 +6,7 @@ use App\Entity\Client;
 use App\Entity\Group;
 use App\Entity\Profile;
 use App\Entity\PublicPageEvent;
+use App\PublicPage\OutboundLinkSigner;
 use App\Tests\Functional\AbstractWebTestCase;
 
 class PublicPageAnalyticsWebTest extends AbstractWebTestCase
@@ -20,33 +21,38 @@ class PublicPageAnalyticsWebTest extends AbstractWebTestCase
         self::assertSame(1, $this->countEvents($group, PublicPageEvent::TYPE_VIEW));
     }
 
-    public function testClickIsRecorded(): void
+    public function testSignedOutboundClickIsRecordedAndRedirects(): void
     {
         $group = $this->makePublicGroup('statsclick01');
+        $signer = static::getContainer()->get(OutboundLinkSigner::class);
+        $target = 'https://www.instagram.com/p/Abc/';
 
-        $this->client->request('POST', '/p/statsclick01/click', ['url' => 'https://www.instagram.com/p/Abc/']);
-        self::assertResponseStatusCodeSame(204);
+        $this->client->request('GET', '/p/statsclick01/go?' . http_build_query(['u' => $target, 's' => $signer->sign($target)]));
 
+        self::assertResponseRedirects($target);
         self::assertSame(1, $this->countEvents($group, PublicPageEvent::TYPE_CLICK));
     }
 
-    public function testClickWithNonHttpUrlIsIgnored(): void
+    public function testInvalidSignatureDoesNotOpenRedirectAndIsNotCounted(): void
     {
         $group = $this->makePublicGroup('statsclick02');
 
-        $this->client->request('POST', '/p/statsclick02/click', ['url' => 'javascript:alert(1)']);
-        self::assertResponseStatusCodeSame(204);
+        $this->client->request('GET', '/p/statsclick02/go?' . http_build_query(['u' => 'https://evil.example.com/', 's' => 'forged']));
 
+        // Redirects to the public page, NOT the unsigned target; nothing recorded.
+        self::assertResponseRedirects('/p/statsclick02');
         self::assertSame(0, $this->countEvents($group, PublicPageEvent::TYPE_CLICK));
     }
 
     public function testAdminGroupPageShowsStats(): void
     {
         $group = $this->makePublicGroup('statsadmin01');
+        $signer = static::getContainer()->get(OutboundLinkSigner::class);
         // Two views, one click.
         $this->client->request('GET', '/p/statsadmin01');
         $this->client->request('GET', '/p/statsadmin01');
-        $this->client->request('POST', '/p/statsadmin01/click', ['url' => 'https://example.com/x']);
+        $target = 'https://example.com/x';
+        $this->client->request('GET', '/p/statsadmin01/go?' . http_build_query(['u' => $target, 's' => $signer->sign($target)]));
 
         $this->loginAsAdmin();
         $crawler = $this->client->request('GET', sprintf('/groups/%d', $group->getId()));


### PR DESCRIPTION
## Klick-Zählung reparieren
Das clientseitige Klick-Tracking (`sendBeacon` an `/click`) wurde von Ad-/Tracking-Blockern still verworfen — Klicks wurden nicht gezählt. Ersetzt durch einen **serverseitigen Redirect**: Ausgehende Links laufen über `/p/{slug}/go?u=&s=`, was den Klick zählt und per 302 zum Ziel weiterleitet. Die URL ist **HMAC-signiert** (App-Secret) → kein Open-Redirect-Missbrauch. Kein JS, kein Blocker, kein Verlust.

## Video-Verhalten
Videos spielen nicht mehr automatisch: Das Cover **verlinkt jetzt zum Original-Instagram-Post** (gezählter Klick), und ein separater Button **„Video hier abspielen"** blendet das lokale `<video>` für die Wiedergabe auf der Seite ein.

## Tests
`PublicPageAnalyticsWebTest`: signierter Klick wird gezählt + leitet weiter; **ungültige Signatur** → Redirect auf die öffentliche Seite (kein Open-Redirect), nicht gezählt; Admin sieht Statistik. Volle Suite grün (342).

## Deploy
Neue Klassen → `dump-autoload`; geänderter Feed-Controller → `asset-map:compile`; `cache:clear`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)