### PR TITLE
Make the post date/time on the public page link to the post

### DIFF
--- a/templates/public/_card.html.twig
+++ b/templates/public/_card.html.twig
@@ -13,7 +13,13 @@
         </a>
         <div class="meta">
             <a class="who" href="{{ public_out(group, profileUrl) }}" target="_blank" rel="noopener nofollow">{{ name }}</a>
-            {% if item.dateTime %}<div class="when" title="{{ item.dateTime|date('d.m.Y H:i') }}">{{ item.dateTime|date('d.m.Y H:i') }}</div>{% endif %}
+            {% if item.dateTime %}
+                {% if permalink starts with 'http' %}
+                    <a class="when" href="{{ public_out(group, permalink) }}" target="_blank" rel="noopener nofollow" title="{{ item.dateTime|date('d.m.Y H:i') }}">{{ item.dateTime|date('d.m.Y H:i') }}</a>
+                {% else %}
+                    <div class="when" title="{{ item.dateTime|date('d.m.Y H:i') }}">{{ item.dateTime|date('d.m.Y H:i') }}</div>
+                {% endif %}
+            {% endif %}
         </div>
     </div>
 

--- a/templates/public/base.html.twig
+++ b/templates/public/base.html.twig
@@ -75,7 +75,8 @@
         .post-head .meta { min-width: 0; flex: 1; }
         .post-head .who { font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-decoration: none; color: var(--fg); display: block; }
         .post-head .who:hover { text-decoration: underline; }
-        .post-head .when { font-size: 12px; color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+        .post-head .when { font-size: 12px; color: var(--fg-muted); font-variant-numeric: tabular-nums; text-decoration: none; }
+        .post-head a.when:hover { text-decoration: underline; color: var(--fg); }
 
         .post-photo { display: block; width: 100%; background: var(--border); cursor: pointer; }
         .post-photo img { display: block; width: 100%; height: auto; transition: opacity .15s ease; }


### PR DESCRIPTION
Datum/Uhrzeit eines Beitrags auf der oeffentlichen Seite war reiner Text. Jetzt ist es ein getrackter Link zum Original-Beitrag (via `public_out`) — Klick oeffnet den Beitrag und wird gezaehlt, wie die anderen Card-Links. Fallback auf reinen Text ohne http-Permalink. Public-Page-Tests gruen (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)