### PR TITLE
Hide push button on public page; add collapsible profile list

### DIFF
--- a/src/Controller/PublicGroupController.php
+++ b/src/Controller/PublicGroupController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Group;
 use App\Entity\Item;
+use App\Entity\Profile;
 use App\Entity\PushSubscription;
 use App\Repository\GroupRepository;
 use App\Repository\ItemRepository;
@@ -69,7 +70,29 @@ class PublicGroupController extends AbstractController
             'hasMore' => $total > self::ITEMS_PER_PAGE,
             'pushEnabled' => $this->vapidPublicKey !== '',
             'vapidPublicKey' => $this->vapidPublicKey,
+            'groupProfiles' => $this->liveProfiles($group),
         ]);
+    }
+
+    /**
+     * Live (non-deleted) member profiles, sorted by display name, for the
+     * public page's collapsible profile list.
+     *
+     * @return list<Profile>
+     */
+    private function liveProfiles(Group $group): array
+    {
+        $profiles = array_filter(
+            $group->getProfiles()->toArray(),
+            static fn (Profile $profile): bool => !$profile->isDeleted(),
+        );
+
+        usort(
+            $profiles,
+            static fn (Profile $a, Profile $b): int => strcasecmp($a->getDisplayName(), $b->getDisplayName()),
+        );
+
+        return array_values($profiles);
     }
 
     #[Route('/{slug}/go', name: 'app_public_group_go', methods: ['GET'])]

--- a/templates/public/base.html.twig
+++ b/templates/public/base.html.twig
@@ -44,6 +44,17 @@
         header.page-head .desc { color: var(--fg-muted); font-size: 13px; margin: 0 0 4px; white-space: pre-wrap; }
         header.page-head .sub { color: var(--fg-muted); font-size: 13px; display: flex; gap: 12px; flex-wrap: wrap; }
         header.page-head .sub .dot { color: var(--accent); }
+        .group-profiles { margin-top: 12px; font-size: 13px; }
+        .group-profiles > summary { cursor: pointer; color: var(--fg-muted); font-weight: 600; list-style: none; }
+        .group-profiles > summary::-webkit-details-marker { display: none; }
+        .group-profiles > summary::before { content: '▸'; display: inline-block; margin-right: 6px; transition: transform .15s; }
+        .group-profiles[open] > summary::before { transform: rotate(90deg); }
+        .group-profiles ul { list-style: none; margin: 8px 0 0; padding: 0; display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; }
+        .group-profiles li a, .group-profiles li .nolink { display: flex; align-items: center; gap: 7px; padding: 3px 0; color: var(--fg); text-decoration: none; }
+        .group-profiles li a:hover .pname { text-decoration: underline; }
+        .group-profiles .pname { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .group-profiles .net-dot { flex: 0 0 auto; width: 18px; height: 18px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-size: 10px; }
+        @media (max-width: 380px) { .group-profiles ul { grid-template-columns: 1fr; } }
         header.page-head .push-subscribe { margin-top: 12px; }
         .push-btn { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border, #d0d0d0); background: transparent; color: var(--fg, inherit); transition: background .15s, border-color .15s; }
         .push-btn:hover:not(:disabled) { border-color: var(--accent); }

--- a/templates/public/group.html.twig
+++ b/templates/public/group.html.twig
@@ -8,14 +8,28 @@
             {% if group.timeWindowDays %}<span><span class="dot">●</span> letzte {{ group.timeWindowDays }} Tage</span>{% endif %}
             <span>{{ total }} {{ total == 1 ? 'Beitrag' : 'Beiträge' }}</span>
         </div>
-        {% if pushEnabled %}
-            <div class="push-subscribe" hidden
-                 data-controller="push-subscribe"
-                 data-push-subscribe-vapid-public-key-value="{{ vapidPublicKey }}"
-                 data-push-subscribe-subscribe-url-value="{{ path('app_public_group_push_subscribe', {slug: group.publicSlug}) }}"
-                 data-push-subscribe-unsubscribe-url-value="{{ path('app_public_group_push_unsubscribe', {slug: group.publicSlug}) }}">
-                <button type="button" class="push-btn" data-push-subscribe-target="button" data-action="push-subscribe#toggle">🔔 Benachrichtigungen an</button>
-            </div>
+        {% if groupProfiles is not empty %}
+            <details class="group-profiles">
+                <summary>{{ groupProfiles|length }} {{ groupProfiles|length == 1 ? 'Profil' : 'Profile' }} in dieser Gruppe</summary>
+                <ul>
+                    {% for p in groupProfiles %}
+                        {% set net = p.network %}
+                        <li>
+                            {% if p.identifier starts with 'http' %}
+                                <a href="{{ public_out(group, p.identifier) }}" target="_blank" rel="noopener nofollow">
+                                    {% if net %}<span class="net-dot" style="background:{{ net.backgroundColor }}"><i class="{{ net.icon }}"></i></span>{% endif %}
+                                    <span class="pname">{{ p|public_profile_name }}</span>
+                                </a>
+                            {% else %}
+                                <span class="nolink">
+                                    {% if net %}<span class="net-dot" style="background:{{ net.backgroundColor }}"><i class="{{ net.icon }}"></i></span>{% endif %}
+                                    <span class="pname">{{ p|public_profile_name }}</span>
+                                </span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </details>
         {% endif %}
     </header>
 

--- a/tests/Functional/PublicPage/PublicGroupControllerTest.php
+++ b/tests/Functional/PublicPage/PublicGroupControllerTest.php
@@ -39,6 +39,20 @@ class PublicGroupControllerTest extends AbstractApiTestCase
         self::assertStringNotContainsString('>https://mastodon.social/@shared</a>', $body);
     }
 
+    public function testGroupProfilesListIsShown(): void
+    {
+        $client = static::createClient();
+        $this->makeGroup('profiles01', ['timeWindowDays' => null]);
+
+        $client->request('GET', '/p/profiles01');
+        $body = $this->body($client);
+
+        // Collapsible profile list with a tracked link to the member profile.
+        self::assertStringContainsString('group-profiles', $body);
+        self::assertStringContainsString('in dieser Gruppe', $body);
+        self::assertStringContainsString('/p/profiles01/go?', $body);
+    }
+
     public function testDisabledGroupReturns404(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Push ausblenden
Der (noch in Arbeit befindliche) Abo-Button fuer Push-Benachrichtigungen wird von der oeffentlichen Gruppen-Seite entfernt. Backend/Endpunkte/Service-Worker bleiben fuer spaeter erhalten — nur der Button ist weg.

## Profil-Liste
Stattdessen eine ausklappbare Liste `N Profile in dieser Gruppe` im Header: je Profil ein Link zur Netzwerk-Profilseite (ueber den getrackten Redirect `public_out`, zaehlt also als Klick), mit Netzwerk-Icon, sortiert nach Anzeigename, nur Live-Profile.

## Tests
`testGroupProfilesListIsShown`: Liste + getrackter Link vorhanden. Volle Suite gruen (343).
🤖 Generated with [Claude Code](https://claude.com/claude-code)