### PR TITLE
Let admins set a profile's RSS.app feed id by hand

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -284,6 +284,24 @@ class ProfileController extends AbstractController
         ]);
     }
 
+    #[Route('/{id}/rss-app-feed-id', name: 'app_profile_set_rss_app_feed_id', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function setRssAppFeedId(Request $request, Profile $profile, EntityManagerInterface $em): Response
+    {
+        if (!$this->isCsrfTokenValid('set-rss-app-feed-id-' . $profile->getId(), $request->request->getString('_token'))) {
+            return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+        }
+
+        $feedId = trim($request->request->getString('rss_app_feed_id'));
+        $profile->setRssAppFeedId($feedId !== '' ? $feedId : null);
+        $em->flush();
+
+        $this->addFlash('success', $feedId !== ''
+            ? sprintf('RSS.app-Feed-ID „%s" wurde gesetzt.', $feedId)
+            : 'RSS.app-Feed-ID wurde entfernt.');
+
+        return $this->redirectToRoute('app_profile_show', ['id' => $profile->getId()]);
+    }
+
     #[Route('/{id}/change-identifier', name: 'app_profile_change_identifier', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function changeIdentifier(Request $request, Profile $profile, IdentifierChanger $identifierChanger): Response
     {

--- a/templates/profile/show.html.twig
+++ b/templates/profile/show.html.twig
@@ -131,6 +131,27 @@
             </div>
 
             <div class="data-card mb-4">
+                <div class="data-card-header">RSS.app-Feed-ID</div>
+                <div class="data-card-body">
+                    <p class="text-muted small mb-2">
+                        Trägt die RSS.app-Feed-ID manuell ein (aus dem RSS.app-Dashboard), ohne die
+                        automatische Registrierung über die API — hilfreich, wenn dabei Fehler 429
+                        (Rate-Limit) auftreten. Leer lassen und speichern entfernt die ID.
+                    </p>
+                    <form method="post" action="{{ path('app_profile_set_rss_app_feed_id', {id: profile.id}) }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('set-rss-app-feed-id-' ~ profile.id) }}">
+                        <div class="input-group">
+                            <input type="text" name="rss_app_feed_id" class="form-control font-monospace"
+                                   value="{{ profile.rssAppFeedId }}" placeholder="z. B. jjutbdPwGeghjbC6" aria-label="RSS.app-Feed-ID">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save me-1"></i>Speichern
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="data-card mb-4">
                 <div class="data-card-header">Clients ({{ profile.clients|length }})</div>
                 <div class="data-card-body">
                     {% if profile.clients|length > 0 %}

--- a/tests/Functional/Web/ProfileRssAppFeedIdWebTest.php
+++ b/tests/Functional/Web/ProfileRssAppFeedIdWebTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Web;
+
+use App\Entity\Profile;
+use App\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * Admins can set a profile's RSS.app feed id by hand (to avoid the 429-prone
+ * automatic API registration).
+ */
+class ProfileRssAppFeedIdWebTest extends AbstractWebTestCase
+{
+    private const PROFILE_ID = 90005; // fixture Instagram profile, feed id "fixture-feed-instagram"
+
+    public function testSetFeedIdByHand(): void
+    {
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', '/profiles/' . self::PROFILE_ID);
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[action$="/rss-app-feed-id"]')->form(['rss_app_feed_id' => 'ManualFeedId123']);
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/profiles/' . self::PROFILE_ID);
+        self::assertSame('ManualFeedId123', $this->reloadProfile()->getRssAppFeedId());
+    }
+
+    public function testClearFeedId(): void
+    {
+        $this->loginAsAdmin();
+        $crawler = $this->client->request('GET', '/profiles/' . self::PROFILE_ID);
+
+        $form = $crawler->filter('form[action$="/rss-app-feed-id"]')->form(['rss_app_feed_id' => '']);
+        $this->client->submit($form);
+
+        self::assertNull($this->reloadProfile()->getRssAppFeedId());
+    }
+
+    private function reloadProfile(): Profile
+    {
+        $em = $this->entityManager();
+        $em->clear();
+
+        return $em->getRepository(Profile::class)->find(self::PROFILE_ID);
+    }
+}


### PR DESCRIPTION
Die automatische RSS.app-Registrierung ueber die API laeuft oft in HTTP 429. Neue Karte **RSS.app-Feed-ID** auf der Profilseite: die Feed-ID manuell eintragen (aus dem RSS.app-Dashboard), ohne API-Aufruf. Leeres Feld speichern entfernt die ID. `POST /profiles/{id}/rss-app-feed-id`, CSRF-geschuetzt. Test: setzen + leeren. Volle Suite gruen (345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)