### PR TITLE
Sort the profile list by last fetch and creation date

### DIFF
--- a/assets/controllers/profile_list_controller.js
+++ b/assets/controllers/profile_list_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
         pages: Number,
     };
 
-    static targets = ['searchInput', 'networkCheckbox', 'networkCount', 'statusRadio', 'tableBody', 'pagination', 'totalBadge'];
+    static targets = ['searchInput', 'networkCheckbox', 'networkCount', 'statusRadio', 'sortSelect', 'tableBody', 'pagination', 'totalBadge'];
 
     _searchTimeout = null;
 
@@ -42,6 +42,11 @@ export default class extends Controller {
     }
 
     onStatusChange() {
+        this.pageValue = 1;
+        this._load();
+    }
+
+    onSortChange() {
         this.pageValue = 1;
         this._load();
     }
@@ -84,6 +89,10 @@ export default class extends Controller {
         const selectedStatus = this.statusRadioTargets.find(r => r.checked);
         if (selectedStatus) {
             params.set('status', selectedStatus.value);
+        }
+
+        if (this.hasSortSelectTarget && this.sortSelectTarget.value) {
+            params.set('sort', this.sortSelectTarget.value);
         }
 
         try {

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -47,11 +47,15 @@ class ProfileController extends AbstractController
             $networkIds = [$request->query->getInt('network')];
         }
         $status = $request->query->getString('status', '');
+        $sort = $request->query->getString('sort', 'identifier');
+        if (!in_array($sort, ProfileRepository::SORTS, true)) {
+            $sort = 'identifier';
+        }
 
         $total = $profileRepository->countFiltered($networkIds, $search, $status);
         $pages = max(1, (int) ceil($total / self::PROFILES_PER_PAGE));
         $page = min($page, $pages);
-        $profiles = $profileRepository->findPaginated($page, self::PROFILES_PER_PAGE, $networkIds, $search, $status);
+        $profiles = $profileRepository->findPaginated($page, self::PROFILES_PER_PAGE, $networkIds, $search, $status, $sort);
 
         $profileIds = array_map(static fn ($p) => $p->getId(), $profiles);
         $itemCounts = $itemRepository->countByProfileIds($profileIds);
@@ -83,6 +87,7 @@ class ProfileController extends AbstractController
             'search' => $search,
             'selectedNetworks' => $networkIds,
             'selectedStatus' => $status,
+            'selectedSort' => $sort,
         ]);
     }
 

--- a/src/Repository/ProfileRepository.php
+++ b/src/Repository/ProfileRepository.php
@@ -72,20 +72,48 @@ class ProfileRepository extends ServiceEntityRepository
      * @param list<int> $networkIds
      * @return list<Profile>
      */
-    public function findPaginated(int $page, int $limit, array $networkIds = [], string $search = '', string $status = ''): array
+    public const SORTS = ['identifier', 'fetch_desc', 'fetch_asc', 'created_desc', 'created_asc'];
+
+    public function findPaginated(int $page, int $limit, array $networkIds = [], string $search = '', string $status = '', string $sort = 'identifier'): array
     {
         $qb = $this->createQueryBuilder('p')
             ->leftJoin('p.network', 'n')
-            ->addSelect('n')
-            ->orderBy('p.identifier', 'ASC');
+            ->addSelect('n');
 
         $this->applyFilters($qb, $networkIds, $search, $status);
+        $this->applySort($qb, $sort);
 
         return $qb
             ->setFirstResult(($page - 1) * $limit)
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
+    }
+
+    private function applySort(\Doctrine\ORM\QueryBuilder $qb, string $sort): void
+    {
+        // For date sorts, keep rows without a value at the bottom on both MySQL
+        // and PostgreSQL (their default NULL ordering differs) via a HIDDEN flag.
+        switch ($sort) {
+            case 'fetch_desc':
+                $qb->addSelect('CASE WHEN p.lastFetchSuccessDateTime IS NULL THEN 1 ELSE 0 END AS HIDDEN nullsLast')
+                    ->orderBy('nullsLast', 'ASC')
+                    ->addOrderBy('p.lastFetchSuccessDateTime', 'DESC');
+                break;
+            case 'fetch_asc':
+                $qb->addSelect('CASE WHEN p.lastFetchSuccessDateTime IS NULL THEN 1 ELSE 0 END AS HIDDEN nullsLast')
+                    ->orderBy('nullsLast', 'ASC')
+                    ->addOrderBy('p.lastFetchSuccessDateTime', 'ASC');
+                break;
+            case 'created_desc':
+                $qb->orderBy('p.createdAt', 'DESC');
+                break;
+            case 'created_asc':
+                $qb->orderBy('p.createdAt', 'ASC');
+                break;
+            default:
+                $qb->orderBy('p.identifier', 'ASC');
+        }
     }
 
     /**

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -101,6 +101,15 @@
                         </li>
                     </ul>
                 </div>
+                <select class="form-select w-auto ms-auto" aria-label="Sortierung"
+                        data-profile-list-target="sortSelect"
+                        data-action="change->profile-list#onSortChange">
+                    <option value="identifier" {{ selectedSort == 'identifier' ? 'selected' : '' }}>Identifier A–Z</option>
+                    <option value="fetch_desc" {{ selectedSort == 'fetch_desc' ? 'selected' : '' }}>Letzter Fetch (neueste)</option>
+                    <option value="fetch_asc" {{ selectedSort == 'fetch_asc' ? 'selected' : '' }}>Letzter Fetch (älteste)</option>
+                    <option value="created_desc" {{ selectedSort == 'created_desc' ? 'selected' : '' }}>Angelegt (neueste)</option>
+                    <option value="created_asc" {{ selectedSort == 'created_asc' ? 'selected' : '' }}>Angelegt (älteste)</option>
+                </select>
             </div>
         </div>
 

--- a/tests/Functional/Repository/ProfileSortTest.php
+++ b/tests/Functional/Repository/ProfileSortTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Network;
+use App\Entity\Profile;
+use App\Repository\ProfileRepository;
+use App\Tests\Functional\AbstractWebTestCase;
+
+class ProfileSortTest extends AbstractWebTestCase
+{
+    public function testSortByCreatedAtAndLastFetch(): void
+    {
+        $em = $this->entityManager();
+        $network = $em->getRepository(Network::class)->findOneBy(['identifier' => 'mastodon']);
+
+        $this->makeProfile(97001, '2026-01-01', '2026-06-01'); // oldest created, mid fetch
+        $this->makeProfile(97002, '2026-03-01', null);          // newest created, never fetched
+        $this->makeProfile(97003, '2026-02-01', '2026-07-01');  // newest fetch
+        $em->flush();
+
+        /** @var ProfileRepository $repo */
+        $repo = $em->getRepository(Profile::class);
+        $ids = fn (string $sort): array => array_map(
+            static fn (Profile $p): int => $p->getId(),
+            $repo->findPaginated(1, 50, [], 'sorttest', '', $sort),
+        );
+
+        self::assertSame([97002, 97003, 97001], $ids('created_desc'));
+        self::assertSame([97001, 97003, 97002], $ids('created_asc'));
+        // Never-fetched (97002) is kept last in both directions.
+        self::assertSame([97003, 97001, 97002], $ids('fetch_desc'));
+        self::assertSame([97001, 97003, 97002], $ids('fetch_asc'));
+    }
+
+    private function makeProfile(int $id, string $created, ?string $fetched): void
+    {
+        $em = $this->entityManager();
+        $network = $em->getRepository(Network::class)->findOneBy(['identifier' => 'mastodon']);
+
+        $profile = new Profile();
+        $profile->setId($id);
+        $profile->setIdentifier('sorttest-' . $id);
+        $profile->setNetwork($network);
+        $profile->setCreatedAt(new \DateTimeImmutable($created));
+        if ($fetched !== null) {
+            $profile->setLastFetchSuccessDateTime(new \DateTimeImmutable($fetched));
+        }
+        $em->persist($profile);
+    }
+}


### PR DESCRIPTION
Sortier-Dropdown auf `/profiles`: Identifier (Default), **Letzter Fetch** (neueste/aelteste) und **Angelegt** (neueste/aelteste). Laeuft ueber den bestehenden AJAX-Filter-Controller. Datums-Sortierungen halten Zeilen ohne Wert unten — DB-agnostisch (MySQL + PostgreSQL) via HIDDEN nulls-last-Flag. Volle Suite gruen (346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)