### PR TITLE
Fix app:import-profiles crash on profile id collision

### DIFF
--- a/src/Command/ImportProfilesCommand.php
+++ b/src/Command/ImportProfilesCommand.php
@@ -116,7 +116,33 @@ class ImportProfilesCommand extends Command
                 $isNew = false;
             } else {
                 $profile = new Profile();
-                $profile->setId($data['id']);
+
+                // The API-create path (ClientScopedProfileProcessor) assigns ids via
+                // findNextFreeId(), so the local id space can diverge from the source id.
+                // If the source id is already taken by an unrelated profile, fall back to a
+                // free local id instead of aborting the whole import with a duplicate-PK
+                // error (this command previously crashed mid-run on such a collision).
+                $newId = (int) $data['id'];
+
+                if (null !== $this->profileRepository->find($newId)) {
+                    if (!$dryRun && $batchCount > 0) {
+                        // Flush pending inserts so findNextFreeId() sees the current max.
+                        $this->entityManager->flush();
+                        $batchCount = 0;
+                    }
+
+                    $freeId = $this->profileRepository->findNextFreeId();
+                    $io->warning(sprintf(
+                        'Quell-ID %d bereits belegt – vergebe freie lokale ID %d für %s (%s).',
+                        $newId,
+                        $freeId,
+                        $data['identifier'],
+                        $data['network'],
+                    ));
+                    $newId = $freeId;
+                }
+
+                $profile->setId($newId);
                 $isNew = true;
             }
 


### PR DESCRIPTION
## Summary

`app:import-profiles` crashed mid-run with `SQLSTATE[23000] 1062 Duplicate entry '116' for key 'PRIMARY'`, aborting the whole import.

**Root cause:** two conflicting id strategies. The import mirrors the source (criticalmass.in) id via `Profile::setId($data['id'])`, but the API-create path (`ClientScopedProfileProcessor`) assigns ids via `findNextFreeId()`. So the local id space diverges from the source, and when a source id is already taken by an unrelated, API-created profile, the insert hits a duplicate primary key. (Note: this is **not** a lost AUTO_INCREMENT — `Profile.id` is intentionally assigned, no `#[ORM\GeneratedValue]`; see corrected note on #129.)

## Change

When the source id is already taken, fall back to a free local id (`findNextFreeId()`, same as the API path) and emit a warning, instead of crashing. Existing profiles are still matched/updated by `(network, identifier)` — the unique natural key — so only genuinely new rows are affected. A pending batch is flushed before `findNextFreeId()` so it sees the current max.

## Test Plan

- `php -l` clean; repo has no PHPStan config.
- `app:import-profiles --dry-run` / real run no longer aborts on a colliding id; colliding new profiles get a free local id with a warning; non-colliding rows keep mirroring the source id.

## Follow-up

The deeper design tension (import wants `id == source id` for `app:import-items`, while the API path uses `findNextFreeId()`) remains — see #129. This PR stops the crash without changing the happy-path behaviour.

Refs #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)